### PR TITLE
perf(hnsw): bound search_layer traversal with a visit budget (#80)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.319"
+version = "0.3.320"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -49,6 +49,17 @@ const MIN_ORPHANS_FOR_REBUILD: usize = 100;
 const ORPHAN_RATIO_THRESHOLD: f64 = 0.3;
 const MAX_ABSOLUTE_ORPHANS: usize = 10_000;
 
+/// Backstop bound on nodes visited per `search_layer` call (#80).
+///
+/// When the active vector count is below `ef` (or a neighbourhood is
+/// orphan-dense), `results` can't fill to `ef` and the distance-based early-stop
+/// never fires, so the layer search would otherwise walk the whole reachable
+/// graph. The budget = `ef * VISIT_BUDGET_FACTOR` (floored at `MIN_VISIT_BUDGET`)
+/// is set far above what a healthy query touches — healthy queries early-stop by
+/// distance long before — so it only caps pathological orphan-dense scans.
+const VISIT_BUDGET_FACTOR: usize = 64;
+const MIN_VISIT_BUDGET: usize = 1024;
+
 /// A node in the HNSW graph
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct HnswNode {
@@ -885,6 +896,10 @@ impl HnswIndex {
         // results or the reachable graph is exhausted.
         let is_active = |idx: usize| self.id_to_index.contains_key(&self.nodes[idx].id);
 
+        // #80: backstop so a few-active / orphan-dense layer can't degrade into a
+        // full reachable-graph walk. Generous — healthy queries early-stop first.
+        let max_visits = ef.saturating_mul(VISIT_BUDGET_FACTOR).max(MIN_VISIT_BUDGET);
+
         let entry_dist = self.compute_distance(query, &self.nodes[entry].vector);
         visited.insert(entry);
         candidates.push(NearestCandidate {
@@ -903,6 +918,10 @@ impl HnswIndex {
             distance: current_dist,
         }) = candidates.pop()
         {
+            // #80 backstop: stop if we've already explored the visit budget.
+            if visited.len() >= max_visits {
+                break;
+            }
             // Early stop only once we have ef *active* results and the closest
             // remaining frontier node is farther than the furthest of them.
             if results.len() >= ef {
@@ -1112,6 +1131,39 @@ mod tests {
             idx.needs_rebuild(),
             "absolute orphan cap should trigger rebuild even below the ratio threshold"
         );
+    }
+
+    #[test]
+    fn search_returns_all_active_with_orphans_under_budget() {
+        // #80: few active vectors + orphan churn (under the visit budget) must
+        // still return every active node — the backstop bounds work without
+        // truncating valid results. Uses a realistic config (good connectivity);
+        // the point under test is the budget, not graph quality.
+        let mut idx = HnswIndex::with_dim(12);
+        for i in 0..12 {
+            let mut v = vec![0.0f32; 12];
+            v[i] = 1.0; // orthogonal one-hot directions, distinct under cosine
+            idx.insert(&format!("a{i}"), &v).unwrap();
+        }
+        // ~600 orphans (well under MIN_VISIT_BUDGET=1024) via insert+remove.
+        for i in 0..600 {
+            let id = format!("tmp{i}");
+            let mut v = vec![0.0f32; 12];
+            v[i % 12] = 0.5;
+            v[(i + 1) % 12] = 0.5;
+            idx.insert(&id, &v).unwrap();
+            idx.remove(&id);
+        }
+        for i in 0..12 {
+            let mut v = vec![0.0f32; 12];
+            v[i] = 1.0;
+            let res = idx.search(&v, 1);
+            assert_eq!(
+                res.first().map(|r| r.id.as_str()),
+                Some(format!("a{i}").as_str()),
+                "active anchor a{i} must self-retrieve despite orphan churn"
+            );
+        }
     }
 
     #[test]

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.513"
+version = "1.0.514"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Closes #80.

## Problem
When active vectors < `ef` (or a neighbourhood is orphan-dense), `results` can't fill to `ef`, the distance early-stop never fires, and `search_layer` walks the **entire reachable graph** per call (search and insert/`ef_construction`). #81 caps absolute orphans at 10k, but that still allows ~10k node visits per query in the pre-rebuild window.

## Fix
Backstop **visit budget**: stop a layer search once it has touched `ef * VISIT_BUDGET_FACTOR` (64) nodes, floored at `MIN_VISIT_BUDGET` (1024). Far above what a healthy query touches (those early-stop by distance first) → **neutral for normal indexes**, caps only pathological orphan-dense / few-active scans.

## Test
`search_returns_all_active_with_orphans_under_budget` — 12 active + 600 orphan churn, every active node still self-retrieves (budget bounds work without truncating valid results).

Full `ironbase-core` suite green (1807), fmt + clippy clean. Versions: workspace `0.3.320`, mcp-server `1.0.514`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Az HNSW rétegbeli keresések korlátozása egy látogatási kerettel, hogy megakadályozzuk a kóros, teljes gráfra kiterjedő bejárásokat, miközben megőrizzük a normál lekérdezési viselkedést.

Új funkciók:
- Konfigurálható látogatási keret bevezetése az HNSW rétegbeli keresésekhez, amely az ef értékén alapul, és egy minimális küszöböt használ a csomópont-látogatások lekérdezésenkénti korlátozására.

Build:
- A workspace crate verzió frissítése 0.3.320-ra és az mcp szerver verzió frissítése 1.0.514-re.

Tesztek:
- Regressziós teszt hozzáadása annak biztosítására, hogy minden aktív vektor továbbra is helyesen visszatérjen akkor is, ha sok árva elem létezik a látogatási keret mellett.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit HNSW layer searches with a visit budget to prevent pathological full-graph traversals while preserving normal query behavior.

New Features:
- Introduce a configurable visit budget for HNSW layer searches based on ef with a minimum threshold to cap node visits per query.

Build:
- Bump workspace crate version to 0.3.320 and mcp server version to 1.0.514.

Tests:
- Add a regression test ensuring all active vectors are still returned correctly when many orphans exist under the visit budget.

</details>