### PR TITLE
fix(durability): checkpoint/compact regressions from PR #89 (v1.0.520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — checkpoint/compact durability regressions from PR #89 (mcp-server v1.0.520, core v0.3.326)
+
+Three correctness regressions introduced by the scalability batch-1 split (PR #89, v1.0.519),
+fixed before deploy. All in the storage durability path (`ironbase-core`).
+
+- **Data loss (HIGH) — concurrent write lost across `checkpoint_wal_only`.** The two-phase
+  checkpoint serializes metadata under `storage.read()` (Phase A), releases it, then clears the
+  WAL under `storage.write()` (Phase B). When Phase A saw clean metadata it returned `None`; the
+  P1-3 split then made the Phase-B `None` arm clear the WAL unconditionally. An insert committing
+  in the gap between the two phases dirties the in-memory catalog and writes its only durable
+  record to the WAL — clearing it without flushing stranded that committed document on a crash
+  before the next checkpoint. Fix: the `None` arm now re-checks `is_metadata_dirty()` under the
+  Phase-B write lock and runs a full `checkpoint()` (flush-then-clear) when dirty, restoring the
+  pre-PR-89 `_ => checkpoint()` safety. (`database/maintenance.rs`)
+- **`checkpoint_wal_clear_only` did not reset `metadata_snapshot_pending`.** Clearing the WAL
+  discards the metadata snapshot it held, so the next `ensure_metadata_snapshot()` must write a
+  fresh one; leaving the flag set made it early-return, yielding an empty WAL with no recovery
+  base. Now reset after `wal.clear()`, matching every sibling WAL-clearer. (`storage/mod.rs`)
+- **`last_compact_size` reached the Header only at `close()`.** The Drop/crash path persisted the
+  tx_id watermark but not the compaction-size baseline, so a process that compacted then dropped
+  (or crashed) without an explicit `close()` lost it → `bloat_ratio = +inf` → the auto-compact
+  rewrote the whole file on the next start (P1-7). Now persisted into the Header at compact time
+  (under the storage write lock, in both the blocking and non-blocking compact paths), which marks
+  metadata dirty so Drop's `flush()` and the next checkpoint both write it. (`database/maintenance.rs`)
+
 ### Fixed — `search` context budget collapsed broad queries (mcp-server v1.0.518)
 
 The `search` tool's response contract (`retrieval/contract.rs`) spent its 12 000-char

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.325"
+version = "0.3.326"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/database/maintenance.rs
+++ b/ironbase-core/src/database/maintenance.rs
@@ -144,6 +144,13 @@ impl DatabaseCore<StorageEngine> {
         let stats = storage.compact()?;
         // Calibrate last_compact_size for bloat_ratio calculations
         self.set_last_compact_size(stats.size_after);
+        // Persist the baseline into the Header while the write lock is held so
+        // it survives a crash or Drop before the next close() (PR #89 follow-up,
+        // finding C+D). set_last_compact_size marks metadata dirty → the next
+        // checkpoint and Drop's flush() both write the updated Header. Without
+        // this the baseline only reached the Header at close(), so the auto-
+        // compact rewrote the whole file again on the next start (P1-7).
+        storage.set_last_compact_size(stats.size_after)?;
         Ok(stats)
     }
 
@@ -235,7 +242,14 @@ impl DatabaseCore<StorageEngine> {
 
         // Phase C: brief storage.write() — catch-up + finalize
         let mut storage = self.storage.write();
-        storage.compact_finalize_with_catchup(scan_result, &snapshot_collections)
+        let stats = storage.compact_finalize_with_catchup(scan_result, &snapshot_collections)?;
+        // Persist the baseline into the Header while this write lock is still
+        // held — the outer compact_nonblocking() sets only the in-memory atomic
+        // and runs after the lock is released (PR #89 follow-up, finding C+D).
+        // Marks metadata dirty → next checkpoint / Drop's flush() writes it,
+        // so the baseline survives a crash before close() (P1-7).
+        storage.set_last_compact_size(stats.size_after)?;
+        Ok(stats)
     }
 
     /// Checkpoint - flush indexes and clear WAL (MongoDB-style)
@@ -411,12 +425,27 @@ impl DatabaseCore<StorageEngine> {
                 storage.checkpoint_with_preserialized(metadata_bytes)
             }
             None => {
-                // Metadata was clean at Phase A (no mutations since the last
-                // flush): the catalog is already durable, so a full checkpoint
-                // would only re-append it and grow the file on every idle
-                // checkpoint (audit P1-3). Clear the WAL only — in this state it
-                // holds no un-checkpointed ops, so it is a cheap no-op.
-                storage.checkpoint_wal_clear_only()
+                // Metadata was clean at Phase A, but Phase A released
+                // storage.read() before Phase B acquired storage.write(). A
+                // concurrent insert in that gap commits its txn to the WAL and
+                // dirties the in-memory catalog WITHOUT flushing it. Re-check
+                // dirtiness under the Phase-B write lock: clearing the WAL while
+                // metadata is dirty would erase that insert's only durable
+                // record while the catalog is never flushed → committed doc lost
+                // on restart (PR #89 follow-up, finding A).
+                if storage.is_metadata_dirty() {
+                    // Dirtied between phases → full checkpoint flushes the
+                    // catalog to the main file BEFORE clearing the WAL.
+                    storage.checkpoint()
+                } else {
+                    // Truly clean (no mutations since the last flush): the
+                    // catalog is already durable, so a full checkpoint would
+                    // only re-append it and grow the file on every idle
+                    // checkpoint (audit P1-3). Clear the WAL only — in this
+                    // state it holds no un-checkpointed ops, so it is a cheap
+                    // no-op.
+                    storage.checkpoint_wal_clear_only()
+                }
             }
             Some(_) => {
                 // Guard FAIL: mutations happened between Phase A and B (or a v2

--- a/ironbase-core/src/storage/mod.rs
+++ b/ironbase-core/src/storage/mod.rs
@@ -1120,6 +1120,13 @@ impl StorageEngine {
     pub fn checkpoint_wal_clear_only(&mut self) -> Result<compaction::CheckpointStats> {
         let wal_size_before = self.wal.file_size().unwrap_or(0);
         self.wal.clear()?;
+        // The cleared WAL no longer holds the metadata snapshot, so the next
+        // ensure_metadata_snapshot() must write a fresh one into the now-empty
+        // WAL. Leaving this true would make ensure_metadata_snapshot() early-
+        // return → an empty WAL with no recovery base (PR #89 follow-up,
+        // finding B). Matches every sibling WAL-clearer (flush / checkpoint /
+        // checkpoint_with_preserialized).
+        self.metadata_snapshot_pending = false;
         self.wal_ops_since_clear = 0;
         let wal_size_after = self.wal.file_size().unwrap_or(0);
         Ok(compaction::CheckpointStats {
@@ -2536,6 +2543,126 @@ mod tests {
         assert_eq!(
             serde_json::to_vec(&owned).unwrap(),
             serde_json::to_vec(&by_ref).unwrap()
+        );
+    }
+
+    /// PR #89 follow-up, finding B: `checkpoint_wal_clear_only` clears the WAL,
+    /// which discards the metadata snapshot it held. It must therefore reset
+    /// `metadata_snapshot_pending` (like flush/checkpoint/checkpoint_with_preserialized);
+    /// leaving it true makes the next `ensure_metadata_snapshot()` early-return,
+    /// so the now-empty WAL gets no recovery base.
+    #[test]
+    fn checkpoint_wal_clear_only_resets_snapshot_pending() {
+        let (_t, mut storage) = setup_test_db();
+
+        // Dirty metadata → writes a snapshot into the WAL and arms the flag.
+        storage.mark_metadata_dirty().unwrap();
+        assert!(
+            storage.metadata_snapshot_pending,
+            "mark_metadata_dirty should arm metadata_snapshot_pending"
+        );
+
+        storage.checkpoint_wal_clear_only().unwrap();
+        assert!(
+            !storage.metadata_snapshot_pending,
+            "checkpoint_wal_clear_only must reset metadata_snapshot_pending after clearing the WAL"
+        );
+    }
+
+    /// PR #89 follow-up, finding A (RED, data loss) — crash-durability of the
+    /// choice the `checkpoint_wal_only` None arm makes, exercised through the
+    /// REAL production recovery path. A committed insert's durable record is its
+    /// WAL `Begin`/`Operation`/`Commit` entries (the document bytes are in the
+    /// data region, but the on-disk catalog does not yet reference them, and the
+    /// catalog is only made durable by a metadata flush). `DatabaseCore::open`
+    /// ALWAYS replays the WAL (`recover_from_wal`), so a committed insert
+    /// survives a crash via that replay — UNLESS the WAL was cleared first. The
+    /// buggy None arm cleared the WAL (`checkpoint_wal_clear_only`) without
+    /// flushing the catalog, so a crash before the next checkpoint left nothing
+    /// to replay and a stale on-disk catalog → the committed doc was lost. The
+    /// fix routes the dirty case to `checkpoint()`, which flushes the catalog
+    /// to the main file before the WAL is cleared.
+    ///
+    /// The insert uses the real `commit_transaction` path (real WAL txn entries)
+    /// and reopen goes through `DatabaseCore::open` (real `recover_from_wal`), so
+    /// this models the actual durability mechanism — not the MetadataSnapshot
+    /// entries, which recovery skips. A crash is simulated by releasing the file
+    /// lock and `mem::forget`-ing the engine so its Drop (which would flush +
+    /// checkpoint) never runs, leaving exactly the on-disk state a power loss
+    /// would. NOTE: this pins the durability CONTRACT the None arm chooses
+    /// between (`checkpoint` vs `checkpoint_wal_clear_only`); the None-arm wiring
+    /// itself is only reachable via the Phase-A→B race and is covered by review,
+    /// not driven here (a deterministic wiring test would need a test-only seam
+    /// in the checkpoint hot path).
+    #[test]
+    fn committed_write_survives_crash_via_checkpoint() {
+        use crate::transaction::{Operation, Transaction};
+
+        // Returns the document count visible after a simulated crash, where
+        // `finalize` is the None-arm action applied to the dirty engine.
+        fn run(tag: &str, finalize: impl Fn(&mut StorageEngine)) -> u64 {
+            let temp_dir = TempDir::new().unwrap();
+            let db_path = temp_dir.path().join(format!("crash_{tag}.mlite"));
+
+            {
+                let mut storage = StorageEngine::open(&db_path).unwrap();
+                storage.create_collection("c").unwrap();
+                storage.flush().unwrap(); // clean baseline: empty catalog on disk
+
+                // A real committed insert: Begin/Operation/Commit fsynced to the
+                // WAL, the in-memory catalog updated, metadata marked dirty — but
+                // NOT flushed to the main metadata section (per-commit flush was
+                // removed for perf, so the WAL is the only durable record yet).
+                let mut tx = Transaction::new(1);
+                tx.add_operation(Operation::Insert {
+                    collection: "c".to_string(),
+                    doc_id: crate::document::DocumentId::Int(1),
+                    doc: std::sync::Arc::new(serde_json::json!({"v": 1})),
+                })
+                .unwrap();
+                storage.commit_transaction(&mut tx).unwrap();
+                assert!(storage.is_metadata_dirty());
+
+                finalize(&mut storage); // the None-arm action under test
+
+                // Simulate a crash: free the lock, then skip Drop (no flush).
+                storage.release_lock().unwrap();
+                std::mem::forget(storage);
+            }
+
+            // Reopen via DatabaseCore so recover_from_wal() runs (production path).
+            let db = crate::DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+            db.count_documents("c", &serde_json::json!({})).unwrap() as u64
+        }
+
+        // Control: no checkpoint at all → the WAL still holds the txn, so the
+        // committed insert is recovered by recover_from_wal on reopen. Proves the
+        // recovery path is genuinely exercised and that any loss below is caused
+        // specifically by clearing the WAL, not by a broken reopen.
+        let recovered = run("no_clear", |_s| {});
+        assert_eq!(
+            recovered, 1,
+            "a committed insert must be recovered from the WAL on crash when the WAL is intact"
+        );
+
+        // Buggy choice: clear the WAL without flushing → the committed insert has
+        // no durable record left (empty WAL + stale catalog) → lost on crash.
+        let lost = run("clear_only", |s| {
+            s.checkpoint_wal_clear_only().unwrap();
+        });
+        assert_eq!(
+            lost, 0,
+            "checkpoint_wal_clear_only on dirty metadata strands the committed insert on crash — \
+             this is exactly why the None arm must not use it while metadata is dirty"
+        );
+
+        // Fixed choice: checkpoint() flushes the catalog first → the write survives.
+        let kept = run("checkpoint", |s| {
+            s.checkpoint().unwrap();
+        });
+        assert_eq!(
+            kept, 1,
+            "checkpoint() must flush the catalog so a committed insert survives a crash"
         );
     }
 

--- a/ironbase-core/tests/compaction_tests.rs
+++ b/ironbase-core/tests/compaction_tests.rs
@@ -332,3 +332,109 @@ fn idle_checkpoint_does_not_grow_file() {
         size1, size2
     );
 }
+
+/// PR #89 follow-up, finding A (companion to the storage-level crash test
+/// `committed_write_survives_crash_via_checkpoint`): exercise the two-phase
+/// `checkpoint_wal_only` (including the re-check the fix added to the Phase-B
+/// `None` arm) under heavy concurrency. The fix calls `storage.checkpoint()`
+/// while already holding `storage.write()`; this guards against a deadlock or
+/// panic on that path and confirms that under a *graceful* shutdown every
+/// committed insert is present. (It does NOT prove the crash-durability fix —
+/// a graceful close always flushes the in-memory catalog, healing any WAL
+/// clear; the crash case is covered deterministically in the storage test.)
+#[test]
+fn concurrent_inserts_and_wal_checkpoints_stay_consistent() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("ckpt_race.mlite");
+    // Enough concurrency to race Phase A/B against committing inserts and hit the
+    // None/Some arms repeatedly; kept modest so CI cost stays low (this is a
+    // deadlock/consistency smoke test, not the durability guard).
+    const N: i64 = 600;
+
+    {
+        let db = Arc::new(DatabaseCore::<StorageEngine>::open(&db_path).unwrap());
+
+        let writer = {
+            let db = Arc::clone(&db);
+            thread::spawn(move || {
+                for i in 0..N {
+                    let mut doc = HashMap::new();
+                    doc.insert("i".to_string(), json!(i));
+                    db.insert_one("c", doc).unwrap();
+                }
+            })
+        };
+
+        // Race the two-phase checkpoint against the writer, so Phase A
+        // frequently catches a clean state (→ None path, which now re-checks
+        // is_metadata_dirty and may call checkpoint() under the write lock).
+        // yield_now() between iterations avoids a CPU-burning busy-spin that
+        // would also starve the writer and inflate the test's wall-clock.
+        while !writer.is_finished() {
+            db.checkpoint_wal_only().unwrap();
+            std::thread::yield_now();
+        }
+        writer.join().unwrap();
+
+        db.checkpoint_wal_only().unwrap();
+        db.close().unwrap();
+    }
+
+    // Graceful shutdown → every committed insert must be present (no deadlock,
+    // no panic, no double-count).
+    let db2 = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+    let count = db2.count_documents("c", &json!({})).unwrap();
+    assert_eq!(
+        count as i64, N,
+        "concurrent inserts + checkpoints lost consistency (got {} of {})",
+        count, N
+    );
+}
+
+/// PR #89 follow-up, finding C+D: `last_compact_size` reached the Header only via
+/// `close()`. The Drop path persisted the tx_id watermark but NOT the compact-size
+/// baseline, so a process that compacted and then dropped (or crashed) without an
+/// explicit `close()` lost the baseline → `bloat_ratio = +inf` → the auto-compact
+/// rewrote the whole file on the next start (P1-7). The fix persists the baseline
+/// into the Header at compact time (under the storage write lock), which marks
+/// metadata dirty so Drop's `flush()` writes it. This guard compacts and then lets
+/// the DB *drop* (no `close()`), and requires the baseline to come back on reopen.
+#[test]
+fn last_compact_size_persists_across_drop_without_close() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("persist_compact_drop.mlite");
+
+    let size_after_compact: u64;
+    {
+        let db = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+        for i in 0..50i64 {
+            let mut doc = HashMap::new();
+            doc.insert("v".to_string(), json!(i));
+            db.insert_one("c", doc).unwrap();
+        }
+        for i in 0..20i64 {
+            db.delete_one("c", &json!({ "v": i })).unwrap();
+        }
+        let stats = db.compact().unwrap();
+        size_after_compact = stats.size_after;
+        assert!(size_after_compact > 0);
+        // NO close() — the DB drops here. Drop::flush() must persist the Header
+        // because compact() marked metadata dirty via storage.set_last_compact_size.
+    }
+
+    let db2 = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+    let w = db2.storage_wastage();
+    assert_eq!(
+        w.estimated_live_bytes, size_after_compact,
+        "last_compact_size must survive a Drop without close() (got {}, expected {})",
+        w.estimated_live_bytes, size_after_compact
+    );
+    assert!(
+        w.bloat_ratio.is_finite(),
+        "bloat_ratio must be finite after reopen, got {}",
+        w.bloat_ratio
+    );
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.519"
+version = "1.0.520"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Follow-up to **#89** (v1.0.519): three correctness regressions introduced by the scalability batch-1 split, in the storage durability path. Fix **before** v1.0.519 is deployed — finding A is data loss. Reviewed by a 5-lens adversarial pass; no production defects found.

## Fixes

### A — HIGH, data loss: concurrent write lost across `checkpoint_wal_only`
`checkpoint_wal_only` serializes metadata under `storage.read()` (Phase A), releases it, then clears the WAL under `storage.write()` (Phase B). The P1-3 split made the Phase-B `None` arm clear the WAL **unconditionally**. An insert committing in the Phase-A→B gap dirties the in-memory catalog and writes its only durable record to the WAL — clearing it without flushing strands that committed document on a crash before the next checkpoint.

**Fix:** the `None` arm re-checks `is_metadata_dirty()` under the Phase-B write lock and runs a full `checkpoint()` (flush-then-clear) when dirty, restoring the pre-#89 `_ => checkpoint()` safety. (`database/maintenance.rs`)

### B — MEDIUM: `checkpoint_wal_clear_only` didn't reset `metadata_snapshot_pending`
Clearing the WAL discards the metadata snapshot it held, so the next `ensure_metadata_snapshot()` must write a fresh one; leaving the flag set made it early-return → an empty WAL with no recovery base. Now reset after `wal.clear()`, matching every sibling WAL-clearer. (`storage/mod.rs`)

### C+D — MEDIUM: `last_compact_size` reached the Header only at `close()`
The Drop/crash path persisted the tx_id watermark but not the compaction-size baseline, so a process that compacted then dropped (or crashed) without an explicit `close()` lost it → `bloat_ratio = +inf` → the auto-compact rewrote the whole file on the next start (P1-7). Now persisted into the Header at compact time (under the storage write lock, both blocking and non-blocking paths), which marks metadata dirty so Drop's `flush()` and the next checkpoint write it. (`database/maintenance.rs`)

## Tests
- **B / C+D:** deterministic regression guards, each verified to **fail** on the reverted code (C+D: `got 0, expected 1999`).
- **A:** faithful crash test via the real `commit_transaction` (WAL Begin/Op/Commit) + `DatabaseCore::open` → `recover_from_wal` path, with a control case proving WAL replay works: `recovered==1`, `lost==0`, `kept==1`.
- Reframed the concurrent checkpoint test as a deadlock/consistency smoke test and cut its runtime ~70s → ~7s.

## Known residual (accepted)
Finding A's None-arm **routing** is not driven by a failing test (the inter-phase race isn't deterministically reachable; a real guard would need a `#[cfg(test)]` seam in the checkpoint hot path, for which the codebase has no precedent). The production fix is correct and reviewed; the durability *contract* it chooses between is pinned by the storage-level crash test. Documented inline.

## Verification
`cargo test -p ironbase-core` — lib 1088 · storage-module 54 · compaction 11 · recovery 18 · chaos_crash 25, all green. fmt + clippy clean. Versions: mcp-server 1.0.520, workspace 0.3.326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tárolási tartóssági visszaesések javítása a checkpointolásban és tömörítésben, valamint regressziós tesztek hozzáadása a következő core/server verziók kiadása előtt.

Hibajavítások:
- Biztosítani, hogy a `checkpoint_wal_only` újraellenőrizze a metaadatok „piszkos” állapotát az írási zárolás alatt, és teljes checkpointra váltson vissza, így a napló (WAL) törlésekor a párhuzamosan elkötelezett írások nem vesznek el.
- A `metadata_snapshot_pending` visszaállítása WAL-tisztítási műveletek után, hogy az üres WAL mindig friss metaadat-pillanatképet kapjon a helyreállításhoz.
- A `last_compact_size` lemezre írása a fejlécbe tömörítéskor (mind blokkoló, mind nem blokkoló tömörítés esetén), hogy a felfúvódás-számítások és az automatikus tömörítés helyesek maradjanak összeomlások vagy drop után is, explicit lezárás nélkül.

Build:
- A workspace és a server crate verzióinak emelése az új tartóssági javító kiadáshoz.

Dokumentáció:
- A checkpoint- és tömörítés-tartóssági javítások és regressziók dokumentálása a changelogban.

Tesztelés:
- Összeomlás utáni tartóssági teszt hozzáadása, amely lefedi a WAL-alapú helyreállítást és a checkpoint viselkedést az `checkpoint_wal_only` alatti elkötelezett írások esetén.
- Regressziós teszt hozzáadása, amely biztosítja, hogy a `checkpoint_wal_clear_only` törli a metadata snapshot pending flaget.
- Regressziós teszt hozzáadása, amely biztosítja, hogy a `last_compact_size` túlél egy dropot explicit lezárás nélkül is, így a felfúvódási arány véges marad.
- Párhuzamos beszúrások vs. WAL-checkpoint „smoke test” hozzáadása a konzisztencia és a holtpontmentes viselkedés ellenőrzésére a kétfázisú checkpoint alatt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix storage durability regressions in checkpointing and compaction, and add regression tests, before shipping the next core/server versions.

Bug Fixes:
- Ensure `checkpoint_wal_only` re-checks metadata dirtiness under the write lock and falls back to a full checkpoint so concurrent committed writes are not lost when clearing the WAL.
- Reset `metadata_snapshot_pending` after WAL clear operations so an empty WAL always receives a fresh metadata snapshot for recovery.
- Persist `last_compact_size` to the on-disk header at compaction time (for both blocking and non-blocking compaction) so bloat calculations and auto-compaction remain correct across crashes or drops without an explicit close.

Build:
- Bump workspace and server crate versions for the new durability fix release.

Documentation:
- Document the checkpoint and compaction durability fixes and regressions in the changelog.

Tests:
- Add crash-durability test covering WAL-based recovery vs checkpoint behavior for committed writes under `checkpoint_wal_only`.
- Add regression test ensuring `checkpoint_wal_clear_only` clears the metadata snapshot pending flag.
- Add regression test ensuring `last_compact_size` survives a drop without explicit close, keeping bloat ratio finite.
- Add a concurrent inserts vs WAL checkpoint smoke test to validate consistency and deadlock-free behavior under the two-phase checkpoint.

</details>