### PR TITLE
fix(core): resolve insert_many↔count ABBA deadlock (#75)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.315"
+version = "0.3.316"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/count.rs
+++ b/ironbase-core/src/collection_core/count.rs
@@ -182,6 +182,18 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
     /// conditions on multiple fields (e.g., $regex on a non-indexed field).
     fn count_with_plan(&self, query_json: &Value, ctx: Option<&ExecutionContext>) -> Result<u64> {
         // Try index-based counting
+        //
+        // LOCK ORDER (issue #75): acquire `storage` BEFORE `indexes`. The write
+        // paths (insert/update *_raw) hold `storage.write()` across their index
+        // updates for read-modify-write atomicity ($inc), i.e. they lock in
+        // storage→indexes order. Co-holding here in the opposite order
+        // (indexes→storage) produced a classic ABBA deadlock: a concurrent
+        // insert_many holding storage.write waited for indexes.write while this
+        // count held indexes.read and waited for storage.read. We adopt the same
+        // global storage→indexes order. Branches that delegate (count_index_narrowed
+        // / count_with_scan, which re-acquire storage themselves) drop BOTH guards
+        // first to avoid a re-entrant read deadlock.
+        let storage = self.storage.read();
         let indexes = self.indexes.read();
         let index_fields = indexes.list_indexes_with_compound_info();
 
@@ -213,7 +225,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 let end_key = end.as_ref().unwrap_or(&default_end);
 
                                 if fully_covered {
-                                    let storage = self.storage.read();
                                     let meta = storage.get_collection_meta(&self.name).ok_or_else(
                                         || IronBaseError::CollectionNotFound(self.name.clone()),
                                     )?;
@@ -241,6 +252,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                         )
                                         .unwrap_docs();
                                     drop(indexes);
+                                    drop(storage);
                                     return self.count_index_narrowed(doc_ids, query_json, ctx);
                                 }
                             }
@@ -252,7 +264,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                         } => {
                             if let Some(index) = indexes.get_btree_index(index_name) {
                                 if fully_covered {
-                                    let storage = self.storage.read();
                                     let meta = storage.get_collection_meta(&self.name).ok_or_else(
                                         || IronBaseError::CollectionNotFound(self.name.clone()),
                                     )?;
@@ -304,6 +315,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                     all_doc_ids.sort_unstable();
                                     all_doc_ids.dedup();
                                     drop(indexes);
+                                    drop(storage);
                                     return self.count_index_narrowed(all_doc_ids, query_json, ctx);
                                 }
                             }
@@ -322,7 +334,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 };
 
                                 if fully_covered {
-                                    let storage = self.storage.read();
                                     let meta = storage.get_collection_meta(&self.name).ok_or_else(
                                         || IronBaseError::CollectionNotFound(self.name.clone()),
                                     )?;
@@ -344,6 +355,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                         .range_query(&start, &end, true, true, mode)
                                         .unwrap_docs();
                                     drop(indexes);
+                                    drop(storage);
                                     return self.count_index_narrowed(doc_ids, query_json, ctx);
                                 }
                             }
@@ -351,6 +363,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                         _ => {
                             // Other plan types: use collect_doc_ids_from_plan as fallback
                             drop(indexes);
+                            drop(storage);
                             let parsed_query = Query::from_json(query_json)?;
                             let cancel_flag = ctx.and_then(|c| c.cancel_flag());
                             let deadline = ctx.and_then(|c| c.deadline());
@@ -372,6 +385,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
 
             // Fallback: original per-clause logical operator handling
             drop(indexes);
+            drop(storage);
             let parsed_query = Query::from_json(query_json)?;
             let cancel_flag = ctx.and_then(|c| c.cancel_flag());
             let deadline = ctx.and_then(|c| c.deadline());
@@ -411,7 +425,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
 
                         if fully_covered {
                             // Fast path: validate index entries against catalog — O(1) memory
-                            let storage = self.storage.read();
                             let meta =
                                 storage.get_collection_meta(&self.name).ok_or_else(|| {
                                     IronBaseError::CollectionNotFound(self.name.clone())
@@ -435,6 +448,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 .range_query(&start, &end, true, true, mode)
                                 .unwrap_docs();
                             drop(indexes);
+                            drop(storage);
                             return self.count_index_narrowed(doc_ids, query_json, ctx);
                         }
                     }
@@ -455,7 +469,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
 
                         if fully_covered {
                             // Fast path: validate index entries against catalog — O(1) memory
-                            let storage = self.storage.read();
                             let meta =
                                 storage.get_collection_meta(&self.name).ok_or_else(|| {
                                     IronBaseError::CollectionNotFound(self.name.clone())
@@ -485,6 +498,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 )
                                 .unwrap_docs();
                             drop(indexes);
+                            drop(storage);
                             return self.count_index_narrowed(doc_ids, query_json, ctx);
                         }
                     }
@@ -502,7 +516,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
 
                             if fully_covered {
                                 // Fast path: validate index entries against catalog — O(1) memory
-                                let storage = self.storage.read();
                                 let meta =
                                     storage.get_collection_meta(&self.name).ok_or_else(|| {
                                         IronBaseError::CollectionNotFound(self.name.clone())
@@ -526,6 +539,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                     .range_query(&start, &end, true, true, mode)
                                     .unwrap_docs();
                                 drop(indexes);
+                                drop(storage);
                                 return self.count_index_narrowed(doc_ids, query_json, ctx);
                             }
                         }
@@ -539,7 +553,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                     if let Some(index) = indexes.get_btree_index(index_name) {
                         if fully_covered {
                             // Fast path: validate index entries against catalog — O(1) memory
-                            let storage = self.storage.read();
                             let meta =
                                 storage.get_collection_meta(&self.name).ok_or_else(|| {
                                     IronBaseError::CollectionNotFound(self.name.clone())
@@ -599,6 +612,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                             all_doc_ids.sort_unstable();
                             all_doc_ids.dedup();
                             drop(indexes);
+                            drop(storage);
                             return self.count_index_narrowed(all_doc_ids, query_json, ctx);
                         }
                     }
@@ -611,7 +625,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                     if let Some(index) = indexes.get_btree_index(index_name) {
                         if fully_covered {
                             // Fast path: validate index entries against catalog — O(1) memory
-                            let storage = self.storage.read();
                             let meta =
                                 storage.get_collection_meta(&self.name).ok_or_else(|| {
                                     IronBaseError::CollectionNotFound(self.name.clone())
@@ -658,6 +671,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                             all_doc_ids.sort_unstable();
                             all_doc_ids.dedup();
                             drop(indexes);
+                            drop(storage);
                             return self.count_index_narrowed(all_doc_ids, query_json, ctx);
                         }
                     }
@@ -666,7 +680,6 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                     if let Some(index) = indexes.get_btree_index(index_name) {
                         if fully_covered {
                             // Fast path: validate index entries against catalog — O(1) memory
-                            let storage = self.storage.read();
                             let meta =
                                 storage.get_collection_meta(&self.name).ok_or_else(|| {
                                     IronBaseError::CollectionNotFound(self.name.clone())
@@ -690,6 +703,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 .range_query(&IndexKey::Null, &IndexKey::MaxKey, true, true, mode)
                                 .unwrap_docs();
                             drop(indexes);
+                            drop(storage);
                             return self.count_index_narrowed(doc_ids, query_json, ctx);
                         }
                     }
@@ -697,8 +711,10 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
             }
 
             drop(indexes);
+            drop(storage);
         } else {
             drop(indexes);
+            drop(storage);
         }
 
         // Fallback: streaming count without Vec allocation

--- a/ironbase-core/src/collection_core/index_ops.rs
+++ b/ironbase-core/src/collection_core/index_ops.rs
@@ -803,12 +803,17 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
     /// Drop an index
     pub fn drop_index(&self, index_name: &str) -> Result<()> {
         self.check_not_closed()?;
+        // LOCK ORDER (issue #75): acquire `storage` BEFORE `indexes` to match the
+        // global storage→indexes order used by the write paths (insert/update *_raw)
+        // and by count_with_plan. Acquiring indexes-then-storage here previously
+        // risked an ABBA deadlock against concurrent storage→indexes writers.
+        // Both locks are held simultaneously so the metadata update stays atomic.
+        let mut storage = self.storage.write();
         let mut indexes = self.indexes.write();
         indexes.drop_index(index_name)?;
 
-        // FIX: Hold index lock while updating metadata to prevent race condition
-        // where another thread sees inconsistent state (index gone but metadata present)
-        let mut storage = self.storage.write();
+        // Hold both locks while updating metadata to prevent a race where another
+        // thread sees inconsistent state (index gone but metadata present).
         if let Some(meta) = storage.get_collection_meta_mut(&self.name) {
             // Remove from B+ tree indexes
             meta.indexes.retain(|idx| idx.name != index_name);

--- a/ironbase-core/tests/regression_insert_count_deadlock.rs
+++ b/ironbase-core/tests/regression_insert_count_deadlock.rs
@@ -1,0 +1,103 @@
+//! Regression test for issue #75: ABBA deadlock between a concurrent
+//! `insert_many` and an index-using filtered `count`.
+//!
+//! Root cause: the write paths (`insert_many_raw` / `insert_one_raw` /
+//! `update_*_raw`) hold `storage.write()` across their index updates for
+//! read-modify-write atomicity, i.e. they lock in **storage → indexes** order.
+//! `count_with_plan` (and `drop_index`) used the opposite **indexes → storage**
+//! order — holding `indexes.read()` while acquiring `storage.read()`. Under
+//! concurrency this formed a classic ABBA cycle:
+//!   * writer holds `storage.write`, waits for `indexes.write` (batch_add)
+//!   * reader holds `indexes.read`, waits for `storage.read`
+//!
+//! Fix: unify everyone on the **storage → indexes** order. This test pins the
+//! invariant: a writer and a reader hammering the same collection must both make
+//! progress and finish promptly. Before the fix the writer deadlocked on its
+//! very first `insert_many` (0 inserts completed).
+
+use ironbase_core::database::DatabaseCore;
+use ironbase_core::storage::MemoryStorage;
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[test]
+fn insert_many_and_filtered_count_do_not_deadlock() {
+    let db = Arc::new(DatabaseCore::<MemoryStorage>::open_memory().unwrap());
+    let coll = db.collection("probe").unwrap();
+    // Index on "status" makes the filtered count a fully-covered IndexScan,
+    // which is exactly the count_with_plan branch that co-held indexes+storage.
+    coll.create_index("status".to_string(), false, false)
+        .unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let inserted = Arc::new(AtomicU64::new(0));
+    let counts = Arc::new(AtomicU64::new(0));
+
+    // Writer: continuous insert_many batches.
+    let writer = {
+        let db = Arc::clone(&db);
+        let stop = Arc::clone(&stop);
+        let inserted = Arc::clone(&inserted);
+        thread::spawn(move || {
+            let mut seq = 0u64;
+            while !stop.load(Ordering::Relaxed) {
+                let mut batch = Vec::with_capacity(200);
+                for _ in 0..200 {
+                    seq += 1;
+                    batch.push(HashMap::from([
+                        ("status".to_string(), json!("active")),
+                        ("seq".to_string(), json!(seq)),
+                    ]));
+                }
+                db.insert_many("probe", batch).expect("insert_many");
+                inserted.fetch_add(200, Ordering::Relaxed);
+            }
+        })
+    };
+
+    // Reader: continuous filtered count (fully-covered index path).
+    let reader = {
+        let db = Arc::clone(&db);
+        let stop = Arc::clone(&stop);
+        let counts = Arc::clone(&counts);
+        thread::spawn(move || {
+            let coll = db.collection("probe").unwrap();
+            while !stop.load(Ordering::Relaxed) {
+                coll.count_documents(&json!({"status": "active"}))
+                    .expect("count");
+                counts.fetch_add(1, Ordering::Relaxed);
+            }
+        })
+    };
+
+    // Run briefly, then require BOTH threads to wind down quickly.
+    thread::sleep(Duration::from_secs(3));
+    stop.store(true, Ordering::Relaxed);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !(writer.is_finished() && reader.is_finished()) {
+        assert!(
+            Instant::now() < deadline,
+            "DEADLOCK: threads stuck (inserted={}, counts={})",
+            inserted.load(Ordering::Relaxed),
+            counts.load(Ordering::Relaxed)
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    writer.join().unwrap();
+    reader.join().unwrap();
+
+    // Both sides must have made real progress.
+    assert!(
+        inserted.load(Ordering::Relaxed) > 0,
+        "writer made no progress"
+    );
+    assert!(
+        counts.load(Ordering::Relaxed) > 0,
+        "reader made no progress"
+    );
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.509"
+version = "1.0.510"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
Fixes #75 — a concurrent `insert_many` + index-using filtered `count` on the same collection deadlocked 100% of the time (both threads parked on `futex_wait`, 0% CPU).

Proven via lock-tracing instrumentation:
- **writer** `insert_many_raw` holds `storage.write` across `batch_add_to_indexes` (indexes.write) → **storage → indexes** (deliberate: `*_raw` insert/update paths keep `storage.write` held across index updates for `$inc` read-modify-write atomicity).
- **reader** `count_with_plan` held `indexes.read` across `storage.read` in the fully-covered branches → **indexes → storage**.

Opposite acquisition order ⇒ classic ABBA cycle. `MemoryStorage`/`open_memory()` routes `insert_many` to `insert_many_raw` (the non-WAL path), which is the co-holder.

## Fix
Unify everyone on the writers' atomicity-mandated **storage → indexes** order:
- **`count_with_plan`** — acquire `storage.read` before `indexes.read`; fully-covered branches share one top-level guard; delegating branches (`count_index_narrowed`/`count_with_scan`, which re-acquire storage themselves) drop **both** guards first to avoid a re-entrant read deadlock.
- **`drop_index`** — acquire `storage.write` before `indexes.write` (still co-held → metadata update stays atomic).

A full `collection_core` audit confirmed these were the **only two** `indexes → storage` co-hold sites; `find`/`distinct`/`aggregate` and the delete `*_raw` paths do not co-hold.

## Verification
- New `tests/regression_insert_count_deadlock.rs` reproduced the hang (writer completed **0** inserts before the fix) and now passes.
- Full `ironbase-core` suite green (1073 lib + integration), fmt + clippy clean.
- Versions: workspace `0.3.316`, mcp-server `1.0.510`.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Egyidejű beszúrás és lekérdezés (count) műveletek közötti holtpont (deadlock) feloldása azzal, hogy kikényszerítjük a következetes „storage-before-indexes” zárolási sorrendet, valamint regressziós lefedettséget adunk hozzá.

Hibajavítások:
- Megakadályozza az ABBA típusú holtpontot az `insert_many` és az indexet használó szűrt `count` között a zárolási sorrend egységesítésével a storage- és indexzárak között.
- Megszünteti a potenciális holtpontot a `drop_index` műveletben azáltal, hogy a storage- és index-írási zárakat ugyanabban a globális sorrendben szerzi meg, mint más írási útvonalak.

Build:
- A workspace crate verziójának frissítése 0.3.316-ra, valamint az `mcp-ironbase-server` frissítése 1.0.510-re.

Tesztek:
- Regressziós teszt hozzáadása, amely párhuzamosan futtat `insert_many`-t és teljesen indexelt szűrt `count`-ot ugyanazon a kollekción, hogy biztosítsa, hogy mindkét művelet előrehaladjon holtpont kialakulása nélkül.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve a deadlock between concurrent insert and count operations by enforcing a consistent storage-before-indexes lock acquisition order and adding regression coverage.

Bug Fixes:
- Prevent ABBA deadlock between insert_many and index-using filtered count by standardizing lock acquisition order between storage and index locks.
- Eliminate potential deadlock in drop_index by acquiring storage and index write locks in the same global order as other write paths.

Build:
- Bump workspace crate version to 0.3.316 and mcp-ironbase-server to 1.0.510.

Tests:
- Add a regression test that runs concurrent insert_many and fully indexed filtered count on the same collection to ensure both operations make progress without deadlocking.

</details>