### PR TITLE
perf: scalability tech-debt batch 1 (audit P1-7/P1-3/P1-6/P1-8/P2-9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.324"
+version = "0.3.325"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/mod.rs
+++ b/ironbase-core/src/collection_core/mod.rs
@@ -2059,7 +2059,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
     ///
     /// FIX #19: Refactored to use IndexManager.add_document_to_indexes()
     /// which properly handles compound indexes.
-    fn batch_add_to_indexes(&self, docs: &[Document]) -> Result<()> {
+    fn batch_add_to_indexes(&self, docs: &[&Document]) -> Result<()> {
         if docs.is_empty() {
             return Ok(());
         }
@@ -2067,7 +2067,7 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
         let mut indexes = self.indexes.write();
         let id_index_name = format!("{}_id", self.name);
 
-        for doc in docs {
+        for &doc in docs {
             // Add to _id index (handled separately due to DocumentId type)
             if let Some(id_index) = indexes.get_btree_index_mut(&id_index_name) {
                 let id_key = match &doc.id {

--- a/ironbase-core/src/collection_core/raw_operations.rs
+++ b/ironbase-core/src/collection_core/raw_operations.rs
@@ -670,9 +670,10 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
         // Update last_id with max of manual + auto-generated IDs
         meta.last_id = meta.last_id.max(start_id + auto_id_count);
 
-        // Update indexes in batch BEFORE writing to storage
-        let docs_for_index: Vec<Document> =
-            prepared_docs.iter().map(|(_, doc)| doc.clone()).collect();
+        // Update indexes in batch BEFORE writing to storage.
+        // Borrow the documents (no content clone) — batch_add_to_indexes only
+        // reads them, and prepared_docs is consumed by the storage write below.
+        let docs_for_index: Vec<&Document> = prepared_docs.iter().map(|(_, doc)| doc).collect();
         self.batch_add_to_indexes(&docs_for_index)?;
 
         // Write all documents to storage
@@ -1788,12 +1789,10 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
         }
 
         // Update indexes in batch FIRST (atomic operation, all-or-nothing)
-        // This is safer for partial storage failure - phantom entries are handled gracefully
-        let docs_for_index: Vec<Document> = prepared
-            .prepared_docs
-            .iter()
-            .map(|p| p.document.clone())
-            .collect();
+        // This is safer for partial storage failure - phantom entries are handled gracefully.
+        // Borrow the documents (no content clone) — batch_add_to_indexes only reads them.
+        let docs_for_index: Vec<&Document> =
+            prepared.prepared_docs.iter().map(|p| &p.document).collect();
         self.batch_add_to_indexes(&docs_for_index)?;
 
         // Write all documents to storage

--- a/ironbase-core/src/database/maintenance.rs
+++ b/ironbase-core/src/database/maintenance.rs
@@ -410,11 +410,18 @@ impl DatabaseCore<StorageEngine> {
                 // calls flush() which normalizes immediately.
                 storage.checkpoint_with_preserialized(metadata_bytes)
             }
-            _ => {
-                // Guard FAIL: mutations happened between Phase A and B, v2 migration
-                // needed, or no dirty metadata.
-                // Fall back to full checkpoint under lock (serialize + write + fsync).
-                // This is the same as the previous behavior — no worse than before.
+            None => {
+                // Metadata was clean at Phase A (no mutations since the last
+                // flush): the catalog is already durable, so a full checkpoint
+                // would only re-append it and grow the file on every idle
+                // checkpoint (audit P1-3). Clear the WAL only — in this state it
+                // holds no un-checkpointed ops, so it is a cheap no-op.
+                storage.checkpoint_wal_clear_only()
+            }
+            Some(_) => {
+                // Guard FAIL: mutations happened between Phase A and B (or a v2
+                // database needing migration). Fall back to a full checkpoint
+                // under lock (serialize + write + fsync) — same as before.
                 storage.checkpoint()
             }
         }

--- a/ironbase-core/src/database/maintenance.rs
+++ b/ironbase-core/src/database/maintenance.rs
@@ -316,6 +316,10 @@ impl DatabaseCore<StorageEngine> {
         {
             let mut storage = self.storage.write();
             storage.set_last_committed_tx_id(self.max_committed_tx_id.load(Ordering::SeqCst))?;
+            // Persist the compaction-size baseline so bloat_ratio survives the
+            // restart and the auto-compact does not rewrite the whole file again
+            // on next open (P1-7). Mirrors the tx_id watermark persistence above.
+            storage.set_last_compact_size(self.last_compact_size.load(Ordering::Relaxed))?;
             storage.mark_clean_shutdown()?;
         }
 

--- a/ironbase-core/src/database/mod.rs
+++ b/ironbase-core/src/database/mod.rs
@@ -413,6 +413,10 @@ impl DatabaseCore<StorageEngine> {
         // the watermark so post-rebuild flushes stamp a non-zero value
         // into the index metadata even on read-mostly DBs.
         let stored_watermark = storage.last_committed_tx_id();
+        // P1-7: seed the compaction-size baseline from the persisted Header so a
+        // reopened DB keeps an accurate bloat_ratio instead of 0 → +inf → a
+        // spurious full-file auto-compaction on every restart.
+        let stored_compact_size = storage.last_compact_size();
         let max_recovered = recovered_ops
             .iter()
             .map(|(tx_id, _)| *tx_id)
@@ -472,7 +476,7 @@ impl DatabaseCore<StorageEngine> {
             is_closed: Arc::new(AtomicBool::new(false)),
             collection_write_locks: Arc::new(RwLock::new(HashMap::new())),
             is_compacting: AtomicBool::new(false),
-            last_compact_size: AtomicU64::new(0),
+            last_compact_size: AtomicU64::new(stored_compact_size),
             recovered_operations: Arc::new(RwLock::new(recovered_ops_by_collection)),
         };
 

--- a/ironbase-core/src/index/manager.rs
+++ b/ironbase-core/src/index/manager.rs
@@ -1211,11 +1211,27 @@ impl IndexManager {
             return None;
         }
 
+        // Stream the current-format (v3) index directly off disk — roughly half
+        // the peak memory of read-all + from_bytes on a large index (audit P1-6).
+        // Legacy v1/v2 or any stream error falls through to the buffered path.
+        if let Some(index) = std::fs::File::open(&cache_path)
+            .ok()
+            .and_then(|f| HnswIndex::from_reader(std::io::BufReader::new(f)).ok())
+        {
+            crate::log_debug!(
+                "Loaded vector index '{}' from {} ({} vectors, streamed)",
+                index_name,
+                cache_path.display(),
+                index.len()
+            );
+            return Some(index);
+        }
+
         match std::fs::read(&cache_path) {
             Ok(bytes) => match HnswIndex::from_bytes(&bytes) {
                 Ok(index) => {
                     crate::log_debug!(
-                        "Loaded vector index '{}' from {} ({} vectors)",
+                        "Loaded vector index '{}' from {} ({} vectors, buffered)",
                         index_name,
                         cache_path.display(),
                         index.len()

--- a/ironbase-core/src/storage/metadata.rs
+++ b/ironbase-core/src/storage/metadata.rs
@@ -488,6 +488,7 @@ mod tests {
             data_end_offset: HEADER_SIZE,
             clean_shutdown: false,
             last_committed_tx_id: 0,
+            last_compact_size: 0,
         }
     }
 

--- a/ironbase-core/src/storage/mod.rs
+++ b/ironbase-core/src/storage/mod.rs
@@ -1072,6 +1072,26 @@ impl StorageEngine {
         })
     }
 
+    /// WAL-clear-only checkpoint: clears the WAL WITHOUT re-flushing metadata.
+    ///
+    /// Used by `checkpoint_wal_only` when metadata is clean (no mutations since
+    /// the last flush): the catalog is already durable, so calling `flush_metadata`
+    /// would only append the full catalog again and grow the file on every idle
+    /// checkpoint (audit P1-3). In that state the WAL holds no un-checkpointed
+    /// ops, so clearing it is a cheap no-op.
+    pub fn checkpoint_wal_clear_only(&mut self) -> Result<compaction::CheckpointStats> {
+        let wal_size_before = self.wal.file_size().unwrap_or(0);
+        self.wal.clear()?;
+        self.wal_ops_since_clear = 0;
+        let wal_size_after = self.wal.file_size().unwrap_or(0);
+        Ok(compaction::CheckpointStats {
+            wal_size_before,
+            wal_size_after,
+            wal_ops_cleared: 0,
+            indexes_flushed: 0,
+        })
+    }
+
     /// Checkpoint with a pre-serialized metadata buffer (lock-optimized path)
     ///
     /// Instead of serializing metadata under storage.write() lock, the caller

--- a/ironbase-core/src/storage/mod.rs
+++ b/ironbase-core/src/storage/mod.rs
@@ -182,13 +182,23 @@ pub struct Header {
     // the new value.
     #[serde(default)]
     pub last_committed_tx_id: u64,
+
+    // Persisted compaction-size baseline (version 6+)
+    // Data file size after the last successful compaction. `storage_wastage`
+    // uses it as `estimated_live_bytes` to compute `bloat_ratio`. Persisting it
+    // means a freshly reopened DB keeps an accurate baseline instead of seeing
+    // `bloat_ratio = +inf` (the 0-init case) and rewriting the entire file via
+    // auto-compaction on every restart. `#[serde(default)]` → legacy DBs read 0
+    // (first compaction recalibrates), mirroring `last_committed_tx_id` (R1).
+    #[serde(default)]
+    pub last_compact_size: u64,
 }
 
 impl Default for Header {
     fn default() -> Self {
         Header {
             magic: *b"MONGOLTE",
-            version: 5, // Version 5: tx_id watermark persistence (task #26 R1)
+            version: 6, // Version 6: last_compact_size persistence (P1-7)
             page_size: 4096,
             collection_count: 0,
             free_list_head: 0,
@@ -198,6 +208,7 @@ impl Default for Header {
             data_end_offset: HEADER_SIZE, // Documents start right after header
             clean_shutdown: false,        // Will be set to true on graceful shutdown
             last_committed_tx_id: 0,      // Persisted at clean shutdown, replaces 0-init on reopen
+            last_compact_size: 0,         // Persisted after compaction; 0 = never compacted
         }
     }
 }
@@ -1419,6 +1430,28 @@ impl StorageEngine {
         Ok(())
     }
 
+    /// Data file size after the last successful compaction (0 = never compacted),
+    /// persisted in the Header so `bloat_ratio` survives restarts.
+    pub fn last_compact_size(&self) -> u64 {
+        self.header.last_compact_size
+    }
+
+    /// Persist the post-compaction data file size baseline. Called after a
+    /// successful compaction and at graceful shutdown (next to
+    /// `set_last_committed_tx_id`). Marks metadata dirty so the new value is
+    /// written by the next checkpoint / clean-shutdown flush.
+    pub fn set_last_compact_size(&mut self, size: u64) -> Result<()> {
+        if self.header.last_compact_size == size {
+            return Ok(());
+        }
+        if self.header.version < 6 {
+            self.header.version = 6;
+        }
+        self.header.last_compact_size = size;
+        self.mark_metadata_dirty()?;
+        Ok(())
+    }
+
     /// Commit a transaction (9-step atomic operation) - internal implementation
     /// This is the core of ACD guarantee
     ///
@@ -2352,6 +2385,14 @@ impl Storage for StorageEngine {
         StorageEngine::set_last_committed_tx_id(self, tx_id)
     }
 
+    fn last_compact_size(&self) -> u64 {
+        StorageEngine::last_compact_size(self)
+    }
+
+    fn set_last_compact_size(&mut self, size: u64) -> Result<()> {
+        StorageEngine::set_last_compact_size(self, size)
+    }
+
     fn mark_clean_shutdown(&mut self) -> Result<()> {
         StorageEngine::mark_clean_shutdown(self)
     }
@@ -2422,7 +2463,7 @@ mod tests {
         let (_temp, storage) = setup_test_db();
 
         assert_eq!(storage.header.magic, *b"MONGOLTE");
-        assert_eq!(storage.header.version, 5); // Version 5: tx_id watermark persistence (task #26 R1)
+        assert_eq!(storage.header.version, 6); // Version 6: last_compact_size persistence (P1-7)
         assert_eq!(storage.header.page_size, 4096);
         assert_eq!(storage.header.collection_count, 0);
         assert_eq!(storage.collections.len(), 0);
@@ -2766,7 +2807,7 @@ mod tests {
         let header = Header::default();
 
         assert_eq!(header.magic, *b"MONGOLTE");
-        assert_eq!(header.version, 5); // Version 5: tx_id watermark persistence (task #26 R1)
+        assert_eq!(header.version, 6); // Version 6: last_compact_size persistence (P1-7)
         assert_eq!(header.page_size, 4096);
         assert_eq!(header.collection_count, 0);
         assert_eq!(header.free_list_head, 0);

--- a/ironbase-core/src/storage/mod.rs
+++ b/ironbase-core/src/storage/mod.rs
@@ -399,6 +399,17 @@ pub struct MetadataWALEntry {
     pub data_end_offset: u64,
 }
 
+/// Borrowing twin of `MetadataWALEntry` used only for serialization, so the WAL
+/// snapshot can be written WITHOUT deep-cloning the entire `collections` map
+/// (a multi-GB allocation under the write lock on a large catalog — audit P1-8).
+/// serde encodes `&HashMap` byte-identically to `HashMap`, so the WAL JSON — and
+/// crash recovery via `MetadataWALEntry` — is unchanged.
+#[derive(Serialize)]
+struct MetadataWALEntryRef<'a> {
+    collections: &'a HashMap<String, CollectionMeta>,
+    data_end_offset: u64,
+}
+
 // ============================================================================
 // HEADER WRITER - Safe, invariant-preserving header modifications
 // ============================================================================
@@ -944,12 +955,39 @@ impl StorageEngine {
     fn write_metadata_snapshot(&mut self) -> Result<()> {
         use crate::wal::{WALEntry, WALEntryType};
 
-        let metadata_entry = MetadataWALEntry {
-            collections: self.collections.clone(),
+        // Serialize from a borrow — NO full catalog clone (a 50M-doc catalog clone
+        // was a multi-GB allocation under the write lock). serde encodes the
+        // borrowing twin identically, so the WAL format / crash recovery is the same.
+        let metadata_ref = MetadataWALEntryRef {
+            collections: &self.collections,
             data_end_offset: self.header.data_end_offset,
         };
 
-        let entry_data = serde_json::to_vec(&metadata_entry)
+        // Estimate + try_reserve the buffer so a giant catalog fails with a typed
+        // OutOfMemory error instead of aborting the process (mirrors
+        // serialize_metadata's guard at metadata.rs).
+        let estimated_size: usize = 4 + self
+            .collections
+            .values()
+            .map(|meta| {
+                let catalog_size = meta.document_catalog.len() * 30;
+                let order_size = meta.document_order.len() * 10;
+                4 + catalog_size + order_size + 512
+            })
+            .sum::<usize>();
+        let mut entry_data: Vec<u8> = Vec::new();
+        entry_data.try_reserve(estimated_size).map_err(|_| {
+            IronBaseError::OutOfMemory(format!(
+                "Failed to allocate {}MB for metadata WAL snapshot ({} collections, {} total docs)",
+                estimated_size / (1024 * 1024),
+                self.collections.len(),
+                self.collections
+                    .values()
+                    .map(|m| m.document_catalog.len())
+                    .sum::<usize>()
+            ))
+        })?;
+        serde_json::to_writer(&mut entry_data, &metadata_ref)
             .map_err(|e| IronBaseError::Serialization(e.to_string()))?;
 
         let entry = WALEntry::new(
@@ -2476,6 +2514,29 @@ mod tests {
         let db_path = temp_dir.path().join("test.mlite");
         let storage = StorageEngine::open(&db_path).unwrap();
         (temp_dir, storage)
+    }
+
+    /// P1-8: the borrowing `MetadataWALEntryRef` used by `write_metadata_snapshot`
+    /// (to avoid deep-cloning the whole catalog) must serialize byte-identically
+    /// to the owned `MetadataWALEntry`, so the WAL format and crash recovery are
+    /// unchanged.
+    #[test]
+    fn metadata_snapshot_ref_serializes_identically() {
+        let (_t, mut storage) = setup_test_db();
+        storage.create_collection("c").unwrap();
+
+        let owned = MetadataWALEntry {
+            collections: storage.collections.clone(),
+            data_end_offset: storage.header.data_end_offset,
+        };
+        let by_ref = MetadataWALEntryRef {
+            collections: &storage.collections,
+            data_end_offset: storage.header.data_end_offset,
+        };
+        assert_eq!(
+            serde_json::to_vec(&owned).unwrap(),
+            serde_json::to_vec(&by_ref).unwrap()
+        );
     }
 
     #[test]

--- a/ironbase-core/src/storage/traits.rs
+++ b/ironbase-core/src/storage/traits.rs
@@ -170,6 +170,21 @@ pub trait Storage: Send + Sync {
         Ok(())
     }
 
+    /// Data file size after the previous compaction (0 = never compacted /
+    /// unknown). Used by `storage_wastage` to compute `bloat_ratio` across
+    /// restarts; without it the in-memory baseline resets to 0 on every
+    /// `open()` → `bloat_ratio = +inf` → a spurious full-file compaction on
+    /// every restart. Default no-op returns 0 (suitable for in-memory storage).
+    fn last_compact_size(&self) -> u64 {
+        0
+    }
+
+    /// Persist the data file size after a successful compaction.
+    /// Default no-op (suitable for in-memory storage that does not survive exit).
+    fn set_last_compact_size(&mut self, _size: u64) -> Result<()> {
+        Ok(())
+    }
+
     /// Mark the database as cleanly shutting down
     ///
     /// Called during graceful shutdown to enable fast restart.

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -634,11 +634,21 @@ impl HnswIndex {
         // IMPORTANT: iterate id_to_index (HashMap, unique keys) instead of nodes,
         // because nodes may contain duplicate IDs after remove+reinsert cycles
         // (orphan node + new active node with same ID).
-        let items: Vec<(String, Vec<f32>)> = self
-            .id_to_index
-            .iter()
-            .map(|(id, &idx)| (id.clone(), self.nodes[idx].vector.clone()))
-            .collect();
+        // try_reserve so a huge index fails with a typed OOM error instead of
+        // aborting during the rebuild clone (mirrors the insert-path guard).
+        let mut items: Vec<(String, Vec<f32>)> = Vec::new();
+        items.try_reserve(self.id_to_index.len()).map_err(|e| {
+            IronBaseError::OutOfMemory(format!(
+                "Failed to reserve {} entries for HNSW rebuild: {}",
+                self.id_to_index.len(),
+                e
+            ))
+        })?;
+        items.extend(
+            self.id_to_index
+                .iter()
+                .map(|(id, &idx)| (id.clone(), self.nodes[idx].vector.clone())),
+        );
 
         // Clear and reinsert
         self.nodes.clear();

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -728,6 +728,47 @@ impl HnswIndex {
         Ok(())
     }
 
+    /// Stream-deserialize a current-format (v3) index from a reader, e.g.
+    /// `BufReader<File>`. Decodes directly off disk via `bincode::deserialize_from`
+    /// instead of buffering the entire file into a `Vec` first (as `from_bytes`
+    /// does) — roughly halves the peak memory when loading a large index (the file
+    /// buffer + the graph both resident). (Audit P1-6.)
+    ///
+    /// Only the v3 framing is streamed; legacy (v1/v2) files return an error so
+    /// the caller falls back to the buffered `from_bytes` — those are old/small,
+    /// so the 2× spike is moot there.
+    pub fn from_reader(mut reader: impl std::io::Read) -> Result<Self> {
+        // v3 header: MAGIC (4) + version (4, LE) + watermark (8, LE) = 16 bytes.
+        let mut hdr = [0u8; 16];
+        reader.read_exact(&mut hdr).map_err(|e| {
+            IronBaseError::Io(std::io::Error::other(format!(
+                "Failed to read HNSW v3 header: {}",
+                e
+            )))
+        })?;
+        if &hdr[0..4] != Self::MAGIC_HEADER {
+            return Err(IronBaseError::Serialization(
+                "not a v3 HNSW stream (legacy/headerless) — fall back to from_bytes".to_string(),
+            ));
+        }
+        let version = u32::from_le_bytes([hdr[4], hdr[5], hdr[6], hdr[7]]);
+        if version != Self::SERIALIZATION_VERSION {
+            return Err(IronBaseError::Serialization(format!(
+                "HNSW stream version {} != current {} — fall back to from_bytes",
+                version,
+                Self::SERIALIZATION_VERSION
+            )));
+        }
+        let watermark = u64::from_le_bytes([
+            hdr[8], hdr[9], hdr[10], hdr[11], hdr[12], hdr[13], hdr[14], hdr[15],
+        ]);
+        let mut index: HnswIndex = bincode::deserialize_from(&mut reader).map_err(|e| {
+            IronBaseError::Serialization(format!("Failed to deserialize HNSW index: {}", e))
+        })?;
+        index.last_flushed_tx_id = watermark;
+        Ok(index)
+    }
+
     /// Deserialize the index from bytes
     ///
     /// Supports v1 (legacy, no header), v2 (header, no watermark), and v3
@@ -1674,6 +1715,30 @@ mod tests {
         assert_eq!(hnsw2.len(), 2);
         assert!(hnsw2.contains("doc1"));
         assert!(hnsw2.contains("doc2"));
+    }
+
+    /// P1-6: `from_reader` streams the v3 format off a reader (½ peak memory of
+    /// `from_bytes`) and must round-trip identically; legacy/headerless input
+    /// returns Err so the caller falls back to the buffered `from_bytes`.
+    #[test]
+    fn from_reader_streams_v3_roundtrip() {
+        let mut hnsw = HnswIndex::with_dim(3);
+        hnsw.insert("doc1", &[1.0, 0.0, 0.0]).unwrap();
+        hnsw.insert("doc2", &[0.0, 1.0, 0.0]).unwrap();
+
+        // v3 stream framing (same one persist_hnsw_to_file / save_to_writer emit).
+        let mut buf = Vec::new();
+        hnsw.save_to_writer(&mut buf).unwrap();
+
+        // Streamed load == buffered load.
+        let streamed = HnswIndex::from_reader(&buf[..]).unwrap();
+        assert_eq!(streamed.len(), 2);
+        assert!(streamed.contains("doc1"));
+        assert!(streamed.contains("doc2"));
+        assert_eq!(streamed.len(), HnswIndex::from_bytes(&buf).unwrap().len());
+
+        // Headerless / legacy input → Err (caller uses from_bytes fallback).
+        assert!(HnswIndex::from_reader(&b"not-an-hnsw-stream-0123456789abcd"[..]).is_err());
     }
 
     #[test]

--- a/ironbase-core/tests/compaction_tests.rs
+++ b/ironbase-core/tests/compaction_tests.rs
@@ -258,3 +258,44 @@ fn test_compaction_no_sparse_hole_on_drop() {
         assert_eq!(docs.len(), 10, "Should have 10 documents after compact");
     }
 }
+
+/// P1-7: `last_compact_size` must persist across a graceful close+reopen so the
+/// reopened DB keeps an accurate `bloat_ratio`. Before the fix it reset to 0 →
+/// `bloat_ratio = +inf` → the auto-compact rewrote the whole file on every
+/// restart. This regression guard fails on the unfixed code (estimated_live=0,
+/// bloat_ratio=inf) and passes after the Header field is persisted.
+#[test]
+fn last_compact_size_persists_across_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("persist_compact.mlite");
+
+    {
+        let db = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+        for i in 0..50i64 {
+            let mut doc = HashMap::new();
+            doc.insert("v".to_string(), json!(i));
+            db.insert_one("c", doc).unwrap();
+        }
+        // Create reclaimable bloat, then compact (sets the in-memory baseline).
+        for i in 0..20i64 {
+            db.delete_one("c", &json!({ "v": i })).unwrap();
+        }
+        let stats = db.compact().unwrap();
+        assert!(stats.size_after > 0);
+        // Graceful close persists last_compact_size into the Header.
+        db.close().unwrap();
+    }
+
+    // Reopen: the baseline must come back from the Header, NOT reset to 0.
+    let db2 = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+    let w = db2.storage_wastage();
+    assert!(
+        w.estimated_live_bytes > 0,
+        "last_compact_size must persist across reopen (got 0 → bloat_ratio would be +inf)"
+    );
+    assert!(
+        w.bloat_ratio.is_finite(),
+        "bloat_ratio must be finite after reopen, got {}",
+        w.bloat_ratio
+    );
+}

--- a/ironbase-core/tests/compaction_tests.rs
+++ b/ironbase-core/tests/compaction_tests.rs
@@ -299,3 +299,36 @@ fn last_compact_size_persists_across_reopen() {
         w.bloat_ratio
     );
 }
+
+/// P1-3: idle checkpoints (no writes since the last flush) must NOT re-append the
+/// metadata catalog. Before the fix the clean path fell through to a full
+/// `storage.checkpoint()` whose `flush_metadata()` appends the catalog regardless
+/// of dirtiness, so an idle DB grew on every 60s checkpoint (multi-GB/day at
+/// 100GB). This guard fails on the unfixed code (file grows) and passes after the
+/// clean path is routed to WAL-clear-only.
+#[test]
+fn idle_checkpoint_does_not_grow_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("idle_ckpt.mlite");
+    let db = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+    for i in 0..30i64 {
+        let mut doc = HashMap::new();
+        doc.insert("v".to_string(), json!(i));
+        db.insert_one("c", doc).unwrap();
+    }
+    // First checkpoint flushes the (dirty) metadata to disk.
+    db.checkpoint_wal_only().unwrap();
+    let size1 = std::fs::metadata(&db_path).unwrap().len();
+
+    // No writes since → metadata is clean → further checkpoints must be no-ops
+    // for the data file (only WAL is touched), so the file must NOT grow.
+    for _ in 0..5 {
+        db.checkpoint_wal_only().unwrap();
+    }
+    let size2 = std::fs::metadata(&db_path).unwrap().len();
+    assert_eq!(
+        size2, size1,
+        "idle checkpoints must not re-append metadata (file grew {} → {})",
+        size1, size2
+    );
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.518"
+version = "1.0.519"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
**Scalability audit P1-7 (Theme E)** — első implementált elem a 100GB+ tech-adósság roadmap-ből.

## Probléma
`last_compact_size` minden `open()`-kor `AtomicU64::new(0)`, sosem perzisztált → `storage_wastage()` `bloat_ratio = +inf`-et számol az első in-session compactig. Az auto-compact (default on) emiatt **minden restartkor a teljes adatfájlt újraírja** ~5 perccel indulás után. 100GB-on ez több-GB read+write, ami egy szűkös host page cache-ét swap-thrash-be viszi (a ma diagnosztizált prod startup-szaturáció). A visszavont `dead_writes==0` gate rossz fix volt: a prodon egy `dead_writes=0` compact is jogosan szabadított fel 1.39GB felhalmozott metaadatot → a dead_writes megbízhatatlan jel.

## Megoldás (a `last_committed_tx_id` / task #26 R1 mintát tükrözi)
- `Header` + `#[serde(default)] last_compact_size: u64` (v6); legacy fájl 0-t olvas (első compact rekalibrál) — backward-safe.
- Storage trait `last_compact_size()` / `set_last_compact_size()` default no-op (MemoryStorage); StorageEngine a Header ellen felülírja.
- `close()` perzisztálja a baseline-t (a tx_id watermark mellett).
- `open_with_durability()` a perzisztált Header-ből seedeli az `AtomicU64`-et.

Graceful restart után pontos a bloat_ratio → az auto-compact csak valós bloatnál fut.

## Tesztek
`last_compact_size_persists_across_reopen` — **mutáció-bizonyítottan nem-vacuous** (az `open()` read 0-ra állítása megbuktatja: „bloat_ratio would be +inf"). Teljes ironbase-core suite zöld; fmt + clippy tiszta; Header version assertek 5→6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

A tárhelytömörítés kiindulási értékének (compaction baseline) tartós tárolása a fejlécben, hogy a töredezettség-alapú automatikus tömörítés újraindítások után is helyesen működjön, és elkerüljük a felesleges teljes fájl újraírásokat.

New Features:
- A `last_compact_size` lemezre írása a Headerben, és elérhetővé tétele a `Storage` traiten és a `StorageEngine`-en keresztül, hogy a tömörítés kiindulási értéke újraindítások között is követhető legyen.

Bug Fixes:
- Az ismétlődő, minden újraindítás után lefutó teljes fájlos automatikus tömörítés javítása azzal, hogy a `bloat_ratio` a tartósan tárolt `last_compact_size` alapján inicializálódik, ahelyett hogy nullára lenne visszaállítva.

Enhancements:
- A fejléc verziójának 6-ra emelése az új, tartósan tárolt tömörítési kiindulási mező figyelembevételéhez.
- A `last_compact_size` tartós tárolása a szabályos leállítás során a tranzakciós watermark mellett, hogy a metaadatok újranyitás után is konzisztensen maradjanak.
- A `DatabaseCore` memória-beli `last_compact_size` értékének inicializálása a tárolt értékről megnyitáskor, hogy a `storage_wastage` statisztikák pontosak maradjanak.

Build:
- A workspace és az mcp server crate verzióinak emelése a tárhely-metaadat változásának tükrözésére.

Tests:
- Regressziós teszt hozzáadása, amely biztosítja, hogy a `last_compact_size` megmarad a szabályos lezárás és újranyitás között, és a `bloat_ratio` véges marad.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist the storage compaction baseline in the header so bloat-based auto-compaction behaves correctly across restarts and avoid redundant full-file rewrites.

New Features:
- Store last_compact_size in the on-disk Header and expose it via the Storage trait and StorageEngine to track compaction baseline across restarts.

Bug Fixes:
- Fix repeated full-file auto-compaction after every restart by seeding bloat_ratio from the persisted last_compact_size instead of resetting it to zero.

Enhancements:
- Bump header version to 6 to account for the new persisted compaction baseline field.
- Persist last_compact_size during graceful shutdown alongside the transaction watermark to keep metadata consistent across reopen.
- Initialize DatabaseCore's in-memory last_compact_size from the stored value on open to maintain accurate storage_wastage statistics.

Build:
- Bump workspace and mcp server crate versions to reflect the storage metadata change.

Tests:
- Add a regression test ensuring last_compact_size persists across graceful close and reopen and keeps bloat_ratio finite.

</details>