### PR TITLE
fix(hnsw): re-anchor entry_point on remove + drop redundant orphan post-filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.317"
+version = "0.3.318"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -462,18 +462,12 @@ impl HnswIndex {
             current = self.search_layer_greedy(query, current, level);
         }
 
-        // Search at layer 0 with ef_search candidates
+        // Search at layer 0. search_layer already excludes orphan (lazy-removed)
+        // nodes from its result set, so every candidate here is an active vector.
         let candidates = self.search_layer(query, current, self.config.ef_search, 0);
 
-        // Convert to results with similarity scores based on metric
-        // Filter out orphan nodes: after lazy remove(), nodes remain in the graph
-        // but are no longer in id_to_index. Only return active (non-orphan) results.
         candidates
             .into_iter()
-            .filter(|(idx, _)| {
-                let node = &self.nodes[*idx];
-                self.id_to_index.contains_key(&node.id)
-            })
             .take(k)
             .map(|(idx, _distance)| {
                 let node = &self.nodes[idx];
@@ -511,19 +505,16 @@ impl HnswIndex {
             current = self.search_layer_greedy(query, current, level);
         }
 
-        // Search at layer 0 with more candidates to compensate for filtering
+        // Search at layer 0 with extra candidates to compensate for the caller's
+        // filter dropping results. Orphan (lazy-removed) nodes are already
+        // excluded by search_layer, so this budget only covers the caller filter.
         let ef = self.config.ef_search * 3; // Expand search space
         let candidates = self.search_layer(query, current, ef, 0);
 
-        // Filter and convert to results
-        // First filter out orphan nodes (lazy-deleted), then apply caller's filter.
         candidates
             .into_iter()
             .filter_map(|(idx, _distance)| {
                 let node = &self.nodes[idx];
-                if !self.id_to_index.contains_key(&node.id) {
-                    return None; // orphan node — skip
-                }
                 if filter(&node.id) {
                     let score = self.compute_similarity(query, &node.vector);
                     Some(VectorSearchResult {
@@ -583,10 +574,25 @@ impl HnswIndex {
     /// Note: This marks the node as deleted but doesn't fully update
     /// the graph structure. Call rebuild() after many deletions.
     pub fn remove(&mut self, id: &str) -> bool {
-        if let Some(&_idx) = self.id_to_index.get(id) {
-            // For now, just remove from lookup (lazy removal)
+        if let Some(&idx) = self.id_to_index.get(id) {
+            // Lazy removal: drop from the lookup; the node and its edges stay in
+            // the graph as an orphan (search_layer traverses through but never
+            // returns orphans). Memory is reclaimed later by rebuild().
             self.id_to_index.remove(id);
             self.dirty = true;
+
+            // If we just removed the graph entry point, re-anchor it to a live
+            // node. Otherwise upper-layer descent (search_layer_greedy) would
+            // start every search from a dead node, which can settle in an orphan
+            // local minimum and hurt recall (#77). Pick the highest-level active
+            // node (most neighbor layers) as the new entry; None if none remain.
+            if self.entry_point == Some(idx) {
+                self.entry_point = self
+                    .id_to_index
+                    .values()
+                    .copied()
+                    .max_by_key(|&i| self.nodes[i].neighbors.len());
+            }
             true
         } else {
             false

--- a/ironbase-core/tests/repro_hnsw_replace_recall.rs
+++ b/ironbase-core/tests/repro_hnsw_replace_recall.rs
@@ -173,3 +173,60 @@ fn deleted_vector_not_returned() {
         "deleted vector must not be returned by search"
     );
 }
+
+/// Deleting the graph entry point (the first-inserted node) must not break
+/// search: `remove()` re-anchors `entry_point` to a live node, so upper-layer
+/// descent never starts from a dead node. Repeatedly delete the current
+/// first-generation anchor and confirm the rest stays fully retrievable.
+#[test]
+fn search_survives_entry_point_deletion() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("kb").unwrap();
+    const DIM: usize = 32;
+    const DOCS: usize = 24;
+    make_index(&coll, DIM);
+
+    let embedding = |d: usize| -> Vec<f32> {
+        let mut v = vec![0.0f32; DIM];
+        v[d % DIM] = 1.0;
+        v[(d + 5) % DIM] = 0.4;
+        v
+    };
+
+    // "anchor" is inserted FIRST, so it becomes the HNSW entry point.
+    let mut anchor_ids = db
+        .insert_many("kb", vec![embedding_doc("anchor", &embedding(0))])
+        .unwrap();
+    for d in 1..DOCS {
+        db.insert_many("kb", vec![embedding_doc(&format!("doc{d}"), &embedding(d))])
+            .unwrap();
+    }
+
+    // Delete + re-insert the entry-point anchor several times. Each delete drops
+    // the node that is (or was promoted to) entry point.
+    for _ in 0..6 {
+        let ids: Vec<serde_json::Value> = anchor_ids.iter().map(|id| json!(id)).collect();
+        db.delete_many("kb", &json!({ "_id": { "$in": ids } }))
+            .unwrap();
+        anchor_ids = db
+            .insert_many("kb", vec![embedding_doc("anchor", &embedding(0))])
+            .unwrap();
+    }
+
+    // All docs (including the re-inserted anchor) must self-retrieve.
+    for d in 0..DOCS {
+        let want = if d == 0 {
+            "anchor".to_string()
+        } else {
+            format!("doc{d}")
+        };
+        let res = coll.vector_search("embedding", &embedding(d), 1).unwrap();
+        assert_eq!(
+            res.first()
+                .and_then(|(doc, _)| doc.get("doc_id"))
+                .and_then(|v| v.as_str()),
+            Some(want.as_str()),
+            "self-retrieval failed for {want} after entry-point deletions"
+        );
+    }
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.511"
+version = "1.0.512"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Follow-up from the code review of the #77/#53 orphan-robust search fix (PR #78).

## #1 — recall: re-anchor `entry_point` on `remove()`
`remove()` never reassigned `entry_point`. If the entry-point node was deleted (a replace cycle), every search descended the **upper layers** from a dead (orphan) node via `search_layer_greedy` — which navigates purely by distance and can settle in an orphan local minimum. Only layer-0 benefited from the orphan-through-traversal fix, so recall could still drop for queries near a deleted-entry-point region.

`remove()` now re-anchors `entry_point` to the **highest-level active node** (`None` when none remain), so descent always starts from a live node.

## #4 — cleanup: drop dead orphan post-filters
`search()` and `search_with_filter()` still post-filtered orphans on the `search_layer` output, but `search_layer` already excludes orphans from its result set → those filters were dead. Removed them; updated the `ef_search * 3` comment in `search_with_filter` to note it now compensates only for the caller filter, not orphan loss.

## Test
Adds `search_survives_entry_point_deletion` (delete + re-insert the entry-point node 6×, assert full self-retrieval).

Full `ironbase-core` suite green (1804), fmt + clippy clean. Versions: workspace `0.3.318`, mcp-server `1.0.512`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Az HNSW index robusztusságának javítása a lazy törlések és a belépési pont (entry point) kezelésével kapcsolatban, valamint a verziók megfelelő frissítése.

Hibajavítások:
- Az HNSW gráf belépési pontjának újrahorgonyzása a legmagasabb szintű aktív csomópontra, amikor az aktuális belépési pontként szolgáló csomópontot eltávolítjuk. Ez megakadályozza, hogy a keresések törölt csomópontról induljanak, és megőrzi a visszakeresési pontosságot (recall).

Fejlesztések:
- Redundáns, árva csomópontokra vonatkozó utólagos szűrés eltávolítása az HNSW keresési útvonalakból, mivel a mag keresési réteg már eleve kizárja a lazy módon törölt csomópontokat a jelöltkészletéből.

Build:
- A workspace csomag verziójának emelése 0.3.318-ra, valamint az `mcp-ironbase-server` crate verziójának emelése 1.0.512-re.

Tesztek:
- Regressziós teszt hozzáadása annak biztosítására, hogy az HNSW keresés továbbra is teljesen helyes maradjon, miután a gráf belépési pontjaként szolgáló csomópontot ismételten töröljük és újra beszúrjuk.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve HNSW index robustness around lazy deletions and entry-point handling, and adjust versions accordingly.

Bug Fixes:
- Re-anchor the HNSW graph entry point to the highest-level active node when the current entry-point node is removed, preventing searches from starting from a deleted node and preserving recall.

Enhancements:
- Remove redundant orphan-node post-filtering from HNSW search paths now that the core search layer already excludes lazy-deleted nodes from its candidate set.

Build:
- Bump workspace package version to 0.3.318 and mcp-ironbase-server crate version to 1.0.512.

Tests:
- Add a regression test ensuring HNSW search remains fully correct after repeatedly deleting and reinserting the graph entry-point node.

</details>