### PR TITLE
perf(storage): compaction snapshot via Arc copy-on-write — no deep clone under write lock (P0-1, v1.0.521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance — compaction snapshot no longer deep-clones the catalog under the write lock (mcp-server v1.0.521, core v0.3.327)
+
+Scalability audit item **P0-1** (100GB+ roadmap). `StorageEngine.collections` is now held
+behind an `Arc<HashMap<…>>` so the catalog can be snapshotted copy-on-write.
+
+- **`compact_prepare` (Phase A) took an O(N) deep clone of the entire collection catalog
+  under the global `storage.write()` lock.** On a large database the `document_catalog`
+  (`HashMap<DocumentId,u64>`) + `document_order` of every collection is tens of millions of
+  entries (multi-GB); cloning it while holding the write lock stalled **all** writes for
+  seconds at the start of every compaction. Now Phase A takes an O(1) `Arc::clone` snapshot and
+  releases the lock immediately. The frozen snapshot drives the lock-free Phase-B scan and the
+  Phase-C catch-up diff exactly as before. (`storage/compaction.rs`, `database/maintenance.rs`)
+- **Copy-on-write semantics.** All catalog mutations go through a new private
+  `StorageEngine::collections_mut()` (`Arc::make_mut`). While a compaction snapshot is alive,
+  the *first* concurrent write deep-clones the catalog once; every other write is O(1). An
+  idle or read-only compaction pays **zero** clones. Worst case is therefore one deferred clone
+  borne by a single writer, versus the previous unconditional clone under the lock. Reads are
+  unchanged (via `Deref`); the public API (`collections_ref`, `get_collection_meta_mut`, …) is
+  untouched. (`storage/mod.rs`, `storage/metadata.rs`)
+- Regression-guarded by `compact_prepare_snapshot_is_cow_not_deep_clone` (asserts `Arc::ptr_eq`
+  before the first mutation and divergence after) plus the full storage + compaction suites.
+
 ### Fixed — checkpoint/compact durability regressions from PR #89 (mcp-server v1.0.520, core v0.3.326)
 
 Three correctness regressions introduced by the scalability batch-1 split (PR #89, v1.0.519),

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.326"
+version = "0.3.327"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/database/maintenance.rs
+++ b/ironbase-core/src/database/maintenance.rs
@@ -231,7 +231,11 @@ impl DatabaseCore<StorageEngine> {
         let (snapshot, snapshot_collections) = {
             let mut storage = self.storage.write();
             let snapshot = storage.compact_prepare()?;
-            // Arc::clone is O(1) — no deep copy of collection metadata
+            // Genuinely O(1): `compact_prepare` now snapshots the catalog with an
+            // `Arc::clone` (copy-on-write), so the multi-GB catalog is NOT
+            // deep-cloned under the write lock (audit P0-1). A concurrent write
+            // during Phase B pays a single `Arc::make_mut` clone; this clone here
+            // just bumps the refcount.
             let snap_colls = std::sync::Arc::clone(&snapshot.snapshot_collections);
             (snapshot, snap_colls)
         }; // storage.write() RELEASED

--- a/ironbase-core/src/storage/compaction.rs
+++ b/ironbase-core/src/storage/compaction.rs
@@ -235,8 +235,11 @@ impl StorageEngine {
         let size_before = self.file.metadata()?.len();
         let snapshot_data_end_offset = self.header.data_end_offset;
 
-        // Snapshot collections (clone current state, Arc-wrapped for cheap sharing)
-        let snapshot_collections = Arc::new(self.collections.clone());
+        // Snapshot collections — O(1) Arc::clone (copy-on-write). The catalog is
+        // NOT deep-cloned here under the write lock (audit P0-1); the first
+        // concurrent write during Phase B pays a single `Arc::make_mut` clone,
+        // and an idle/read-only compaction pays nothing.
+        let snapshot_collections = Arc::clone(&self.collections);
 
         Ok(CompactionSnapshot {
             temp_file: new_file,
@@ -303,7 +306,7 @@ impl StorageEngine {
 
         let mut ops: Vec<CatchupOp> = Vec::new();
 
-        for (coll_name, current_meta) in &self.collections {
+        for (coll_name, current_meta) in self.collections.iter() {
             let snap_meta = snapshot_collections.get(coll_name);
 
             match snap_meta {
@@ -555,7 +558,7 @@ impl StorageEngine {
         // Update self
         self.file = file;
         self.header = header;
-        self.collections = collections;
+        self.collections = Arc::new(collections);
 
         Ok(())
     }

--- a/ironbase-core/src/storage/metadata.rs
+++ b/ironbase-core/src/storage/metadata.rs
@@ -262,7 +262,7 @@ impl StorageEngine {
     pub(crate) fn flush_metadata(&mut self) -> Result<()> {
         // 1. Update collection offsets (documents start right after header)
         let data_offset = super::HEADER_SIZE;
-        for meta in self.collections.values_mut() {
+        for meta in self.collections_mut().values_mut() {
             meta.data_offset = data_offset;
             meta.index_offset = data_offset;
         }

--- a/ironbase-core/src/storage/mod.rs
+++ b/ironbase-core/src/storage/mod.rs
@@ -540,7 +540,14 @@ pub fn write_compaction_header(
 pub struct StorageEngine {
     file: File,
     header: Header,
-    collections: HashMap<String, CollectionMeta>,
+    /// Collection catalog behind an `Arc` for copy-on-write snapshots.
+    ///
+    /// Compaction's Phase A (`compact_prepare`) takes an O(1) `Arc::clone`
+    /// snapshot instead of deep-cloning the whole catalog under the write lock
+    /// (audit P0-1). Mutations go through `collections_mut()` (`Arc::make_mut`),
+    /// which deep-clones once on the first write while a snapshot is alive and is
+    /// O(1) otherwise.
+    collections: std::sync::Arc<HashMap<String, CollectionMeta>>,
     file_path: String,
     wal: WriteAheadLog,
     metadata_dirty: bool,
@@ -753,7 +760,7 @@ impl StorageEngine {
         let mut storage = StorageEngine {
             file,
             header,
-            collections,
+            collections: std::sync::Arc::new(collections),
             file_path: path_str,
             wal,
             metadata_dirty: false,
@@ -763,7 +770,7 @@ impl StorageEngine {
             was_clean_shutdown: was_clean,
         };
 
-        let migrated = Self::rebuild_document_order_if_needed(&mut storage.collections);
+        let migrated = Self::rebuild_document_order_if_needed(storage.collections_mut());
         if migrated {
             storage.metadata_dirty = true;
         }
@@ -876,7 +883,7 @@ impl StorageEngine {
             auto_embedding_config: None,
         };
 
-        self.collections.insert(name.to_string(), meta);
+        self.collections_mut().insert(name.to_string(), meta);
         self.header.collection_count += 1;
 
         // Mark metadata dirty and flush to persist new collection
@@ -892,7 +899,7 @@ impl StorageEngine {
             return Err(IronBaseError::CollectionNotFound(name.to_string()));
         }
 
-        self.collections.remove(name);
+        self.collections_mut().remove(name);
         self.header.collection_count -= 1;
 
         self.mark_metadata_dirty()?;
@@ -921,13 +928,13 @@ impl StorageEngine {
         }
 
         let mut meta = self
-            .collections
+            .collections_mut()
             .remove(old_name)
             .expect("existence checked above");
         meta.apply_rename(old_name, new_name);
 
         // collection_count is unchanged — this is a move, not an add/remove.
-        self.collections.insert(new_name.to_string(), meta);
+        self.collections_mut().insert(new_name.to_string(), meta);
 
         self.mark_metadata_dirty()?;
         self.flush()?;
@@ -948,7 +955,7 @@ impl StorageEngine {
     /// Get collection metadata (mutable)
     /// Metadata changes are persisted only when flush() is called (typically on database close)
     pub fn get_collection_meta_mut(&mut self, name: &str) -> Option<&mut CollectionMeta> {
-        self.collections.get_mut(name)
+        self.collections_mut().get_mut(name)
     }
 
     /// Write a metadata snapshot to the WAL for crash recovery
@@ -1060,6 +1067,17 @@ impl StorageEngine {
     /// Reference to all collection metadata (for pre-serialization outside lock)
     pub(crate) fn collections_ref(&self) -> &HashMap<String, CollectionMeta> {
         &self.collections
+    }
+
+    /// Mutable access to the collection catalog (copy-on-write).
+    ///
+    /// While a compaction snapshot (Phase A `Arc::clone` in `compact_prepare`)
+    /// is still alive, the first mutation deep-clones the catalog exactly once;
+    /// every other call is O(1). Centralizing the `Arc::make_mut` here is what
+    /// keeps `compact_prepare` from deep-cloning the whole catalog under the
+    /// write lock (audit P0-1).
+    fn collections_mut(&mut self) -> &mut HashMap<String, CollectionMeta> {
+        std::sync::Arc::make_mut(&mut self.collections)
     }
 
     /// Checkpoint - flush metadata and clear WAL for durability
@@ -1238,7 +1256,7 @@ impl StorageEngine {
             );
 
             // Restore collections and header
-            self.collections = snapshot.collections;
+            self.collections = std::sync::Arc::new(snapshot.collections);
             // CRITICAL: Use HeaderWriter instead of direct assignment
             // set_recovery_offset sets data_end_offset; flush_metadata() below
             // will call set_after_metadata() which updates metadata_offset too.
@@ -1276,7 +1294,7 @@ impl StorageEngine {
         // If file is too small to have any documents, just initialize empty
         if file_len <= HEADER_SIZE {
             self.header = Header::default();
-            self.collections.clear();
+            self.collections_mut().clear();
             self.mark_metadata_dirty()?;
             self.flush_metadata()?;
             self.metadata_snapshot_pending = false;
@@ -1285,7 +1303,7 @@ impl StorageEngine {
         }
 
         // Clear existing collections - we're rebuilding from scratch
-        self.collections.clear();
+        self.collections_mut().clear();
 
         // Scan all documents from HEADER_SIZE to file end
         // We scan conservatively - stop when we hit invalid data (which is likely metadata)
@@ -1340,7 +1358,7 @@ impl StorageEngine {
                 if let Ok(doc_id) = serde_json::from_value::<DocumentId>(id_val.clone()) {
                     // Get or create collection meta
                     let meta = self
-                        .collections
+                        .collections_mut()
                         .entry(collection_name.clone())
                         .or_insert_with(|| CollectionMeta {
                             name: collection_name.clone(),
@@ -1391,7 +1409,7 @@ impl StorageEngine {
 
         // Update last_id for each collection
         for (collection_name, max_id) in max_ids_by_collection {
-            if let Some(meta) = self.collections.get_mut(&collection_name) {
+            if let Some(meta) = self.collections_mut().get_mut(&collection_name) {
                 meta.last_id = max_id;
             }
         }
@@ -1758,7 +1776,7 @@ impl StorageEngine {
         // Step 7: Apply metadata changes (skip if already applied)
         if !already_applied {
             for metadata_change in transaction.metadata_changes() {
-                if let Some(meta) = self.collections.get_mut(&metadata_change.collection) {
+                if let Some(meta) = self.collections_mut().get_mut(&metadata_change.collection) {
                     // SAFETY: Only positive i64 values are valid auto-increment IDs.
                     // Negative i64 cast to u64 wraps to u64::MAX, corrupting last_id.
                     if metadata_change.last_id > 0 {
@@ -2122,7 +2140,7 @@ impl StorageEngine {
         }
 
         // Clear existing catalogs and reset counts
-        for meta in self.collections.values_mut() {
+        for meta in self.collections_mut().values_mut() {
             meta.document_catalog.clear();
             meta.document_order.clear();
             meta.document_count = 0;
@@ -2170,7 +2188,7 @@ impl StorageEngine {
                         if let Ok(doc_id) = serde_json::from_value::<DocumentId>(id_val.clone()) {
                             // Get or create collection meta
                             let meta = self
-                                .collections
+                                .collections_mut()
                                 .entry(collection_name.to_string())
                                 .or_insert_with(|| CollectionMeta {
                                     name: collection_name.to_string(),
@@ -2226,7 +2244,7 @@ impl StorageEngine {
 
         // Update last_id for each collection
         for (collection_name, max_id) in max_ids_by_collection {
-            if let Some(meta) = self.collections.get_mut(&collection_name) {
+            if let Some(meta) = self.collections_mut().get_mut(&collection_name) {
                 if max_id > meta.last_id {
                     meta.last_id = max_id;
                 }
@@ -2237,7 +2255,7 @@ impl StorageEngine {
         // This is necessary because:
         // 1. Updates/replacements counted each version separately
         // 2. Tombstones removed from catalog but didn't decrement counts
-        for meta in self.collections.values_mut() {
+        for meta in self.collections_mut().values_mut() {
             meta.live_document_count = meta.document_catalog.len() as u64;
             meta.document_count = meta.document_catalog.len() as u64;
         }
@@ -2412,7 +2430,7 @@ impl Storage for StorageEngine {
     }
 
     fn adjust_live_count(&mut self, collection: &str, delta: i64) {
-        if let Some(meta) = self.collections.get_mut(collection) {
+        if let Some(meta) = self.collections_mut().get_mut(collection) {
             if delta >= 0 {
                 meta.live_document_count = meta.live_document_count.saturating_add(delta as u64);
             } else {
@@ -2533,7 +2551,7 @@ mod tests {
         storage.create_collection("c").unwrap();
 
         let owned = MetadataWALEntry {
-            collections: storage.collections.clone(),
+            collections: (*storage.collections).clone(),
             data_end_offset: storage.header.data_end_offset,
         };
         let by_ref = MetadataWALEntryRef {
@@ -2543,6 +2561,44 @@ mod tests {
         assert_eq!(
             serde_json::to_vec(&owned).unwrap(),
             serde_json::to_vec(&by_ref).unwrap()
+        );
+    }
+
+    /// P0-1: `compact_prepare` snapshots the catalog with an O(1) `Arc::clone`
+    /// (copy-on-write), NOT a deep clone under the write lock. The snapshot must
+    /// share the same allocation as the live catalog until the first mutation,
+    /// which then deep-clones exactly once — the live `Arc` diverges while the
+    /// snapshot stays frozen at its Phase-A contents.
+    #[test]
+    fn compact_prepare_snapshot_is_cow_not_deep_clone() {
+        let (_t, mut storage) = setup_test_db();
+        storage.create_collection("c1").unwrap();
+        storage.create_collection("c2").unwrap();
+
+        // Phase A snapshot must be the SAME Arc allocation (no deep clone under
+        // the write lock — the whole point of audit P0-1).
+        let snapshot = storage.compact_prepare().unwrap();
+        assert!(
+            std::sync::Arc::ptr_eq(&snapshot.snapshot_collections, &storage.collections),
+            "compact_prepare must Arc::clone the catalog (O(1)), not deep-clone it"
+        );
+
+        // A mutation while the snapshot is alive triggers copy-on-write: the live
+        // catalog diverges to a fresh allocation; the snapshot stays frozen.
+        storage.create_collection("c3").unwrap();
+        assert!(
+            !std::sync::Arc::ptr_eq(&snapshot.snapshot_collections, &storage.collections),
+            "first mutation while a snapshot is alive must copy-on-write"
+        );
+        assert_eq!(
+            snapshot.snapshot_collections.len(),
+            2,
+            "snapshot is frozen at its Phase-A contents"
+        );
+        assert_eq!(
+            storage.collections.len(),
+            3,
+            "live catalog sees the new write"
         );
     }
 
@@ -3243,7 +3299,7 @@ mod tests {
             let offset = storage.write_data(&doc_bytes).unwrap();
 
             // Update collection metadata
-            let meta = storage.collections.get_mut("users").unwrap();
+            let meta = storage.collections_mut().get_mut("users").unwrap();
             meta.document_count = 1;
             meta.document_catalog
                 .insert(crate::document::DocumentId::Int(1), offset);
@@ -3278,7 +3334,7 @@ mod tests {
                 let doc_bytes = serde_json::to_vec(&doc).unwrap();
                 let offset = storage.write_data(&doc_bytes).unwrap();
 
-                let meta = storage.collections.get_mut("products").unwrap();
+                let meta = storage.collections_mut().get_mut("products").unwrap();
                 meta.document_count = i as u64;
                 meta.document_catalog
                     .insert(crate::document::DocumentId::Int(i), offset);
@@ -3338,7 +3394,7 @@ mod tests {
                 let doc_bytes = serde_json::to_vec(&doc).unwrap();
                 let offset = storage.write_data(&doc_bytes).unwrap();
 
-                let meta = storage.collections.get_mut("items").unwrap();
+                let meta = storage.collections_mut().get_mut("items").unwrap();
                 meta.document_count = i as u64;
                 meta.document_catalog
                     .insert(crate::document::DocumentId::Int(i), offset);

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.520"
+version = "1.0.521"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Scalability audit P0-1 (100GB+ roadmap)

`StorageEngine.collections` is now held behind `Arc<HashMap<String, CollectionMeta>>` so compaction can snapshot the catalog **copy-on-write**.

### Problem
`compact_prepare` (Phase A) did `Arc::new(self.collections.clone())` — a **deep clone** of every collection's `document_catalog` (`HashMap<DocumentId,u64>`) + `document_order` (tens of millions of entries / multi-GB on a large DB) **while holding the global `storage.write()` lock**. This stalled *all* writes for seconds at the start of every compaction.

### Fix
- **Phase A** takes an O(1) `Arc::clone` and releases the lock immediately. The frozen snapshot drives the lock-free Phase-B scan and the Phase-C catch-up diff exactly as before.
- All catalog mutations now go through a private `StorageEngine::collections_mut()` (`Arc::make_mut`). While a snapshot is alive the **first** concurrent write deep-clones once; every other write is O(1). An idle / read-only compaction pays **zero** clones.
- Reads unchanged (via `Deref`); public API (`collections_ref`, `get_collection_meta_mut`, …) untouched. `MemoryStorage` (separate struct) untouched.

### Cost trade-off
Worst case is one *deferred* clone borne by a single writer during compaction, vs. the previous *unconditional* clone under the lock — strictly better, and zero clones in the common idle/read-heavy case.

### Verification
- New `compact_prepare_snapshot_is_cow_not_deep_clone`: asserts `Arc::ptr_eq` before the first mutation (same allocation → no deep clone) and divergence after (COW).
- Full `ironbase-core` suite (1090+), `compaction_tests`, clippy, fmt — green.
- 3-lens adversarial review (concurrency/data-loss, COW/perf, API/borrow), each finding adversarially verified → **0 defects**.

Versions: mcp-server `v1.0.521`, core `v0.3.327`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Átváltás az adattár-gyűjtemények katalógusának egy `Arc`-re épülő, copy-on-write adatszerkezetre, hogy a tömörítés (compaction) O(1) időben készíthessen snapshotot a metadatalról, anélkül hogy mély másolatot kellene készíteni a globális írási zárolás alatt.

New Features:
- Copy-on-write katalóguselérés bevezetése a `StorageEngine`-ben egy `Arc`-kel becsomagolt gyűjteménytérképen (`collections map`) keresztül, valamint egy központosított `collections_mut()` hozzáférőn keresztül.

Enhancements:
- A tömörítési és karbantartási kódútvonalak frissítése úgy, hogy `Arc`-klónozást használjanak a katalógus-snapshotokhoz, csökkentve a zárolás idejét és elkerülve a fölösleges mély másolatokat.
- A metadatakezelés és helyreállítási útvonalak igazítása az `Arc`-re épülő gyűjteménykatalógushoz anélkül, hogy a publikus tároló API megváltozna.

Build:
- Az `ironbase-core` és `mcp-server` crate verziók emelése a tömörítési teljesítményjavulás tükrözésére.

Documentation:
- A tömörítési teljesítményváltozás és a copy-on-write katalógus-szemantika dokumentálása a changelogban, frissített core és server verziókkal.

Tests:
- Regressziós teszt hozzáadása, amely biztosítja, hogy a `compact_prepare` O(1) időben végrehajtható `Arc`-klónt használjon a katalógus-snapshotokhoz, és csak az első módosításkor készítsen mély másolatot, amíg egy snapshot él.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch the storage collections catalog to an Arc-backed, copy-on-write data structure so compaction can snapshot metadata in O(1) without deep-cloning under the global write lock.

New Features:
- Introduce copy-on-write catalog access in StorageEngine via an Arc-wrapped collections map and a centralized collections_mut() accessor.

Enhancements:
- Update compaction and maintenance code paths to use Arc cloning for catalog snapshots, reducing lock hold time and avoiding unnecessary deep copies.
- Adjust metadata handling and recovery paths to work with the Arc-backed collections catalog without changing the public storage API.

Build:
- Bump ironbase-core and mcp-server crate versions to reflect the compaction performance improvement.

Documentation:
- Document the compaction performance change and copy-on-write catalog semantics in the changelog with updated core and server versions.

Tests:
- Add a regression test ensuring compact_prepare uses an O(1) Arc clone for catalog snapshots and only deep-clones on first mutation while a snapshot is alive.

</details>