### PR TITLE
fix(search): breadth-first context-budget allocation (broad queries collapsed to ~4 docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `search` context budget collapsed broad queries (mcp-server v1.0.518)
+
+The `search` tool's response contract (`retrieval/contract.rs`) spent its 12 000-char
+context budget **depth-first**: it emitted every passage of the first document before the
+next, so one large document (e.g. 10 × ~1000-char passages) consumed ~70 % of the budget and
+all remaining matched documents were dropped with empty passages. A broad query (`fékerőmérő`:
+602 matching documents, 194 from the shared engine) returned only **4**, and `limit` was
+effectively ignored. The fix allocates the budget **breadth-first** (Pass 1: one passage per
+document up to `limit`; Pass 2: fill the remainder with further passages), so `count` reflects
+matched documents up to `limit`, each with ≥1 representative passage. Budget-dropped documents
+are surfaced via a new `dropped_due_to_budget` field (P6). Pure response-shaping change — the
+shared `retrieve_and_fuse`/`build_doc_groups` engine and `db_hybrid_search` are unchanged.
+
 ### BREAKING — MCP tool naming canonicalization + index consolidation (mcp-server v1.0.509)
 
 Single canonical naming convention (`<resource>_<verb>`, noun-first, full words) plus

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.323"
+version = "0.3.324"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.517"
+version = "1.0.518"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mcp-server/src/tools/retrieval/contract.rs
+++ b/mcp-server/src/tools/retrieval/contract.rs
@@ -45,13 +45,31 @@ pub(crate) fn assemble(
     format: &str,
     debug: bool,
 ) -> Result<Value> {
-    let mut documents: Vec<Value> = Vec::with_capacity(groups.len());
     let mut used_chars: usize = 0;
     let mut trimmed = false;
-    // Groups that had chunks but yielded no usable passage text (body under a
+    // Groups whose chunks carried no body text under `text_field` (body under a
     // different field) — surfaced in the response (P6), never silently dropped.
     let mut dropped_empty: usize = 0;
+    // Groups that matched and HAD body text but did not fit the char budget — the
+    // count silently shrinking the result set is exactly the bug this fixes, so it
+    // is surfaced too (P6).
+    let mut dropped_due_to_budget: usize = 0;
 
+    // A staged document: doc-level fields + its ordered passage bodies. The char
+    // budget is spent in two passes — Pass 1 reserves ONE passage per document
+    // (breadth), Pass 2 fills the remainder with further passages (depth). This
+    // stops a single large document from monopolizing the budget and starving the
+    // rest (the depth-first allocation collapsed broad queries to a few docs).
+    struct Staged {
+        doc_id: String,
+        relevance: f64,
+        doc_fields: Map<String, Value>,
+        texts: Vec<String>,
+        emitted: usize,
+    }
+
+    // Extract doc-level fields + non-empty passage bodies per group.
+    let mut staged: Vec<Staged> = Vec::with_capacity(groups.len());
     for g in groups {
         // Doc-level fields: the lifted set (already free of engine keys — lift
         // never promotes doc_id/best_score/chunk_count/chunks or `_`-prefixed/
@@ -76,48 +94,81 @@ pub(crate) fn assemble(
             }
         }
 
-        // Passages: the text body of each chunk (no internals). Hard char budget;
-        // a passage that would exceed it is dropped and `trimmed` surfaced (P6) —
-        // EXCEPT at least one passage is always included in the whole response so a
-        // non-empty corpus never yields an empty result.
-        let mut passages: Vec<Value> = Vec::with_capacity(g.chunks.len());
-        for c in &g.chunks {
-            let text = c.get(text_field).and_then(|v| v.as_str()).unwrap_or("");
-            if text.is_empty() {
-                continue;
-            }
-            let nothing_yet = documents.is_empty() && passages.is_empty();
-            if !nothing_yet && used_chars + text.len() > DEFAULT_MAX_CONTEXT_CHARS {
-                trimmed = true;
-                break;
-            }
-            used_chars += text.len();
-            passages.push(json!({ "text": text }));
-        }
+        let texts: Vec<String> = g
+            .chunks
+            .iter()
+            .filter_map(|c| c.get(text_field).and_then(|v| v.as_str()))
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
 
-        if passages.is_empty() {
-            // Distinguish a budget trim (chunk had text but didn't fit) from an
-            // anomaly (chunks present but none carried body text under text_field).
-            let any_text = g.chunks.iter().any(|c| {
-                c.get(text_field)
-                    .and_then(|v| v.as_str())
-                    .map(|s| !s.is_empty())
-                    .unwrap_or(false)
-            });
-            if any_text {
-                trimmed = true;
-            } else if !g.chunks.is_empty() {
+        if texts.is_empty() {
+            // Chunks present but none carried body text under the resolved field.
+            if !g.chunks.is_empty() {
                 dropped_empty += 1;
             }
             continue;
         }
 
-        let mut doc = Map::new();
-        doc.insert("doc_id".to_string(), json!(g.doc_id));
-        for (k, v) in doc_fields {
-            doc.insert(k, v);
+        staged.push(Staged {
+            doc_id: g.doc_id.clone(),
+            relevance: g.best_score,
+            doc_fields,
+            texts,
+            emitted: 0,
+        });
+    }
+
+    // Pass 1 — breadth: include each document (relevance order) with its first
+    // passage if it fits. The very first document is always included so a
+    // non-empty corpus never yields an empty result, even if its single passage
+    // exceeds the budget.
+    let mut included: Vec<usize> = Vec::with_capacity(staged.len());
+    for (i, s) in staged.iter_mut().enumerate() {
+        let first_len = s.texts[0].len();
+        let nothing_yet = included.is_empty();
+        if !nothing_yet && used_chars + first_len > DEFAULT_MAX_CONTEXT_CHARS {
+            dropped_due_to_budget += 1;
+            continue;
         }
-        doc.insert("relevance".to_string(), json!(g.best_score));
+        used_chars += first_len;
+        s.emitted = 1;
+        included.push(i);
+    }
+
+    // Pass 2 — depth: spend the remaining budget on further passages of the
+    // already-included documents, in relevance order. A passage that doesn't fit
+    // is dropped (`trimmed`); we move on so a later, smaller passage can still fit.
+    for &i in &included {
+        let s = &mut staged[i];
+        while s.emitted < s.texts.len() {
+            let len = s.texts[s.emitted].len();
+            if used_chars + len > DEFAULT_MAX_CONTEXT_CHARS {
+                trimmed = true;
+                break;
+            }
+            used_chars += len;
+            s.emitted += 1;
+        }
+    }
+    if dropped_due_to_budget > 0 {
+        trimmed = true;
+    }
+
+    // Build the document objects (relevance order preserved).
+    let mut documents: Vec<Value> = Vec::with_capacity(included.len());
+    for &i in &included {
+        let s = &staged[i];
+        let mut doc = Map::new();
+        doc.insert("doc_id".to_string(), json!(s.doc_id));
+        for (k, v) in &s.doc_fields {
+            doc.insert(k.clone(), v.clone());
+        }
+        doc.insert("relevance".to_string(), json!(s.relevance));
+        let passages: Vec<Value> = s.texts[..s.emitted]
+            .iter()
+            .map(|t| json!({ "text": t }))
+            .collect();
         doc.insert("passages".to_string(), json!(passages));
         documents.push(Value::Object(doc));
     }
@@ -140,6 +191,14 @@ pub(crate) fn assemble(
         // Surfaced anomaly (P6): qualified documents whose body text was not under
         // the resolved text field — silently shrinking the result set is forbidden.
         out.insert("dropped_empty_documents".to_string(), json!(dropped_empty));
+    }
+    if dropped_due_to_budget > 0 {
+        // Surfaced (P6): matched documents dropped because the context budget was
+        // already full — the caller sees that more matches exist beyond `count`.
+        out.insert(
+            "dropped_due_to_budget".to_string(),
+            json!(dropped_due_to_budget),
+        );
     }
 
     if debug {
@@ -181,4 +240,155 @@ fn render_context_block(documents: &[Value]) -> String {
         }
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::hybrid::DocGroup;
+
+    const F: &str = "content_text";
+
+    /// A group with `passage_lens.len()` chunks, each carrying a `content_text`
+    /// body of the given length.
+    fn group(doc_id: &str, score: f64, passage_lens: &[usize]) -> DocGroup {
+        let chunks: Vec<Value> = passage_lens
+            .iter()
+            .enumerate()
+            .map(|(i, &n)| json!({"doc_id": doc_id, F: "x".repeat(n), "chunk_index": i}))
+            .collect();
+        DocGroup {
+            doc_id: doc_id.to_string(),
+            best_score: score,
+            lifted: Map::new(),
+            chunks,
+        }
+    }
+
+    fn docs(out: &Value) -> &Vec<Value> {
+        out.get("documents").unwrap().as_array().unwrap()
+    }
+
+    /// The breadth-first regression guard: a single large document must not starve
+    /// the rest. Depth-first allocation (the bug) would return only ~1 document
+    /// here; breadth-first keeps many. A mutation back to depth-first fails this.
+    #[test]
+    fn breadth_first_keeps_many_documents() {
+        // Doc A: 10 large passages (~1000 each) = 10_000 chars (depth-first eats
+        // the 12_000 budget on A alone). Then 60 small one-passage docs.
+        let mut groups = vec![group("A", 1.0, &[1000; 10])];
+        for i in 0..60 {
+            groups.push(group(&format!("d{i}"), 0.9 - i as f64 * 0.001, &[300]));
+        }
+        let out = assemble(&groups, 1000, None, F, "structured", false).unwrap();
+
+        let count = out.get("count").unwrap().as_u64().unwrap();
+        assert!(
+            count >= 30,
+            "breadth-first must keep many docs, got {count}"
+        );
+        // Every returned document carries at least its top passage.
+        for d in docs(&out) {
+            assert!(!d["passages"].as_array().unwrap().is_empty());
+        }
+        // The tail that did not fit is surfaced, not silently dropped (P6).
+        assert!(
+            out.get("dropped_due_to_budget")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                > 0,
+            "documents dropped for budget must be surfaced"
+        );
+    }
+
+    /// The total emitted passage text stays within the budget (except the
+    /// never-empty first-passage guarantee, not exercised here).
+    #[test]
+    fn total_passage_chars_within_budget() {
+        let mut groups = Vec::new();
+        for i in 0..100 {
+            groups.push(group(&format!("d{i}"), 1.0 - i as f64 * 0.001, &[500, 500]));
+        }
+        let out = assemble(&groups, 200, None, F, "structured", false).unwrap();
+        let total: usize = docs(&out)
+            .iter()
+            .flat_map(|d| d["passages"].as_array().unwrap())
+            .map(|p| p["text"].as_str().unwrap().len())
+            .sum();
+        assert!(
+            total <= DEFAULT_MAX_CONTEXT_CHARS,
+            "total {total} exceeds budget"
+        );
+    }
+
+    /// Never-empty: the first document is included even if its single passage
+    /// exceeds the whole budget.
+    #[test]
+    fn never_empty_for_oversized_first_doc() {
+        let groups = vec![group("big", 1.0, &[DEFAULT_MAX_CONTEXT_CHARS + 5000])];
+        let out = assemble(&groups, 1, None, F, "structured", false).unwrap();
+        assert_eq!(out.get("count").unwrap().as_u64().unwrap(), 1);
+        assert_eq!(docs(&out)[0]["passages"].as_array().unwrap().len(), 1);
+    }
+
+    /// A group whose chunks carry no body text under `text_field` is counted as
+    /// `dropped_empty_documents`, distinct from a budget drop.
+    #[test]
+    fn body_less_group_is_dropped_empty() {
+        let g = DocGroup {
+            doc_id: "x".into(),
+            best_score: 1.0,
+            lifted: Map::new(),
+            chunks: vec![json!({"doc_id": "x", "other": "y"})],
+        };
+        let out = assemble(&[g], 1, None, F, "structured", false).unwrap();
+        assert_eq!(out.get("count").unwrap().as_u64().unwrap(), 0);
+        assert_eq!(
+            out.get("dropped_empty_documents").and_then(|v| v.as_u64()),
+            Some(1)
+        );
+        assert!(out.get("dropped_due_to_budget").is_none());
+    }
+
+    /// Engine internals are stripped, doc-level fields lifted, verdict honest.
+    #[test]
+    fn strips_internals_and_marks_unknown() {
+        let g = DocGroup {
+            doc_id: "a".into(),
+            best_score: 0.5,
+            lifted: Map::new(),
+            chunks: vec![json!({
+                "doc_id": "a", F: "hello", "embedding": [0.1],
+                "chunk_index": 2, "_text_score": 3.0, "title": "T"
+            })],
+        };
+        let out = assemble(&[g], 5, None, F, "structured", false).unwrap();
+        assert_eq!(out.get("verdict").unwrap(), &json!("unknown"));
+        let obj = docs(&out)[0].as_object().unwrap();
+        assert!(!obj.contains_key("embedding"));
+        assert!(!obj.contains_key("chunk_index"));
+        assert!(!obj.keys().any(|k| k.starts_with('_')));
+        assert_eq!(obj.get("title").unwrap(), &json!("T"));
+        assert_eq!(obj["passages"][0]["text"], json!("hello"));
+    }
+
+    /// `context_block` format renders citation-marked text with the doc_id.
+    #[test]
+    fn context_block_contains_doc_id() {
+        let out = assemble(
+            &[group("alpha", 1.0, &[100])],
+            5,
+            None,
+            F,
+            "context_block",
+            false,
+        )
+        .unwrap();
+        assert!(out
+            .get("context")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .contains("alpha"));
+    }
 }


### PR DESCRIPTION
> Stacked on #86 (base = `fix/gated-auto-compact-vector-rebuild`). Merge #86 first; this PR's diff is contract.rs + version/changelog only.

## Probléma
A `search` tool széles lekérdezéseknél maroknyi dokumentumra csukott össze. Élesben a docs.mlite-on: „fékerőmérő" **602** dokumentumra illeszkedik (a közös motor `db_hybrid_search`-csel **194**), de a `search` csak **4-et** adott — a `limit=100` hatástalan volt.

## Root cause (`retrieval/contract.rs::assemble`)
A 12 000 karakteres kontextus-budget **mélységi** sorrendben fogyott: a `used_chars` dokumentumok közt kumulál, és egy dokumentum MINDEN passzusa kiíródik a következő előtt. Egy nagy dok (10 × ~1000 karakter = 8 473) megette a budget ~70%-át; az 5. doktól üres passzus → eldobva (`if passages.is_empty() { continue }`). A `count` a budgetet tükrözte, nem az illeszkedést.

## Megoldás — kétlépéses elosztás
- **Pass 1 (breadth):** minden dok (relevancia-sorrend, `limit`-ig) az ELSŐ passzusával, ha befér; never-empty garancia megmarad.
- **Pass 2 (depth):** a maradék budget a befért dokumentumok további passzusaival.
- Budget miatt kiesett dokumentumok új **`dropped_due_to_budget`** mezőben jelezve (P6), külön a `dropped_empty`-től (test nélküli csoportok).
- Változatlan: 12 000 budget, relevancia/sorrend, lifted mezők, `verdict="unknown"`, internals-stripping, formátumok.

Tisztán válasz-formázás: a `retrieve_and_fuse`/`build_doc_groups` motor és a `db_hybrid_search` **érintetlen** (az 194-et adott — így lokalizáltam a hibát a contract-ba).

## Tesztek
6 crate-internal contract-teszt (breadth regresszió-őr — mélységi dispatch megbukik a `count>=30`-on; budget betartva; never-empty; `dropped_empty` vs `dropped_due_to_budget`; internals strip; context_block). `retrieval_eval` + `mcp_tests` zöld; fmt + clippy tiszta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

A keresési kontextus‑keretet (budgetet) dokumentumok között szélességi bejárással osszuk el, hogy a tág lekérdezések sok találó dokumentumot adjanak vissza ahelyett, hogy néhány nagy dokumentumra omlanának össze.

Hibajavítások:
- Megakadályozzuk, hogy a keresési válasz eldobja a legtöbb találó dokumentumot, amikor néhány nagy dokumentum felemészti az egész kontextus‑keretet, mégpedig a szélességi bejárású szakasz‑ (passage) allokációra való áttéréssel és a keret miatt eldobott dokumentumok jelentésével.

Fejlesztések:
- Kitenni egy `dropped_due_to_budget` számlálót a keresési válasz szerződésében (contract), hogy megkülönböztessük a keret miatt megvágott eredményeket az üres törzsű dokumentumoktól, és javítsuk a csonkítási viselkedés megfigyelhetőségét (observability).

Build:
- A workspace és az mcp-server crate verzióinak emelése a javítás kiadásához.

Dokumentáció:
- A keresési kontextus‑keret allokációs javításának és az új `dropped_due_to_budget` mezőnek a dokumentálása a changelogban.

Tesztelés:
- Olyan szerződés‑szintű tesztek hozzáadása, amelyek védik a szélességi bejárású allokációs viselkedést, a keretnek való megfelelést, a „sosem üres” garanciákat, a helyes üres‑dokumentum‑kezelést, a belső részek eltávolítását (internals stripping) és a `context_block` formázását.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allocate search context budget breadth-first across documents so broad queries return many matching documents instead of collapsing to a few large ones.

Bug Fixes:
- Prevent the search response from dropping most matching documents when a few large documents consume the entire context budget by switching to breadth-first passage allocation and reporting budget-dropped documents.

Enhancements:
- Expose a `dropped_due_to_budget` counter in the search response contract to distinguish budget-trimmed results from empty-body documents and improve observability of truncation behavior.

Build:
- Bump workspace and mcp-server crate versions to release the fix.

Documentation:
- Document the search context-budget allocation fix and new `dropped_due_to_budget` field in the changelog.

Tests:
- Add contract-level tests that guard breadth-first allocation behavior, budget compliance, never-empty guarantees, correct empty-document handling, internals stripping, and context_block formatting.

</details>