### PR TITLE
fix(hnsw): force vector rebuild on compact + admit distance ties in search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.321"
+version = "0.3.322"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/index/manager.rs
+++ b/ironbase-core/src/index/manager.rs
@@ -993,28 +993,35 @@ impl IndexManager {
         Ok(rebuilt)
     }
 
-    /// Rebuild ALL vector indexes unconditionally.
+    /// Rebuild ALL non-empty vector indexes **unconditionally**.
     ///
-    /// Used during db_compact to ensure clean HNSW state.
+    /// Used by `db_compact` (the explicit/auto heavy maintenance op) to fully
+    /// rebuild the HNSW graphs from their active vectors. Unlike the checkpoint
+    /// path (`rebuild_vector_indexes_if_needed`, orphan-ratio gated), this does
+    /// NOT gate on orphan count: a graph can be degraded (poor connectivity, e.g.
+    /// built by an older/buggy version) with zero orphans, and only a forced
+    /// rebuild repairs it. `rebuild()` reconstructs from `id_to_index` (the active
+    /// vectors), so it both removes orphans and re-links the graph correctly.
     /// Returns the number of indexes rebuilt.
     pub fn rebuild_all_vector_indexes(&mut self) -> Result<usize> {
         let mut rebuilt = 0;
         let names: Vec<String> = self.vector_indexes.keys().cloned().collect();
         for name in names {
             if let Some(index) = self.vector_indexes.get_mut(&name) {
-                let orphans = index.orphan_count();
-                if orphans > 0 {
-                    let active = index.len();
-                    index.rebuild()?;
-                    self.dirty_vector_indexes.insert(name.clone());
-                    crate::log_info!(
-                        "HNSW index '{}' compacted: removed {} orphan nodes, {} active vectors remain",
-                        name,
-                        orphans,
-                        active
-                    );
-                    rebuilt += 1;
+                let active = index.len();
+                if active == 0 {
+                    continue; // nothing to rebuild
                 }
+                let orphans = index.orphan_count();
+                index.rebuild()?;
+                self.dirty_vector_indexes.insert(name.clone());
+                crate::log_info!(
+                    "HNSW index '{}' rebuilt during compact: {} active vectors, {} orphans removed",
+                    name,
+                    active,
+                    orphans
+                );
+                rebuilt += 1;
             }
         }
         Ok(rebuilt)

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -1010,10 +1010,14 @@ impl HnswIndex {
                 for &neighbor_idx in &neighbors[level] {
                     if visited.insert(neighbor_idx) {
                         let dist = self.compute_distance(query, &self.nodes[neighbor_idx].vector);
-                        // Expand if the navigable set isn't full or this node is
-                        // nearer than its current furthest.
+                        // Expand if the navigable set isn't full, or this node is no
+                        // farther than its current furthest. `<=` (not `<`) admits
+                        // distance ties so that, in a dense same-distance cluster
+                        // (e.g. many identical-vector orphans around one live node),
+                        // the live node is still explored and collected into
+                        // `w_active` instead of being crowded out by the ties.
                         let promising = w_nav.len() < ef
-                            || w_nav.peek().map(|f| dist < f.distance).unwrap_or(true);
+                            || w_nav.peek().map(|f| dist <= f.distance).unwrap_or(true);
                         if promising {
                             candidates.push(NearestCandidate {
                                 index: neighbor_idx,

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.515"
+version = "1.0.516"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Two follow-ups to #84, enabling Phase 5 production remediation and fixing a corner case it exposed.

## 1. `db_compact` force-rebuilds vector indexes
`rebuild_all_vector_indexes` (called only by `db_compact`, **not** the frequent checkpoint) now rebuilds every non-empty vector index **unconditionally**, not just when `orphans>0`. A graph can be degraded (poor connectivity — e.g. built by the pre-#84 inverted-heap code) with **zero orphans**, and only a forced rebuild repairs it. This makes `db_compact` the force-rebuild primitive for the docs.mlite remediation; the checkpoint path stays orphan-gated and cheap.

## 2. `search_layer` admits distance ties (`<=`)
The promising-gate used strict `<`. With many identical-vector orphans around one live node (the replace-churn case), `<` filled the navigable set with same-distance ties and then rejected the live node (`0 < 0` false), so it was never collected even though reachable. `<=` admits ties so the live node is explored and returned. Fixes the deterministic failure of `replace_same_vector_many_times_self_retrieval_holds` that #84's per-index RNG surfaced.

Full `ironbase-core` suite green (1812, ran twice), fmt + clippy clean. Versions: workspace `0.3.322`, mcp-server `1.0.516`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

A nem üres HNSW vektor indexek teljes újraépítésének kikényszerítése adatbázis-kompaktálás során, valamint a HNSW keresés holtverseny-kezelésének módosítása az azonos távolságú szomszédok helyes bejárása érdekében.

Hibajavítások:
- Biztosítja, hogy a `db_compact` mindig újraépítse a nem üres HNSW vektor indexeket az árva csomópontok számától függetlenül, a leromlott gráfok helyreállítása érdekében.
- Lehetővé teszi, hogy a HNSW keresés azonos távolságú jelölteket is figyelembe vegyen, így az aktív csomópontok nem szorulnak háttérbe azonos vektorú árvák miatt.

Fejlesztések:
- Kihagyja az újraépítési munkát az üres vektor indexeknél, miközben a kompaktálást továbbra is teljes újraépítésként kezeli minden feltöltött index esetén.
- Javítja a HNSW-kompaktálás naplózását az aktív vektorok és az árva eltávolítások jelentésével.

Build:
- A workspace crate verziójának frissítése 0.3.322-re, az mcp-ironbase-serveré pedig 1.0.516-ra.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Force full rebuilds of non-empty HNSW vector indexes during database compaction and adjust HNSW search tie-handling to correctly explore equal-distance neighbors.

Bug Fixes:
- Ensure `db_compact` always rebuilds non-empty HNSW vector indexes regardless of orphan count to recover degraded graphs.
- Allow HNSW search to admit equal-distance candidates so live nodes are not starved by identical-vector orphans.

Enhancements:
- Skip rebuild work for empty vector indexes while still treating compaction as a full rebuild for all populated indexes.
- Improve HNSW compaction logging to report active vectors and orphan removals.

Build:
- Bump workspace crate version to 0.3.322 and mcp-ironbase-server to 1.0.516.

</details>