### PR TITLE
fix(compact): gate automatic vector rebuild; force only on explicit db_compact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,9 +430,19 @@ index.needs_rebuild()  // >30% orphan ÉS >100 orphan
 index.rebuild_if_needed()  // Rebuild ha needs_rebuild()
 ```
 
-**Automatikus orphan compaction:**
-- **Checkpoint** (60s): `rebuild_vector_indexes_if_needed()` — csak ha >30% orphan
-- **Compact** (`db_compact`): `rebuild_all_vector_indexes()` — minden orphan eltávolítása
+**Orphan compaction — gated (automatikus) vs force (explicit):**
+- **Checkpoint** (60s): `rebuild_vector_indexes_if_needed()` — csak ha >30% ÉS >100 orphan
+- **Automatikus compact** (bloat-trigger, induláskor: `last_compact_size=0` → `bloat_ratio=inf`):
+  `force_vector_rebuild=false` → `rebuild_vector_indexes_if_needed()` (orphan-gated, **olcsó**).
+  ⚠️ Ezért az automatikus/induló compact **NEM** javít degradált-de-orphan-mentes
+  (vagy <100 orphan) gráfot — ez szándékos (különben minden restart teljes,
+  egyszálú HNSW rebuild-et fizetne 0 orphannál is, ~15-20 perc 1 mag pinned).
+- **Explicit compact** (MCP `db_compact` tool, blokkoló `DatabaseCore::compact()`,
+  Python/C# `db.compact()`): `force_vector_rebuild=true` → `rebuild_all_vector_indexes()`
+  — minden orphan eltávolítása + teljes gráf-rekonstrukció. Degradált gráf
+  javításához EZT kell hívni (pl. régi/buggos verzió után). Szemantika: *explicit hívás = force*.
+- Flag: `CompactionConfig::force_vector_rebuild` (default `false`). Belépési pontok:
+  `mcp-server/src/compaction.rs` auto path → `false`, `tools/admin.rs` db_compact → `true`.
 
 **Key files:**
 - `ironbase-core/src/vector/hnsw.rs` — `len()`, `orphan_count()`, `needs_rebuild()`, `rebuild_if_needed()`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.322"
+version = "0.3.323"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/database/maintenance.rs
+++ b/ironbase-core/src/database/maintenance.rs
@@ -200,10 +200,19 @@ impl DatabaseCore<StorageEngine> {
             let index_managers = self.index_managers.read();
             for (collection_name, index_manager) in index_managers.iter() {
                 let mut mgr = index_manager.write();
-                let rebuilt = mgr.rebuild_all_vector_indexes()?;
+                // A forced (explicit operator) compact fully reconstructs every
+                // graph; the automatic bloat-triggered compact only rebuilds
+                // orphan-heavy ones — so a routine startup compact with zero
+                // orphans no longer pays for a full HNSW rebuild.
+                let rebuilt = if config.force_vector_rebuild {
+                    mgr.rebuild_all_vector_indexes()?
+                } else {
+                    mgr.rebuild_vector_indexes_if_needed()?
+                };
                 if rebuilt > 0 {
                     tracing::info!(
                         collection = %collection_name, rebuilt,
+                        forced = config.force_vector_rebuild,
                         "Compact (non-blocking): HNSW indexes rebuilt"
                     );
                 }
@@ -874,5 +883,152 @@ impl<S: Storage + RawStorage> DatabaseCore<S> {
     /// Get current durability mode
     pub fn durability_mode(&self) -> DurabilityMode {
         self.durability_mode
+    }
+}
+
+#[cfg(test)]
+mod compact_vector_rebuild_tests {
+    //! Verifies the `force_vector_rebuild` dispatch in `compact_nonblocking`.
+    //!
+    //! These are crate-internal so they can read `orphan_count()` (only reachable
+    //! via the `pub(crate)` index_managers) — the divergence between the gated and
+    //! forced paths is NOT observable through the public API. The setup leaves a
+    //! sub-gate number of orphans (< MIN_ORPHANS_FOR_REBUILD=100), the regime
+    //! where the two paths actually differ: the gated (automatic) path is a no-op,
+    //! the forced (explicit) path rebuilds and clears them. Inverting the dispatch
+    //! flips both assertions, so a mis-wired flag is caught.
+
+    use crate::storage::{CompactionConfig, StorageEngine};
+    use crate::vector::{DistanceMetric, VectorIndexConfig};
+    use crate::DatabaseCore;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    // DIM > DOCS so each doc's dominant dimension (`d % DIM`) is unique (distinct
+    // vectors). CHURN < 100 keeps the orphan count below the rebuild gate.
+    const DIM: usize = 64;
+    const DOCS: usize = 60;
+    const CHURN: usize = 40;
+
+    fn embedding(d: usize) -> Vec<f32> {
+        let mut v = vec![0.0f32; DIM];
+        v[d % DIM] = 1.0;
+        v[(d + 1) % DIM] = 0.3;
+        v[(d + 2) % DIM] = 0.1;
+        v
+    }
+
+    fn doc(tag: &str, v: &[f32]) -> HashMap<String, serde_json::Value> {
+        HashMap::from([
+            ("doc_id".to_string(), json!(tag)),
+            ("embedding".to_string(), json!(v)),
+        ])
+    }
+
+    fn orphan_count(db: &DatabaseCore<StorageEngine>) -> usize {
+        let mgrs = db.index_managers.read();
+        let mgr = mgrs.get("kb").expect("kb index manager").read();
+        let idxs = mgr.list_vector_indexes();
+        assert_eq!(idxs.len(), 1, "exactly one vector index expected");
+        idxs[0].orphan_count()
+    }
+
+    /// Build `kb` with DOCS distinct vectors, then churn (delete + reinsert) the
+    /// first CHURN docs so the HNSW graph carries CHURN lazy-removed orphans.
+    fn build_churned_db() -> (TempDir, DatabaseCore<StorageEngine>) {
+        let temp = TempDir::new().unwrap();
+        let db = DatabaseCore::<StorageEngine>::open(temp.path().join("c.mlite")).unwrap();
+        {
+            let coll = db.collection("kb").unwrap();
+            let mut cfg = VectorIndexConfig::new(DIM);
+            cfg.field = "embedding".to_string();
+            cfg.metric = DistanceMetric::Cosine;
+            coll.create_vector_index("embedding", cfg).unwrap();
+        }
+        let mut ids: Vec<Vec<serde_json::Value>> = Vec::with_capacity(DOCS);
+        for d in 0..DOCS {
+            let new = db
+                .insert_many("kb", vec![doc(&format!("doc{d}"), &embedding(d))])
+                .unwrap();
+            ids.push(new.into_iter().map(|i| json!(i)).collect());
+        }
+        for d in 0..CHURN {
+            let new = db
+                .insert_many("kb", vec![doc(&format!("doc{d}"), &embedding(d))])
+                .unwrap();
+            db.delete_many("kb", &json!({ "_id": { "$in": ids[d].clone() } }))
+                .unwrap();
+            ids[d] = new.into_iter().map(|i| json!(i)).collect();
+        }
+        (temp, db)
+    }
+
+    fn assert_top1(db: &DatabaseCore<StorageEngine>, d: usize) {
+        let coll = db.collection("kb").unwrap();
+        let res = coll.vector_search("embedding", &embedding(d), 1).unwrap();
+        assert_eq!(
+            res.first()
+                .and_then(|(doc, _)| doc.get("doc_id"))
+                .and_then(|v| v.as_str()),
+            Some(format!("doc{d}").as_str()),
+            "self-retrieval failed for doc{d}"
+        );
+    }
+
+    /// Automatic (default) compact: orphan-gated → below the gate it must NOT
+    /// rebuild, so the orphans survive and no full-rebuild cost is paid.
+    #[test]
+    fn auto_gated_compact_does_not_rebuild_below_orphan_gate() {
+        let (_t, db) = build_churned_db();
+        let before = orphan_count(&db);
+        assert!(
+            before > 0 && before < 100,
+            "setup must leave sub-gate orphans, got {before}"
+        );
+
+        db.compact_nonblocking(&CompactionConfig::new(), &|_, _| {})
+            .unwrap();
+
+        assert_eq!(
+            orphan_count(&db),
+            before,
+            "automatic (gated) compact must NOT rebuild below the orphan gate"
+        );
+        assert_top1(&db, 0); // search still correct (orphans excluded at query time)
+    }
+
+    /// Explicit operator compact: forced → rebuilds unconditionally and clears
+    /// every orphan, even below the gate.
+    #[test]
+    fn forced_compact_rebuilds_and_clears_orphans() {
+        let (_t, db) = build_churned_db();
+        assert!(orphan_count(&db) > 0, "setup must create orphans");
+
+        db.compact_nonblocking(
+            &CompactionConfig::new().with_force_vector_rebuild(true),
+            &|_, _| {},
+        )
+        .unwrap();
+
+        assert_eq!(
+            orphan_count(&db),
+            0,
+            "forced compact must rebuild and remove all orphans"
+        );
+        assert_top1(&db, 0);
+    }
+
+    /// Regression guard: the default must stay non-forced on every construction
+    /// path, so a routine/automatic compact never triggers the heavy rebuild.
+    #[test]
+    fn compaction_config_defaults_to_gated_rebuild() {
+        assert!(!CompactionConfig::new().force_vector_rebuild);
+        assert!(!CompactionConfig::default().force_vector_rebuild);
+        assert!(
+            CompactionConfig::new()
+                .with_force_vector_rebuild(true)
+                .force_vector_rebuild
+        );
     }
 }

--- a/ironbase-core/src/index/manager.rs
+++ b/ironbase-core/src/index/manager.rs
@@ -995,9 +995,11 @@ impl IndexManager {
 
     /// Rebuild ALL non-empty vector indexes **unconditionally**.
     ///
-    /// Used by `db_compact` (the explicit/auto heavy maintenance op) to fully
-    /// rebuild the HNSW graphs from their active vectors. Unlike the checkpoint
-    /// path (`rebuild_vector_indexes_if_needed`, orphan-ratio gated), this does
+    /// Used by an explicit operator-initiated `db_compact` (force path) and the
+    /// blocking `compact()` to fully rebuild the HNSW graphs from their active
+    /// vectors. The automatic bloat-triggered compact does NOT use this — it
+    /// takes the orphan-gated `rebuild_vector_indexes_if_needed` instead. Unlike
+    /// the checkpoint path (`rebuild_vector_indexes_if_needed`), this does
     /// NOT gate on orphan count: a graph can be degraded (poor connectivity, e.g.
     /// built by an older/buggy version) with zero orphans, and only a forced
     /// rebuild repairs it. `rebuild()` reconstructs from `id_to_index` (the active

--- a/ironbase-core/src/storage/compaction.rs
+++ b/ironbase-core/src/storage/compaction.rs
@@ -21,6 +21,12 @@ pub struct CompactionConfig {
     pub chunk_size: usize,
     /// Optional cancellation flag - set to true to abort compaction
     pub cancel_flag: Option<Arc<AtomicBool>>,
+    /// Force a full rebuild of every vector (HNSW) index even when there is no
+    /// orphan pressure. The automatic bloat-triggered compact leaves this
+    /// `false` (orphan-gated rebuild — cheap when nothing needs repair); an
+    /// explicit operator-initiated `db_compact` sets it `true` to fully
+    /// reconstruct possibly-degraded graphs. Default: `false`.
+    pub force_vector_rebuild: bool,
 }
 
 impl CompactionConfig {
@@ -29,6 +35,7 @@ impl CompactionConfig {
         Self {
             chunk_size: 1000,
             cancel_flag: None,
+            force_vector_rebuild: false,
         }
     }
 
@@ -41,6 +48,12 @@ impl CompactionConfig {
     /// Set a cancellation flag for interruptible compaction
     pub fn with_cancel_flag(mut self, flag: Arc<AtomicBool>) -> Self {
         self.cancel_flag = Some(flag);
+        self
+    }
+
+    /// Force an unconditional rebuild of all vector indexes (see field docs).
+    pub fn with_force_vector_rebuild(mut self, force: bool) -> Self {
+        self.force_vector_rebuild = force;
         self
     }
 

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.516"
+version = "1.0.517"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mcp-server/src/compaction.rs
+++ b/mcp-server/src/compaction.rs
@@ -167,11 +167,16 @@ impl Drop for CompactGuard {
 ///
 /// Takes CompactGuard by reference — the guard is owned by the caller (closure)
 /// and its Drop impl will clear the compacting flag when the closure exits.
+///
+/// `force_vector_rebuild`: `true` for an explicit operator `db_compact` (fully
+/// reconstruct every HNSW graph), `false` for the automatic bloat-triggered
+/// compact (orphan-gated rebuild only — cheap when nothing needs repair).
 pub fn run_compact_job(
     job_id: &str,
     job_mgr: &JobManager,
     guard: &CompactGuard,
     shutdown_flag: &AtomicBool,
+    force_vector_rebuild: bool,
 ) {
     let adapter = &guard.adapter;
     let start = Instant::now();
@@ -179,8 +184,9 @@ pub fn run_compact_job(
 
     // Combined cancel flag: checked by CompactionConfig.is_cancelled()
     let combined_cancel = Arc::new(AtomicBool::new(false));
-    let config =
-        ironbase_core::storage::CompactionConfig::new().with_cancel_flag(combined_cancel.clone());
+    let config = ironbase_core::storage::CompactionConfig::new()
+        .with_cancel_flag(combined_cancel.clone())
+        .with_force_vector_rebuild(force_vector_rebuild);
 
     let result = adapter.compact_nonblocking(&config, &|processed, total| {
         // Cancel propagation: job cancel OR shutdown → combined_cancel
@@ -327,7 +333,9 @@ pub fn auto_compact_check(
     let state_clone = state.clone();
 
     let handle = std::thread::spawn(move || {
-        run_compact_job(&job_id_clone, &job_mgr_clone, &guard, &shutdown_flag);
+        // Automatic (bloat-triggered) compact: orphan-gated vector rebuild only,
+        // so a routine startup compact does not pay for a full HNSW rebuild.
+        run_compact_job(&job_id_clone, &job_mgr_clone, &guard, &shutdown_flag, false);
         // Mark compact completed for cooldown tracking
         state_clone.lock().mark_compact_completed();
     });

--- a/mcp-server/src/tools/admin.rs
+++ b/mcp-server/src/tools/admin.rs
@@ -156,7 +156,9 @@ fn handle_db_compact(
     let handle = std::thread::spawn(move || {
         // guard is moved here — Drop will fire when this closure exits
         // (whether normally, via early return, or via panic)
-        run_compact_job(&job_id_clone, &job_mgr_clone, &guard, &shutdown_flag);
+        // Explicit operator compact: force a full vector-index rebuild so a
+        // degraded graph (e.g. built by an older version) gets reconstructed.
+        run_compact_job(&job_id_clone, &job_mgr_clone, &guard, &shutdown_flag, true);
     });
 
     job_mgr.register_thread(job_id.clone(), handle);

--- a/mcp-server/tests/e2e_smoke.sh
+++ b/mcp-server/tests/e2e_smoke.sh
@@ -7,7 +7,7 @@
 # on the v1.0.505-507 changes, which until now had only in-process Rust coverage:
 #
 #   A. Tool surface     — `search` present; `hybrid_search` / `vector_search_filter`
-#                         removed; tool count == 93.
+#                         removed; tool count == 87 (post-#74 rename).
 #   B. Non-RAG fulltext — multi-field `match_scope="document"` qualification on a
 #                         collection with no parent doc_id (the v1.0.506 fix:
 #                         union must key on `_id`, not a `doc_id` the docs lack).
@@ -95,8 +95,9 @@ echo "== A. Tool surface (v1.0.505-507) =="
 TOOLS="$(rpc "tools/list" '{}' | jq -r '.result.tools[].name')"
 COUNT="$(printf '%s\n' "$TOOLS" | grep -c .)"
 # Non-localhost callers don't see the 8 admin_* tools (tools/list filtering,
-# SECURITY FIX #14): localhost sees 93, a remote/Internal client sees 85.
-EXP_COUNT=$([[ "$SELF_HOSTED" == 1 ]] && echo 93 || echo 85)
+# SECURITY FIX #14): localhost sees 87, a remote/Internal client sees 79.
+# (Tool count is 87 after the #74 noun-first rename + index consolidation.)
+EXP_COUNT=$([[ "$SELF_HOSTED" == 1 ]] && echo 87 || echo 79)
 assert "search tool present"             "$(grep -qx search             <<<"$TOOLS" && echo 1 || echo 0)"
 assert "hybrid_search removed"           "$(grep -qx hybrid_search       <<<"$TOOLS" && echo 0 || echo 1)"
 assert "vector_search_filter removed"    "$(grep -qx vector_search_filter<<<"$TOOLS" && echo 0 || echo 1)"
@@ -107,8 +108,8 @@ echo "== B. Non-RAG multi-field document-scope fulltext (v1.0.506 fix) =="
 tool collection_create "$(jq -nc --arg c "$KB" '{collection:$c}')" >/dev/null
 tool insert_one "$(jq -nc --arg c "$KB" '{collection:$c,document:{content:"fékpad PEF-35 berendezés leírás",title:"alpha"}}')" >/dev/null
 tool insert_one "$(jq -nc --arg c "$KB" '{collection:$c,document:{content:"csak fékpad egyedül",title:"beta"}}')" >/dev/null
-tool index_create_fulltext "$(jq -nc --arg c "$KB" '{collection:$c,field:"content"}')" >/dev/null
-tool index_create_fulltext "$(jq -nc --arg c "$KB" '{collection:$c,field:"title"}')" >/dev/null
+tool index_create "$(jq -nc --arg c "$KB" '{collection:$c,field:"content",type:"fulltext"}')" >/dev/null
+tool index_create "$(jq -nc --arg c "$KB" '{collection:$c,field:"title",type:"fulltext"}')" >/dev/null
 # Multi-field, multi-word, default match_scope="document". Doc 1 has both tokens.
 MF="$(tool fulltext_search "$(jq -nc --arg c "$KB" '{collection:$c,field:"content",fields:["content","title"],query:"fékpad PEF-35"}')")"
 MF_COUNT="$(jq -r '[.results[]? // .[]?] | length' <<<"$MF" 2>/dev/null || echo 0)"
@@ -157,7 +158,7 @@ fi
 echo
 echo "== F. CRUD sanity =="
 tool insert_one "$(jq -nc --arg c "$KB" '{collection:$c,document:{k:"v",n:7}}')" >/dev/null
-CNT="$(tool count_documents "$(jq -nc --arg c "$KB" '{collection:$c,query:{}}')" | jq -r '.count // empty')"
+CNT="$(tool count "$(jq -nc --arg c "$KB" '{collection:$c,query:{}}')" | jq -r '.count // empty')"
 assert "count_documents >= 3 after inserts" "$([[ "${CNT:-0}" -ge 3 ]] && echo 1 || echo 0)" "count=$CNT"
 FND="$(tool find "$(jq -nc --arg c "$KB" '{collection:$c,query:{n:7}}')")"
 assert "find by field returns the doc" "$(jq -e '[.. | objects | select(.n? == 7)] | length > 0' <<<"$FND" >/dev/null 2>&1 && echo 1 || echo 0)"


### PR DESCRIPTION
## Probléma
A diagnózis a prod docs.mlite szerver ~74% CPU-ját egy **automatikus** compact-ra vezette vissza: indításkor `last_compact_size=0` → `bloat_ratio=inf` → az auto-compact lefut, és (a Phase 5 force-rebuild öröksége miatt) **feltétel nélkül** újraépíti a teljes HNSW-t — 0 orphan / 0 dead write mellett is. A ~210K-vektoros, egyszálú rebuild ~15-20 perc 1 mag pinned, **minden restartkor**.

## Megoldás
`force_vector_rebuild: bool` átfűzve a `CompactionConfig`-on:
- **automatikus** compact → `false` → `rebuild_vector_indexes_if_needed()` (orphan-gated, olcsó)
- **explicit** `db_compact` / blokkoló `compact()` → `true` → `rebuild_all_vector_indexes()` (teljes rekonstrukció)

Szemantika: *automatikus timer compact = gated/olcsó; explicit compact = force*. A force-rebuild (degradált gráf javítása, pl. régi verzió után) megmarad explicit úton.

### Trade-off (dokumentált)
Az automatikus compact **nem** javít degradált-de-orphan-mentes (vagy <100 orphan) gráfot — ehhez az explicit `db_compact`-ot kell hívni.

## Tesztek
- `compact_vector_rebuild_tests` (crate-internal): a dispatch-et **orphan_count divergenciával** méri (gated: sub-gate orphanok maradnak; force: 0). **Mutáció-bizonyítottan nem-vacuous** — a dispatch invertálása mindkét tesztet megbuktatja.
- ironbase-core teljes suite + mcp-server suite zöld; fmt + clippy tiszta.

## Egyéb (review-ból)
- `e2e_smoke.sh` elavult tool-felülete javítva (#74 átnevezés: 87 tool, `index_create type:fulltext`, `count`).
- `CLAUDE.md` orphan-compaction szekció frissítve (gated-auto vs force-explicit).

## Review
7-agentes adversarial review (3 finder × verify) futott a diffre: 6 találat, 0 refuted — mind kezelve (tesztek nem-vacuous-sá téve, doksik frissítve, #1/#6 a konzisztens *explicit=force* szemantikával lezárva).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Az automatikus tömörítés korlátozása úgy, hogy csak az árvák által vezérelt, olcsó vektorindex-újraépítéseket hajtsa végre, míg a teljes HNSW gráf rekonstrukciót kifejezetten a `db_compact` műveletekre tartalékoljuk, és a tesztek, dokumentáció és eszközök összehangolása az új szemantikával.

Hibajavítások:
- Megakadályozza, hogy a rutin automatikus tömörítések és az induláskori futások mindig teljes HNSW vektorindex-újraépítést indítsanak, még akkor is, ha nincsenek árvák.

Fejlesztések:
- Bevezet egy `force_vector_rebuild` jelzőt a tömörítési konfigurációban, hogy megkülönböztethessük a korlátozott automatikus tömörítést a kényszerített, explicit tömörítéstől.
- Belső crate-tesztek hozzáadása a tömörítés-diszpécselés viselkedésének és az alapértelmezett `force_vector_rebuild` szemantikának az ellenőrzésére.

Dokumentáció:
- A CLAUDE dokumentáció frissítése a korlátozott és kényszerített árva-tömörítési viselkedés és belépési pontok leírására.

Tesztelés:
- Az MCP szerver end-to-end „smoke” tesztjeinek bővítése az aktualizált eszközszámok és az átnevezett/indexelt eszközök tükrözésére.

Egyéb:
- A workspace és az MCP szerver crate verzióinak emelése a viselkedésbeli változás tükrözésére.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate automatic compaction to only perform orphan-driven, cheap vector index rebuilds while reserving full HNSW graph reconstruction for explicit db_compact operations, and align tests, docs, and tooling with the new semantics.

Bug Fixes:
- Prevent routine automatic compaction and startup runs from always triggering full HNSW vector index rebuilds even when there are no orphans.

Enhancements:
- Introduce a force_vector_rebuild flag in compaction configuration to distinguish between gated automatic compaction and forced explicit compaction.
- Add crate-internal tests to verify compaction dispatch behavior and default force_vector_rebuild semantics.

Documentation:
- Update CLAUDE documentation to describe gated versus forced orphan compaction behavior and entry points.

Tests:
- Extend MCP server end-to-end smoke tests to reflect updated tool counts and renamed/index tools.

Chores:
- Bump workspace and MCP server crate versions to reflect the behavior change.

</details>