### PR TITLE
fix(core,hnsw): orphan-robust vector search — replace recall collapse (#77, #53)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.316"
+version = "0.3.317"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -849,26 +849,42 @@ impl HnswIndex {
         let mut candidates = BinaryHeap::new(); // Min-heap for nearest
         let mut results = BinaryHeap::new(); // Max-heap for furthest (to maintain top-ef)
 
+        // #77/#53: nodes lazily removed via `remove()` stay in the graph (orphans:
+        // still in `nodes`/edges, gone from `id_to_index`). They MUST remain
+        // navigable so traversal can pass *through* them to reach live nodes, but
+        // they must NOT consume the `ef` result budget — otherwise an orphan-dense
+        // neighborhood (e.g. a chunk replaced many times) starves the result set
+        // and search recall collapses. So orphans go into `candidates` (frontier)
+        // but never into `results` (the ef-capped valid set that also drives the
+        // early-stop). Search then keeps expanding until it has `ef` *active*
+        // results or the reachable graph is exhausted.
+        let is_active = |idx: usize| self.id_to_index.contains_key(&self.nodes[idx].id);
+
         let entry_dist = self.compute_distance(query, &self.nodes[entry].vector);
         visited.insert(entry);
         candidates.push(NearestCandidate {
             index: entry,
             distance: entry_dist,
         });
-        results.push(SearchCandidate {
-            index: entry,
-            distance: entry_dist,
-        });
+        if is_active(entry) {
+            results.push(SearchCandidate {
+                index: entry,
+                distance: entry_dist,
+            });
+        }
 
         while let Some(NearestCandidate {
             index: current,
             distance: current_dist,
         }) = candidates.pop()
         {
-            // Check if we can stop early
-            if let Some(furthest) = results.peek() {
-                if current_dist > furthest.distance && results.len() >= ef {
-                    break;
+            // Early stop only once we have ef *active* results and the closest
+            // remaining frontier node is farther than the furthest of them.
+            if results.len() >= ef {
+                if let Some(furthest) = results.peek() {
+                    if current_dist > furthest.distance {
+                        break;
+                    }
                 }
             }
 
@@ -879,23 +895,27 @@ impl HnswIndex {
                     if visited.insert(neighbor_idx) {
                         let dist = self.compute_distance(query, &self.nodes[neighbor_idx].vector);
 
-                        // Add to candidates if promising
-                        let dominated = results.len() >= ef
-                            && results.peek().map(|f| dist >= f.distance).unwrap_or(false);
+                        // A neighbor is worth keeping if we still lack ef active
+                        // results or it is nearer than the current furthest active
+                        // result. Orphans are judged the same way for traversal.
+                        let promising = results.len() < ef
+                            || results.peek().map(|f| dist < f.distance).unwrap_or(true);
 
-                        if !dominated || results.len() < ef {
+                        if promising {
+                            // Always traverse through it (preserves connectivity).
                             candidates.push(NearestCandidate {
                                 index: neighbor_idx,
                                 distance: dist,
                             });
-                            results.push(SearchCandidate {
-                                index: neighbor_idx,
-                                distance: dist,
-                            });
-
-                            // Trim results if too many
-                            while results.len() > ef {
-                                results.pop();
+                            // Only active (non-orphan) nodes count toward results.
+                            if is_active(neighbor_idx) {
+                                results.push(SearchCandidate {
+                                    index: neighbor_idx,
+                                    distance: dist,
+                                });
+                                while results.len() > ef {
+                                    results.pop();
+                                }
                             }
                         }
                     }

--- a/ironbase-core/tests/repro_hnsw_replace_recall.rs
+++ b/ironbase-core/tests/repro_hnsw_replace_recall.rs
@@ -1,0 +1,175 @@
+//! Regression tests for #77 / #53: HNSW search recall must survive repeated
+//! replace (delete + re-insert) of vectors.
+//!
+//! Root cause: `remove()` is lazy — a removed node stays in the graph (still in
+//! `nodes` and reachable via edges) but is dropped from `id_to_index`. The old
+//! `search_layer` added those orphans to the `ef`-capped result set, so an
+//! orphan-dense neighbourhood (a chunk replaced many times — exactly the RAG
+//! `if_exists="replace"` path) starved the result budget and search recall
+//! collapsed (#77: 86% self-retrieval miss in production). Deleted vectors could
+//! also keep surfacing until a rebuild (#53).
+//!
+//! Fix: orphans stay navigable (frontier) but never enter the result/`ef` set,
+//! so search keeps expanding until it has `ef` *active* hits.
+
+use ironbase_core::database::DatabaseCore;
+use ironbase_core::storage::MemoryStorage;
+use ironbase_core::vector::{DistanceMetric, VectorIndexConfig};
+use serde_json::json;
+use std::collections::HashMap;
+
+fn embedding_doc(tag: &str, vec: &[f32]) -> HashMap<String, serde_json::Value> {
+    HashMap::from([
+        ("doc_id".to_string(), json!(tag)),
+        ("embedding".to_string(), json!(vec)),
+    ])
+}
+
+fn make_index(coll: &ironbase_core::collection_core::CollectionCore<MemoryStorage>, dim: usize) {
+    let mut cfg = VectorIndexConfig::new(dim);
+    cfg.field = "embedding".to_string();
+    cfg.metric = DistanceMetric::Cosine;
+    coll.create_vector_index("embedding", cfg).unwrap();
+}
+
+/// One vector replaced 80×: the orphan-dense neighbourhood must not hide the
+/// live anchor from a self-query.
+#[test]
+fn replace_same_vector_many_times_self_retrieval_holds() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("kb").unwrap();
+    make_index(&coll, 8);
+
+    let anchor: Vec<f32> = vec![1.0, 0.5, 0.25, 0.125, 0.0, 0.0, 0.0, 0.0];
+
+    for i in 0..10 {
+        let mut v = vec![0.0f32; 8];
+        v[i % 8] = 1.0;
+        v[(i + 3) % 8] = 0.3;
+        db.insert_many("kb", vec![embedding_doc(&format!("other{i}"), &v)])
+            .unwrap();
+    }
+
+    let mut current_ids = db
+        .insert_many("kb", vec![embedding_doc("anchor", &anchor)])
+        .unwrap();
+    for _ in 0..80 {
+        let new_ids = db
+            .insert_many("kb", vec![embedding_doc("anchor", &anchor)])
+            .unwrap();
+        let old: Vec<serde_json::Value> = current_ids.iter().map(|id| json!(id)).collect();
+        db.delete_many("kb", &json!({ "_id": { "$in": old } }))
+            .unwrap();
+        current_ids = new_ids;
+    }
+
+    let results = coll.vector_search("embedding", &anchor, 1).unwrap();
+    assert!(
+        !results.is_empty(),
+        "self-retrieval returned nothing for the anchor after replaces (orphan poisoning)"
+    );
+    assert_eq!(
+        results[0].0.get("doc_id").and_then(|v| v.as_str()),
+        Some("anchor"),
+        "top hit for the anchor embedding should be the anchor itself"
+    );
+}
+
+/// Production-like: many docs, each replaced several times. Global self-retrieval
+/// recall must stay perfect (this is the 1025-chunk / 86%-miss scenario at scale).
+#[test]
+fn global_recall_after_many_replaces() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("kb").unwrap();
+    const DIM: usize = 48;
+    const DOCS: usize = 40;
+    make_index(&coll, DIM);
+
+    // Each doc gets a clearly distinct embedding: a unique dominant dimension
+    // (d < DIM ⇒ position d is unique) plus two smaller offset components.
+    let embedding = |d: usize| -> Vec<f32> {
+        let mut v = vec![0.0f32; DIM];
+        v[d % DIM] = 1.0;
+        v[(d + 1) % DIM] = 0.3;
+        v[(d + 2) % DIM] = 0.1;
+        v
+    };
+
+    // Initial import.
+    let mut current: Vec<Vec<serde_json::Value>> = Vec::with_capacity(DOCS);
+    for d in 0..DOCS {
+        let ids = db
+            .insert_many("kb", vec![embedding_doc(&format!("doc{d}"), &embedding(d))])
+            .unwrap();
+        current.push(ids.into_iter().map(|id| json!(id)).collect());
+    }
+
+    // 5 re-enrich rounds: replace every doc (delete old + insert new).
+    for _round in 0..5 {
+        for (d, ids) in current.iter_mut().enumerate() {
+            let new_ids = db
+                .insert_many("kb", vec![embedding_doc(&format!("doc{d}"), &embedding(d))])
+                .unwrap();
+            db.delete_many("kb", &json!({ "_id": { "$in": ids.clone() } }))
+                .unwrap();
+            *ids = new_ids.into_iter().map(|id| json!(id)).collect();
+        }
+    }
+
+    // Every doc must retrieve itself as the top hit.
+    let mut hits = 0;
+    for d in 0..DOCS {
+        let res = coll.vector_search("embedding", &embedding(d), 1).unwrap();
+        if res
+            .first()
+            .and_then(|(doc, _)| doc.get("doc_id"))
+            .and_then(|v| v.as_str())
+            == Some(&format!("doc{d}"))
+        {
+            hits += 1;
+        }
+    }
+    assert_eq!(
+        hits, DOCS,
+        "global self-retrieval recall must be 100% after replaces, got {hits}/{DOCS}"
+    );
+}
+
+/// #53 correctness: a deleted vector must not be returned by search.
+#[test]
+fn deleted_vector_not_returned() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("kb").unwrap();
+    make_index(&coll, 8);
+
+    let target: Vec<f32> = vec![0.9, 0.1, 0.0, 0.0, 0.2, 0.0, 0.0, 0.0];
+    for i in 0..5 {
+        let mut v = vec![0.05f32; 8];
+        v[i] = 1.0;
+        db.insert_many("kb", vec![embedding_doc(&format!("keep{i}"), &v)])
+            .unwrap();
+    }
+    let target_ids = db
+        .insert_many("kb", vec![embedding_doc("victim", &target)])
+        .unwrap();
+
+    // Present before delete.
+    let before = coll.vector_search("embedding", &target, 1).unwrap();
+    assert_eq!(
+        before[0].0.get("doc_id").and_then(|v| v.as_str()),
+        Some("victim")
+    );
+
+    // Delete and confirm it never resurfaces.
+    let ids: Vec<serde_json::Value> = target_ids.iter().map(|id| json!(id)).collect();
+    db.delete_many("kb", &json!({ "_id": { "$in": ids } }))
+        .unwrap();
+
+    let after = coll.vector_search("embedding", &target, 5).unwrap();
+    assert!(
+        after
+            .iter()
+            .all(|(doc, _)| doc.get("doc_id").and_then(|v| v.as_str()) != Some("victim")),
+        "deleted vector must not be returned by search"
+    );
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.510"
+version = "1.0.511"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
Fixes #77 and #53. After repeated **replace** (delete + re-insert) of vectors — the RAG `rag_document_import` `if_exists="replace"` path — HNSW search recall collapsed (production: **86% self-retrieval miss** on a 1025-chunk index).

## Root cause (proven with a core repro)
`HnswIndex::remove()` is **lazy**: a removed node stays in `nodes` and in the graph edges, only dropped from `id_to_index` (an *orphan*). `search_layer` added orphans to the `ef`-capped `results` set and used them for the early-stop, so an **orphan-dense neighbourhood** (a chunk replaced N times → N orphans clustered at the same embedding) starved the result budget: the `ef=50` nearest *nodes* were almost all orphans, filtered out afterwards → few or zero valid hits.

The global `needs_rebuild()` threshold (>30% orphans) never caught this because the poisoning is **local** to a neighbourhood. This is **#53** (lazy-removal orphan accumulation) surfacing as **#77** (silent search degradation).

## Fix
In `search_layer`, orphans **stay in the traversal frontier** (`candidates`) so search can still navigate *through* them to reach live nodes, but they **never enter `results` / the `ef` budget / the early-stop**. Search keeps expanding until it has `ef` *active* hits or the reachable graph is exhausted → recall is independent of orphan density.

Memory is still reclaimed by the existing orphan rebuild on checkpoint (>30%) and compact (unconditional); deleted vectors are correctly never returned.

## Tests (`tests/repro_hnsw_replace_recall.rs`)
- single vector replaced 80× → self-retrieval holds (reproduced **empty** result before the fix)
- 40 docs × 5 replace rounds → **100%** global self-retrieval recall
- deleted vector is never returned (#53 correctness)

Full `ironbase-core` suite green (1073 lib + integration), fmt + clippy clean, mcp-server builds. Versions: workspace `0.3.317`, mcp-server `1.0.511`.

Closes #77
Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Az HNSW vektorkeresés robusztusságának javítása a lazán törölt (árva) csomópontokkal szemben, hogy megakadályozzuk a visszakeresési pontosság romlását ismételt csere-műveletek után.

Hibajavítások:
- Biztosítjuk, hogy az HNSW keresés ne engedje, hogy a lazán eltávolított árva csomópontok feléljék az ef eredménykeretet, illetve hogy rontsák a visszakeresési pontosságot ismételt törlés- és újrabeszúrási ciklusok után.
- Garantáljuk, hogy a törölt vektorok soha ne jelenjenek meg az HNSW keresési eredményeiben, még akkor sem, ha a hozzájuk tartozó csomópontok továbbra is a gráf struktúrában maradnak.

Build:
- A workspace crate verziójának frissítése 0.3.317-re és az mcp-ironbase-server crate verziójának frissítése 1.0.511-re.

Tesztek:
- Regressziós tesztek hozzáadása egyetlen vektor ismételt cseréjének lefedésére, hogy ellenőrizzük: az ön-visszakeresés helyes marad, még árva csomópontokban gazdag szomszédságok esetén is.
- Egy, éles környezethez hasonló, többdokumentumos csere-szcenárió hozzáadása annak igazolására, hogy a globális ön-visszakeresési recall több csere-kör után is 100% marad.
- Egy dedikált teszt hozzáadása annak megerősítésére, hogy az HNSW keresés nem ad vissza törölt vektorokat.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve HNSW vector search robustness to lazy-deleted (orphan) nodes to prevent recall degradation after repeated replace operations.

Bug Fixes:
- Ensure HNSW search does not allow lazily removed orphan nodes to consume the ef result budget or degrade recall after repeated delete-and-reinsert cycles.
- Guarantee that deleted vectors are never returned in HNSW search results even when their nodes remain in the graph structure.

Build:
- Bump workspace crate version to 0.3.317 and mcp-ironbase-server crate version to 1.0.511.

Tests:
- Add regression tests covering repeated replacement of a single vector to verify self-retrieval remains correct under orphan-heavy neighborhoods.
- Add a production-like multi-document replace scenario to assert global self-retrieval recall remains at 100% after several replace rounds.
- Add a dedicated test to confirm that deleted vectors are not returned by HNSW search.

</details>