### PR TITLE
fix(vector): RAM-derived max_vectors ceiling (P0-2, v1.0.522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — vector index ceiling is RAM-derived, no longer a fixed 100K cap that could silently lose data (mcp-server v1.0.522, core v0.3.328)
+
+Scalability audit item **P0-2** (100GB+ roadmap). The hard `DEFAULT_MAX_VECTORS = 100_000`
+ceiling is a latent data-loss flaw at scale: once a vector index left at the default cap grows
+past 100K vectors, the HNSW insert returns `OutOfMemory`, every auto-index caller logs-and-drops
+it while the document is already persisted, so those documents silently never appear in vector
+search. (A 2026-06-05 audit of the production `docs.mlite` found **no current loss** — its main
+`docs` index had been given an explicit `262144` cap and is fully indexed at 191207/262144 — but
+any index left at the default 100K sentinel hits this the moment it crosses 100K.) Root cause:
+the fixed cap, fixed here by making the **default** ceiling RAM-derived (an explicit non-default
+`max_vectors` like `docs`'s `262144` is still honoured verbatim).
+
+- **RAM-derived ceiling.** `DEFAULT_MAX_VECTORS` now doubles as an "auto" sentinel: an index
+  whose `max_vectors` is the default resolves at runtime to a memory-budgeted limit
+  (`calculate_max_vectors` / `max_vectors_for_budget`, 50% of available RAM ÷ per-vector cost),
+  mirroring `index::traits::calculate_lazy_threshold()`. The limit is **never persisted** — it
+  lives in a `#[serde(skip)] HnswIndex::effective_max_vectors: Option<usize>` resolved lazily on
+  first insert (`effective_ceiling()`), so existing on-disk indexes (and DBs moved between
+  machines) re-derive the ceiling for the current box with **no format change**. The value only
+  ever *raises* the legacy 100K floor, never lowers it, and is additionally floored at the
+  index's own active population so a large index reopened on a memory-constrained box never
+  rejects or `rebuild()`-truncates vectors it already holds. (`vector/config.rs`, `vector/hnsw.rs`)
+- **Rejection stays swallowed (logged), deliberately NOT propagated.** A code review showed that
+  propagating the `OutOfMemory` out of the auto-index callers corrupts atomicity: the durable
+  (`insert_one_persist`) and batch (`persist_buffered_operations`) paths write storage and commit
+  the WAL **before** the index step, so a propagated error leaves a persisted "ghost" document
+  the caller is told failed — or aborts an entire batch transaction, discarding unrelated ops.
+  The three auto-index sites therefore keep `log_error`/`warn`-and-continue, uniform with the
+  fulltext swallow and the lazy HNSW rebuild path. With the RAM-derived ceiling a genuine hit is
+  reachable only at true RAM exhaustion; there the document is still stored and findable, and the
+  drop is logged (a visible degradation at a real resource limit, not a hidden dummy fallback).
+- **Hardening:** the per-node `try_reserve` growth increment no longer clamps to the ceiling
+  (orphan-heavy indexes could clamp it to 0, leaving the subsequent `push` to reallocate
+  unguarded and abort the process); `effective_max_vectors` is an `Option` (not a `0` sentinel)
+  so an explicit `max_vectors == 0` is not mistaken for "unresolved"; and the per-vector cost is
+  a single shared `per_vector_bytes()` reused by `estimate_memory_bytes`.
+- Regression-guarded by `test_vector_overflow_is_swallowed_not_propagated` (atomicity),
+  `default_config_resolves_ram_derived_ceiling_lazily` + `explicit_small_cap_rejects_overflow`
+  (limit resolution), and `max_vectors_for_budget` / `resolve_max_vectors` arithmetic tests;
+  HNSW recall gates and the full ironbase-core suite stay green.
+
 ### Performance — compaction snapshot no longer deep-clones the catalog under the write lock (mcp-server v1.0.521, core v0.3.327)
 
 Scalability audit item **P0-1** (100GB+ roadmap). `StorageEngine.collections` is now held

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.327"
+version = "0.3.328"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/mod.rs
+++ b/ironbase-core/src/collection_core/mod.rs
@@ -2037,9 +2037,16 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 .filter_map(|v| v.as_f64().map(|f| f as f32))
                                 .collect();
                             if vector.len() == vec_dim {
+                                // Swallow (log-and-continue), NOT propagate — see
+                                // add_document_to_indexes. update_*_persist writes
+                                // storage AFTER batch_update_indexes returns, so a
+                                // propagated Err would diverge the index (NEW
+                                // state) from storage (OLD docs). P0-2's
+                                // RAM-derived ceiling makes a hit reachable only at
+                                // true RAM exhaustion.
                                 if let Err(e) = index.insert(&id_str, &vector) {
                                     log_error!(
-                                        "Failed to update vector index for field '{}': {:?}",
+                                        "Failed to update vector index for field '{}': {:?} (document stored; vector not indexed)",
                                         vec_field,
                                         e
                                     );

--- a/ironbase-core/src/collection_core/vector_ops.rs
+++ b/ironbase-core/src/collection_core/vector_ops.rs
@@ -169,7 +169,13 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 }
                             }
                         } else {
-                            // Insert into HNSW
+                            // Swallow (log-and-skip), uniform with the lazy
+                            // rebuild-from-documents twin (load_or_rebuild_hnsw)
+                            // and with add_document_to_indexes: a build hitting the
+                            // RAM-derived ceiling produces a (logged) partial index
+                            // rather than failing the whole build. P0-2's ceiling
+                            // makes a genuine hit reachable only at true RAM
+                            // exhaustion.
                             if let Err(e) = hnsw.insert(&id_str, &vector) {
                                 tracing::warn!(
                                     doc_id = %id_str,

--- a/ironbase-core/src/index/manager.rs
+++ b/ironbase-core/src/index/manager.rs
@@ -1585,10 +1585,21 @@ impl IndexManager {
                                 DocumentId::String(s) => s.clone(),
                                 DocumentId::ObjectId(oid) => oid.clone(),
                             };
-                            // Insert into HNSW - log error but don't fail (document already persisted)
+                            // Vector overflow is SWALLOWED (log-and-continue),
+                            // NOT propagated — and must stay that way. The durable
+                            // and batch insert paths write the document to storage
+                            // and commit the WAL BEFORE this index step
+                            // (insert_one_persist / persist_buffered_operations),
+                            // so a propagated Err would leave a persisted doc the
+                            // caller is told failed (ghost doc) or abort the whole
+                            // batch transaction. P0-2's RAM-derived ceiling makes a
+                            // genuine hit reachable only at true RAM exhaustion;
+                            // there the doc is still stored and findable and the
+                            // drop is logged. Uniform with the fulltext swallow ~50
+                            // lines above.
                             if let Err(e) = index.insert(&id_str, &vector) {
                                 log_error!(
-                                    "Failed to insert into vector index '{}': {:?}",
+                                    "Failed to insert into vector index '{}': {:?} (document stored; vector not indexed)",
                                     index_name,
                                     e
                                 );
@@ -1891,6 +1902,38 @@ mod tests {
             })
             .unwrap_err();
         assert!(err.to_string().contains("Index already exists"));
+    }
+
+    /// P0-2: vector overflow at the ceiling is SWALLOWED (logged), NOT propagated
+    /// out of `add_document_to_indexes`. The durable/batch insert paths write
+    /// storage + commit the WAL before this index step, so a propagated Err would
+    /// leave a persisted doc the caller is told failed (ghost doc / aborted
+    /// batch). The call must return Ok and simply not index the overflow vector.
+    /// Uses an explicit tiny `max_vectors` so the ceiling is hit deterministically
+    /// without depending on system RAM.
+    #[test]
+    fn test_vector_overflow_is_swallowed_not_propagated() {
+        let mut mgr = IndexManager::new();
+        let config = VectorIndexConfig::new(3)
+            .with_field("embedding")
+            .with_max_vectors(1); // explicit (non-sentinel) hard cap of 1
+        mgr.create_vector_index("emb_idx".to_string(), "embedding".to_string(), config, None)
+            .unwrap();
+
+        let doc1 = serde_json::json!({ "embedding": [0.1, 0.2, 0.3] });
+        let doc2 = serde_json::json!({ "embedding": [0.4, 0.5, 0.6] });
+
+        // First vector fits the cap.
+        mgr.add_document_to_indexes(&doc1, &DocumentId::Int(1), None)
+            .expect("first vector should index");
+
+        // Second vector exceeds the cap → must be SWALLOWED (Ok), so the durable
+        // insert path's atomicity (storage/WAL already committed) is preserved.
+        mgr.add_document_to_indexes(&doc2, &DocumentId::Int(2), None)
+            .expect("over-capacity vector must be swallowed, not propagated");
+
+        // The overflow vector is simply absent; the index holds only the first.
+        assert_eq!(mgr.get_vector_index("emb_idx").unwrap().len(), 1);
     }
 
     /// Test the reverse: btree index blocks vector/fuzzy/fulltext creation

--- a/ironbase-core/src/vector/config.rs
+++ b/ironbase-core/src/vector/config.rs
@@ -3,17 +3,68 @@
 //! This module defines the configuration structures for vector indexes,
 //! including HNSW parameters and distance metrics.
 
+use crate::aggregation::memory_info::get_available_memory_bytes;
 use crate::log_warn;
 use serde::{Deserialize, Serialize};
 
 /// Maximum supported vector dimension
 pub const MAX_VECTOR_DIM: usize = 4096;
 
-/// Default maximum vectors per index
+/// Default maximum vectors per index.
+///
+/// Doubles as the "auto" sentinel: a config whose `max_vectors` equals this
+/// value is resolved at runtime to a RAM-derived ceiling (see
+/// [`VectorIndexConfig::resolve_max_vectors`]). The fixed 100K cap used to
+/// silently drop every vector past 100K on machines with ample RAM — the
+/// 100GB-scale data-loss bug this constant's sentinel role fixes.
 pub const DEFAULT_MAX_VECTORS: usize = 100_000;
 
 /// Warning threshold for vector count
 pub const VECTOR_COUNT_WARNING_THRESHOLD: usize = 1_000_000;
+
+/// Divisor for the RAM-derived vector ceiling: budget `available_bytes / 2`
+/// (50% of currently-available RAM) as the *soft* ceiling for a single vector
+/// index. It is a soft ceiling only — every individual insert is still guarded
+/// by `try_reserve` in `HnswIndex::insert`, so over-committing across several
+/// indexes can never abort the process; it just fails the offending insert with
+/// a typed `OutOfMemory` error.
+const MAX_VECTORS_RAM_DIVISOR: u64 = 2;
+
+/// Resident memory cost of a single indexed vector: the f32 vector itself, the
+/// HNSW neighbour graph (~m*2 usize entries), plus ID-string/HashMap overhead.
+/// Single source of truth shared by [`VectorIndexConfig::estimate_memory_bytes`]
+/// and the RAM-derived ceiling ([`max_vectors_for_budget`]).
+fn per_vector_bytes(dim: usize, m: usize) -> usize {
+    dim * 4 + m * 2 * 8 + 64
+}
+
+/// Pure RAM-budget arithmetic for the vector-count ceiling, factored out of
+/// [`calculate_max_vectors`] so it is unit-testable without reading system
+/// memory. `available_bytes` is the live "available RAM" figure; `dim`/`m`
+/// give the per-vector cost via [`per_vector_bytes`].
+///
+/// The result is clamped to never drop below [`DEFAULT_MAX_VECTORS`]: the
+/// RAM-derived limit only ever *raises* the legacy 100K cap, never lowers it,
+/// so a small box keeps exactly the old behaviour (no regression).
+fn max_vectors_for_budget(available_bytes: u64, dim: usize, m: usize) -> usize {
+    let per_vector = per_vector_bytes(dim, m).max(1) as u64;
+    let budget = available_bytes / MAX_VECTORS_RAM_DIVISOR;
+    ((budget / per_vector) as usize).max(DEFAULT_MAX_VECTORS)
+}
+
+/// RAM-derived maximum vector count for an index of dimension `dim` and graph
+/// fan-out `m`, mirroring `index::traits::calculate_lazy_threshold()`.
+///
+/// Replaces the fixed [`DEFAULT_MAX_VECTORS`] cap, which silently dropped
+/// vectors past 100K on machines with ample RAM. Falls back to
+/// [`DEFAULT_MAX_VECTORS`] when system memory is undetectable (e.g. Windows),
+/// preserving the legacy behaviour there.
+pub fn calculate_max_vectors(dim: usize, m: usize) -> usize {
+    match get_available_memory_bytes() {
+        Some(bytes) => max_vectors_for_budget(bytes, dim, m),
+        None => DEFAULT_MAX_VECTORS,
+    }
+}
 
 /// Distance metric for vector similarity
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -136,6 +187,27 @@ impl VectorIndexConfig {
         self
     }
 
+    /// Resolve the effective vector-count ceiling for this config.
+    ///
+    /// A `max_vectors` left at the default ([`DEFAULT_MAX_VECTORS`]) is treated
+    /// as an "auto" sentinel and resolved to a RAM-derived ceiling via
+    /// [`calculate_max_vectors`]; any explicit non-default value is honoured
+    /// verbatim. The resolved value is never persisted (see
+    /// `HnswIndex::effective_max_vectors`), so a DB created on a large box and
+    /// reopened on a small one re-derives the ceiling for the current machine.
+    ///
+    /// Edge case: an *explicit* `max_vectors == DEFAULT_MAX_VECTORS` is
+    /// indistinguishable from the default and is therefore also auto-resolved
+    /// (yielding a value >= 100K). Callers wanting a hard 100K cap should pass a
+    /// nearby value (e.g. 100_001).
+    pub fn resolve_max_vectors(&self) -> usize {
+        if self.max_vectors == DEFAULT_MAX_VECTORS {
+            calculate_max_vectors(self.dim, self.m)
+        } else {
+            self.max_vectors
+        }
+    }
+
     /// Set the distance metric
     pub fn with_metric(mut self, metric: DistanceMetric) -> Self {
         self.metric = metric;
@@ -195,16 +267,11 @@ impl VectorIndexConfig {
         Ok(())
     }
 
-    /// Estimate memory usage in bytes for the given vector count
+    /// Estimate memory usage in bytes for the given vector count.
+    /// Per-vector cost comes from the shared [`per_vector_bytes`] helper (f32
+    /// vector + neighbour graph + ID/HashMap overhead).
     pub fn estimate_memory_bytes(&self, vector_count: usize) -> usize {
-        // Per vector: dim * 4 bytes (f32)
-        // Per node: ~M * 2 * 8 bytes for neighbor lists (average)
-        // Plus overhead for HashMap, etc.
-        let vector_bytes = vector_count * self.dim * 4;
-        let graph_bytes = vector_count * self.m * 2 * 8;
-        let overhead = vector_count * 64; // ID strings, etc.
-
-        vector_bytes + graph_bytes + overhead
+        vector_count * per_vector_bytes(self.dim, self.m)
     }
 }
 
@@ -367,6 +434,43 @@ mod tests {
         //                  ≈ 152 MB
         assert!(mem > 100_000_000); // > 100 MB
         assert!(mem < 200_000_000); // < 200 MB
+    }
+
+    #[test]
+    fn test_max_vectors_for_budget_scales_above_legacy_cap() {
+        // 8 GB available, BGE-M3 dim=1024, m=16: budget = 4 GB, per-vector ~4.4 KB
+        // => ~950K, comfortably above the legacy 100K cap.
+        let n = max_vectors_for_budget(8 * 1024 * 1024 * 1024, 1024, 16);
+        assert!(
+            n > DEFAULT_MAX_VECTORS,
+            "8GB box should raise the cap well above 100K, got {n}"
+        );
+        // Prod docs.mlite (~119K vectors) must fit on a modest 4 GB-available box.
+        let prod = max_vectors_for_budget(4 * 1024 * 1024 * 1024, 1024, 16);
+        assert!(
+            prod > 119_000,
+            "4GB box must cover prod's ~119K, got {prod}"
+        );
+    }
+
+    #[test]
+    fn test_max_vectors_for_budget_never_below_legacy_floor() {
+        // Tiny RAM must NOT lower the ceiling below the legacy 100K (no regression).
+        let n = max_vectors_for_budget(128 * 1024 * 1024, 1024, 16);
+        assert_eq!(n, DEFAULT_MAX_VECTORS, "tiny RAM clamps to the 100K floor");
+        // Pathological per-vector cost (huge dim) also stays at the floor.
+        let n2 = max_vectors_for_budget(256 * 1024 * 1024, 4096, 48);
+        assert_eq!(n2, DEFAULT_MAX_VECTORS);
+    }
+
+    #[test]
+    fn test_resolve_max_vectors_sentinel_vs_explicit() {
+        // Default (sentinel) => auto-resolved, always >= the legacy floor.
+        let auto = VectorIndexConfig::new(1024);
+        assert!(auto.resolve_max_vectors() >= DEFAULT_MAX_VECTORS);
+        // Explicit non-default => honoured verbatim.
+        let explicit = VectorIndexConfig::new(1024).with_max_vectors(42);
+        assert_eq!(explicit.resolve_max_vectors(), 42);
     }
 
     #[test]

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -199,6 +199,18 @@ pub struct HnswIndex {
     /// sequence, which is fine since levels are only assigned on new inserts.
     #[serde(skip)]
     rng_state: u64,
+    /// Effective (resolved) vector-count ceiling used by the insert cap check.
+    /// Runtime-only (`#[serde(skip)]`) so a machine-specific RAM-derived value is
+    /// never baked into the persisted `.hnsw` body — keeping the on-disk format
+    /// unchanged. `None` means "not yet resolved" and is lazily filled on first
+    /// insert via [`Self::effective_ceiling`]. `Option` (not a 0 sentinel) so a
+    /// legitimately resolved ceiling is never confused with "unresolved" (e.g.
+    /// an explicit `max_vectors == 0`). Because resolution happens at runtime,
+    /// an index loaded from disk (whose persisted `config.max_vectors` is the
+    /// 100K "auto" sentinel) picks up the RAM-derived ceiling on the current
+    /// machine without any format migration (P0-2).
+    #[serde(skip)]
+    effective_max_vectors: Option<usize>,
 }
 
 impl HnswIndex {
@@ -215,6 +227,10 @@ impl HnswIndex {
             dirty: false,
             last_flushed_tx_id: 0,
             rng_state: 0x2545_F491_4F6C_DD1D,
+            // None = unresolved; lazily filled on first insert via
+            // effective_ceiling() (also covers the bincode deserialize paths,
+            // where serde(skip) defaults this to None).
+            effective_max_vectors: None,
         }
     }
 
@@ -226,6 +242,27 @@ impl HnswIndex {
     /// Create with dimension and custom max vectors limit
     pub fn with_dim_and_limits(dim: usize, max_vectors: usize) -> Self {
         Self::new(VectorIndexConfig::new(dim).with_max_vectors(max_vectors))
+    }
+
+    /// Resolve (and cache) the effective vector-count ceiling for the insert cap.
+    ///
+    /// RAM-derived via `config.resolve_max_vectors()` (P0-2), but **never below
+    /// the index's current active population** (`self.len()`): the ceiling only
+    /// bounds NEW growth, so a large index reopened on a memory-constrained box
+    /// (where the RAM-derived value falls under its own size) never rejects or
+    /// truncates vectors it already legitimately holds — which would otherwise
+    /// make `rebuild()`'s re-insertion abort and break checkpoint/compaction.
+    /// Cached after first resolution; `#[serde(skip)]` means it is recomputed
+    /// per process, picking up the current machine's RAM.
+    fn effective_ceiling(&mut self) -> usize {
+        match self.effective_max_vectors {
+            Some(c) => c,
+            None => {
+                let c = self.config.resolve_max_vectors().max(self.len());
+                self.effective_max_vectors = Some(c);
+                c
+            }
+        }
     }
 
     /// Get the number of active (non-orphan) vectors in the index
@@ -349,22 +386,28 @@ impl HnswIndex {
             self.remove(id);
         }
 
-        // OOM Protection: Check vector count limit
-        // Use self.len() (= id_to_index.len()) to count only active vectors,
-        // not self.nodes.len() which includes orphans from lazy removal
-        if self.len() >= self.config.max_vectors {
+        // OOM Protection: Check vector count limit (RAM-derived, P0-2).
+        // Resolve the effective ceiling lazily on first insert so it applies to
+        // indexes loaded from disk too (whose persisted config carries the 100K
+        // "auto" sentinel). Use self.len() (= id_to_index.len()) to count only
+        // active vectors, not self.nodes.len() which includes orphans.
+        let ceiling = self.effective_ceiling();
+        if self.len() >= ceiling {
             return Err(IronBaseError::OutOfMemory(format!(
-                "Vector index full: {} vectors (max: {}). Remove documents or increase max_vectors.",
+                "Vector index full: {} vectors (max: {}, RAM-derived ceiling). \
+                 Free memory, lower the vector dimension, or split the collection.",
                 self.len(),
-                self.config.max_vectors
+                ceiling
             )));
         }
 
-        // OOM Protection: Ensure capacity for new node
+        // OOM Protection: Ensure capacity for new node. Reserve a positive,
+        // bounded growth increment (NOT clamped to the ceiling — orphan nodes can
+        // push nodes.len() to/past the active ceiling, and clamping to 0 there
+        // would make try_reserve a no-op and let the subsequent push reallocate
+        // UNGUARDED, defeating the typed-OOM guard).
         if self.nodes.len() == self.nodes.capacity() {
-            let additional = (self.nodes.len() / 4)
-                .max(100)
-                .min(self.config.max_vectors - self.nodes.len());
+            let additional = (self.nodes.len() / 4).max(100);
             self.nodes.try_reserve(additional).map_err(|_| {
                 IronBaseError::OutOfMemory(format!(
                     "Failed to allocate memory for {} additional HNSW nodes. \
@@ -649,6 +692,14 @@ impl HnswIndex {
                 .iter()
                 .map(|(id, &idx)| (id.clone(), self.nodes[idx].vector.clone())),
         );
+
+        // Floor the effective ceiling at the rebuild population BEFORE clearing:
+        // rebuild re-inserts EXISTING active vectors, which must never be
+        // rejected by the RAM-derived growth cap (#8). Resolve fresh (machine RAM
+        // may have changed since load) but never below items.len(), so a large
+        // index on a memory-constrained box still rebuilds intact rather than
+        // aborting mid-loop and breaking checkpoint/compaction.
+        self.effective_max_vectors = Some(self.config.resolve_max_vectors().max(items.len()));
 
         // Clear and reinsert
         self.nodes.clear();
@@ -1182,6 +1233,41 @@ mod tests {
         let mut cfg = VectorIndexConfig::new(2);
         cfg.metric = DistanceMetric::Euclidean;
         cfg
+    }
+
+    /// P0-2: a default-config index carries the 100K "auto" sentinel; the
+    /// effective ceiling stays unresolved (None) until the first insert, then
+    /// resolves to a RAM-derived value (>= the legacy floor). Proves the lazy
+    /// resolution fires on the common `new()` path so the fixed 100K cap no
+    /// longer bounds large-RAM machines.
+    #[test]
+    fn default_config_resolves_ram_derived_ceiling_lazily() {
+        let mut idx = HnswIndex::new(fast_cfg(8));
+        assert_eq!(
+            idx.effective_max_vectors, None,
+            "ceiling must be unresolved before the first insert"
+        );
+        idx.insert("a", &[0.0; 8]).unwrap();
+        let resolved = idx.effective_max_vectors.expect("resolved on first insert");
+        assert!(
+            resolved >= crate::vector::config::DEFAULT_MAX_VECTORS,
+            "resolved ceiling {resolved} must be >= the legacy 100K floor",
+        );
+    }
+
+    /// P0-2: an explicit (non-sentinel) `max_vectors` is honoured verbatim, and
+    /// hitting it returns a typed OutOfMemory error rather than silently
+    /// dropping the vector.
+    #[test]
+    fn explicit_small_cap_rejects_overflow() {
+        let mut cfg = fast_cfg(4);
+        cfg.max_vectors = 2; // explicit non-sentinel hard cap
+        let mut idx = HnswIndex::new(cfg);
+        idx.insert("a", &[0.1, 0.2, 0.3, 0.4]).unwrap();
+        idx.insert("b", &[0.5, 0.6, 0.7, 0.8]).unwrap();
+        let err = idx.insert("c", &[0.9, 1.0, 1.1, 1.2]).unwrap_err();
+        assert!(matches!(err, IronBaseError::OutOfMemory(_)), "got {err:?}");
+        assert_eq!(idx.len(), 2, "overflow vector must not be added");
     }
 
     #[test]

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.521"
+version = "1.0.522"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## P0-2 · RAM-derived `max_vectors` ceiling

Scalability audit **P0-2** (100GB+ roadmap, stacked on P0-1 #91). The fixed `DEFAULT_MAX_VECTORS = 100_000` cap is a **latent data-loss flaw**: once a vector index left at the default cap grows past 100K vectors, the HNSW insert returns `OutOfMemory` and the auto-index callers log-and-drop it while the doc is already persisted → those documents silently never appear in vector/hybrid search.

> **Prod audit (2026-06-05):** `docs.mlite` has **no current loss** — its main `docs` index uses an explicit `262144` cap and is fully indexed (191207/262144). But any index left at the default 100K sentinel hits this the moment it crosses 100K.

### Fix — RAM-derived ceiling (`vector/config.rs`, `vector/hnsw.rs`)
- `DEFAULT_MAX_VECTORS` doubles as an **"auto" sentinel**; `calculate_max_vectors` / `max_vectors_for_budget` (50% available RAM ÷ per-vector cost, floor 100K) mirror `index::traits::calculate_lazy_threshold()`. `per_vector_bytes()` is a single shared cost formula reused by `estimate_memory_bytes`. An explicit non-default `max_vectors` (e.g. `docs`'s 262144) is honoured verbatim.
- **Never persisted:** `HnswIndex::effective_max_vectors: Option<usize>` resolved lazily on first insert (`effective_ceiling`), so existing on-disk indexes re-derive the ceiling on load with **no format change**. Floored at the index's own population, so a large index reopened on a smaller box never rejects or `rebuild()`-truncates vectors it already holds.

### Rejection stays swallowed (logged), NOT propagated
A `/code-review` pass showed that propagating `OutOfMemory` out of the auto-index callers **breaks atomicity** — the durable (`insert_one_persist`) and batch (`persist_buffered_operations`) paths write storage + commit the WAL **before** the index step, so a propagated error leaves a persisted ghost doc the caller is told failed, or aborts a whole batch discarding unrelated ops. The 3 sites keep log-and-continue, uniform with the fulltext swallow and the lazy rebuild path. At the (now RAM-derived, rarely-hit) ceiling the doc is still stored and findable; the drop is logged.

### Hardening
- Per-node `try_reserve` growth no longer clamps to the ceiling (orphan-heavy clamp-to-0 left the push to reallocate unguarded → process abort).
- `effective_max_vectors` is `Option` (not a 0 sentinel) so explicit `max_vectors==0` is not mistaken for unresolved.

### Tests
swallow/atomicity repro + lazy resolution + budget arithmetic; full `ironbase-core` suite, compaction/recovery/`repro_hnsw_replace_recall` integration, clippy + fmt green; `mcp-server` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

A vektormutató kapacitását a rendelkezésre álló RAM-ból származtatjuk a fix, 100 ezres alapértelmezett korlát helyett, hogy elkerüljük a vektorok csendes eldobását nagy léptékben, miközben megőrizzük a lemezen tárolt adatok kompatibilitását és az index atomikussági szemantikáját.

Hibajavítások:
- Megakadályozzuk a csendes adatvesztést azzal, hogy a fix, 100 ezres alapértelmezett HNSW vektorkorlátot egy, a rendelkezésre álló memóriából és vektoronkénti költségből származtatott felső határral helyettesítjük.
- Biztosítjuk, hogy a kapacitás-felső határnál bekövetkező vektorbeszúrási hibák továbbra is naplózott, de lenyelt hibák maradjanak, így a dokumentumtárolás és a WAL commitok atomikusak maradnak.

Fejlesztések:
- Bevezetünk egy megosztott, vektoronkénti memóriaköltség-segédfüggvényt, amelyet mind a kapacitásszámításhoz, mind a memória-becsléshez használunk, és indexenként gyorsítótárazunk egy effektív, maximális vektorszám-korlátot, amelyet soha nem persistálunk, és soha nem lehet alacsonyabb az aktuális elemszámnál.
- Ellenállóbbá tesszük a HNSW csomópont-növekedési foglalást, hogy elkerüljük a nulla kapacitású foglalásokat, és a típusos OutOfMemory hibákra támaszkodunk az őrizetlen újrafoglalások helyett.

Build:
- A core crate verzióját 0.3.328-ra, az mcp server verzióját 1.0.522-re emeljük.

Dokumentáció:
- Dokumentáljuk az új, RAM-alapú vektorfelső határ működését és annak indoklását a kómegység-kommentekben és a changelogban.

Tesztelés:
- Teszteket adunk hozzá, amelyek lefedik a RAM-költségvetés-alapú maximális vektorszám-számításokat, a sentinel és az explicit `max_vectors` viselkedés közti különbséget, a lusta felső határ-kidolgozást, az explicit, kis kapacitású túlcsordulás kezelését, valamint azt, hogy a vektortúlcsordulások naplózásra kerülnek, de nem propagálódnak az index manager és collection útvonalakról.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Derive vector index capacity from available RAM instead of a fixed 100K default cap to avoid silent vector drops at scale while preserving on-disk compatibility and index atomicity semantics.

Bug Fixes:
- Prevent silent data loss by replacing the fixed 100K default HNSW vector cap with a RAM-derived ceiling based on available memory and per-vector cost.
- Ensure vector insert failures at the capacity ceiling remain logged-but-swallowed so document storage and WAL commits stay atomic.

Enhancements:
- Introduce a shared per-vector memory cost helper used for both capacity calculation and memory estimation, and cache an effective max-vectors ceiling per index that is never persisted and never below the current population.
- Harden HNSW node growth reservation to avoid zero-capacity reservations and rely on typed OutOfMemory errors instead of unguarded reallocations.

Build:
- Bump core crate version to 0.3.328 and mcp server version to 1.0.522.

Documentation:
- Document the new RAM-derived vector ceiling behavior and its rationale in code comments and the changelog.

Tests:
- Add tests covering RAM-budget-based max vector calculations, sentinel vs explicit max_vectors behavior, lazy ceiling resolution, explicit small-cap overflow handling, and that vector overflows are logged but not propagated from index manager and collection paths.

</details>