### PR TITLE
fix(hnsw): churn-aware orphan rebuild trigger — absolute cap (#81)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.318"
+version = "0.3.319"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -36,6 +36,19 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 
+/// Orphan-rebuild thresholds (see `HnswIndex::needs_rebuild`).
+///
+/// `remove()` is lazy — removed nodes linger in the graph as orphans until a
+/// `rebuild()`. Two triggers reclaim them:
+/// - RATIO: an orphan-heavy index (small/medium, where local poisoning is most
+///   likely) is rebuilt once orphans exceed `ORPHAN_RATIO_THRESHOLD` of total.
+/// - ABSOLUTE: a large index under steady replace churn keeps the ratio low
+///   forever, so orphans would accumulate unbounded between full compacts (#81).
+///   An absolute cap bounds that growth regardless of ratio.
+const MIN_ORPHANS_FOR_REBUILD: usize = 100;
+const ORPHAN_RATIO_THRESHOLD: f64 = 0.3;
+const MAX_ABSOLUTE_ORPHANS: usize = 10_000;
+
 /// A node in the HNSW graph
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct HnswNode {
@@ -213,20 +226,26 @@ impl HnswIndex {
         self.nodes.len().saturating_sub(self.id_to_index.len())
     }
 
-    /// Check if the index needs rebuilding due to excessive orphan nodes
+    /// Check if the index needs rebuilding due to excessive orphan nodes.
     ///
-    /// Returns true if orphan ratio exceeds 30% and there are at least 100 orphans.
-    /// Small absolute counts are ignored to avoid unnecessary rebuilds.
+    /// Two triggers (either fires), both ignoring tiny absolute counts:
+    /// - RATIO: orphans exceed `ORPHAN_RATIO_THRESHOLD` (30%) of total nodes —
+    ///   catches orphan-heavy small/medium indexes where search recall/cost is
+    ///   most affected.
+    /// - ABSOLUTE: orphans exceed `MAX_ABSOLUTE_ORPHANS` regardless of ratio —
+    ///   catches a large index under steady replace churn, whose ratio stays
+    ///   under 30% but whose orphans would otherwise grow unbounded between full
+    ///   compacts (#81).
     pub fn needs_rebuild(&self) -> bool {
         let orphans = self.orphan_count();
-        if orphans < 100 {
+        if orphans < MIN_ORPHANS_FOR_REBUILD {
             return false;
         }
         let total = self.nodes.len();
         if total == 0 {
             return false;
         }
-        (orphans as f64 / total as f64) > 0.3
+        (orphans as f64 / total as f64) > ORPHAN_RATIO_THRESHOLD || orphans >= MAX_ABSOLUTE_ORPHANS
     }
 
     /// Rebuild the index only if orphan ratio exceeds threshold.
@@ -1042,6 +1061,58 @@ impl LazyLoadable for HnswIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Small, fast HNSW config for threshold tests (recall quality irrelevant).
+    fn fast_cfg(dim: usize) -> VectorIndexConfig {
+        let mut cfg = VectorIndexConfig::new(dim);
+        cfg.m = 4;
+        cfg.ef_construction = 10;
+        cfg
+    }
+
+    #[test]
+    fn needs_rebuild_respects_min_and_ratio() {
+        let mut idx = HnswIndex::new(fast_cfg(2));
+        for i in 0..200 {
+            idx.insert(&format!("k{i}"), &[i as f32, 0.0]).unwrap();
+        }
+        // 50 orphans (< MIN_ORPHANS_FOR_REBUILD=100) → no rebuild even at 25%.
+        for i in 0..50 {
+            idx.remove(&format!("k{i}"));
+        }
+        assert!(!idx.needs_rebuild());
+        // 150 orphans / 200 total = 75% (> 30%) and ≥ 100 → rebuild.
+        for i in 50..150 {
+            idx.remove(&format!("k{i}"));
+        }
+        assert!(idx.needs_rebuild());
+    }
+
+    #[test]
+    fn needs_rebuild_absolute_cap_fires_below_ratio() {
+        // #81: a large index under churn keeps the ratio < 30% but accumulates
+        // orphans past MAX_ABSOLUTE_ORPHANS — the absolute cap must trigger.
+        let total = 34_000;
+        let orphans = MAX_ABSOLUTE_ORPHANS; // 10_000
+        let mut idx = HnswIndex::new(fast_cfg(2));
+        for i in 0..total {
+            idx.insert(&format!("k{i}"), &[i as f32, (i % 7) as f32])
+                .unwrap();
+        }
+        for i in 0..orphans {
+            idx.remove(&format!("k{i}"));
+        }
+        let ratio = idx.orphan_count() as f64 / idx.total_nodes() as f64;
+        assert!(
+            ratio < ORPHAN_RATIO_THRESHOLD,
+            "precondition: ratio must be below the ratio trigger, got {ratio}"
+        );
+        assert!(idx.orphan_count() >= MAX_ABSOLUTE_ORPHANS);
+        assert!(
+            idx.needs_rebuild(),
+            "absolute orphan cap should trigger rebuild even below the ratio threshold"
+        );
+    }
 
     #[test]
     fn test_empty_index() {

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.512"
+version = "1.0.513"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Closes #81.

## Problem
`HnswIndex::needs_rebuild()` only triggered on a global orphan **ratio** (`>30%` and `>=100` orphans). On a large index under steady replace churn (read-mostly RAG server), the ratio stays under 30% forever → the checkpoint rebuild never fires → orphans accumulate **unbounded** between full compacts (linear RAM + per-query traversal-cost creep, since orphans stay navigable in `search_layer`).

## Fix
Add an **absolute** cap: rebuild also fires when `orphans >= MAX_ABSOLUTE_ORPHANS` (10 000) regardless of ratio. The ratio trigger still covers orphan-heavy small/medium indexes; the absolute trigger bounds growth on large ones. Thresholds are now named constants with a doc block. Propagates unchanged through `rebuild_vector_indexes_if_needed()` (checkpoint) and the unconditional `compact()` path.

## Tests
- `needs_rebuild_respects_min_and_ratio` — MIN (100) + 30% ratio boundaries
- `needs_rebuild_absolute_cap_fires_below_ratio` — 34k nodes, 10k orphans (~29% ratio) → absolute cap triggers

Full `ironbase-core` suite green (1806), fmt + clippy clean. Versions: workspace `0.3.319`, mcp-server `1.0.513`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Abszolút árva-számláló plafon bevezetése az HNSW indexek újraépítésének triggerelésére a meglévő arányalapú küszöb mellett, illetve tesztek hozzáadása mindkét újraépítési feltétel ellenőrzésére.

Hibajavítások:
- Biztosítja, hogy az HNSW indexek újraépüljenek, amikor az árvák száma meghalad egy rögzített maximumot, még akkor is, ha az árva-arány a korábbi 30%-os küszöb alatt marad, megelőzve a korlátlan árva-felhalmozódást nagy indexekben.

Fejlesztések:
- Dokumentálja és központosítja az HNSW árva-alapú újraépítési küszöböket elnevezett konstansokként az átláthatóbb viselkedés és az egyszerűbb hangolhatóság érdekében.

Tesztek:
- Egységteszteket ad hozzá mind a minimális árvaszám + arányalapú újraépítési triggerre, mind az új, nagy indexekre vonatkozó abszolút árva-számláló plafonra.

Karbantartás:
- A workspace és az mcp-ironbase-server crate verzióinak frissítése rendre 0.3.319-re és 1.0.513-ra.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an absolute orphan-count cap to trigger HNSW index rebuilds in addition to the existing ratio-based threshold, and add tests to verify both rebuild conditions.

Bug Fixes:
- Ensure HNSW indexes are rebuilt when orphan count exceeds a fixed maximum even if the orphan ratio stays below the previous 30% threshold, preventing unbounded orphan accumulation in large indexes.

Enhancements:
- Document and centralize HNSW orphan-rebuild thresholds as named constants for clearer behavior and easier tuning.

Tests:
- Add unit tests covering both the minimum orphan count plus ratio-based rebuild trigger and the new absolute orphan-count cap on large indexes.

Chores:
- Bump workspace and mcp-ironbase-server crate versions to 0.3.319 and 1.0.513 respectively.

</details>