### PR TITLE
perf(find): O(k) top-k heap for sort+limit (P1-5, v1.0.523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `find` sort+limit uses an O(k) top-k heap, no longer materializes every matched doc before truncating (mcp-server v1.0.523, core v0.3.329)
+
+Scalability audit item **P1-5** (100GB+ roadmap). When a `find` has a sort that no single-field
+index can satisfy (a multi-field sort, or a single-field sort with no index on that field),
+`QueryExecutionContext` defers the limit (`fetch_limit = None`) and the slow path loaded **every**
+matched document into a `Vec` — `try_reserve(doc_count)` and all — before `apply_sort` sorted the
+whole thing and pagination truncated it to the limit. On a 50M-row unindexed `sort + limit 10`
+that is an O(n) allocation and full sort to return 10 rows. Root cause: there was no top-k path in
+`find` (only aggregation had one).
+
+- **Stream the scan into a bounded heap.** Both find paths — `find_with_options` (the collection
+  slow path) and `find_with_hint_ext` (the index-hint path) — now detect "in-memory sort required
+  AND positive limit" and push documents straight into an O(k) `TopKHeap` (k = skip + limit)
+  instead of the Vec. The heap keeps only the k smallest-by-sort docs seen so far, so memory is
+  O(k) regardless of how many match. The `try_reserve(doc_count)` O(n) pre-allocation is skipped
+  on this path. The heap allocates lazily (not `with_capacity(skip+limit)`), so deep pagination
+  over few matches stays O(retained) and an extreme `skip` can't trigger a capacity-overflow panic.
+  When an index already sorted+paginated for us, the cheap pre-paginated Vec path is unchanged.
+  (`collection_core/mod.rs`, `collection_core/index_ops.rs`)
+- **Reused, not reinvented.** The existing `topk_documents_streaming` heap logic
+  (`query_executor.rs`) was extracted into a reusable `TopKHeap { new, push, into_sorted }` so the
+  fallible document-loading loop (which returns `Result`) can drive it directly; the streaming
+  function now wraps the same struct. (`query_executor.rs`)
+- **Comparator unified to prevent a sort regression.** The heap ranked mixed-type fields with an
+  `Ordering::Equal` fallback while `apply_sort` used a stable `type_priority` fallback — so on a
+  mixed-type sort field the heap could evict the *wrong* documents and the top-k set would differ
+  from the full sort. `compare_docs_by_sort` now uses the identical `type_priority` fallback
+  (shared via `value_utils::type_priority`); top-k results are now byte-for-byte equal to the
+  full-sort prefix on any field, mixed types included. (`query_executor.rs`, `value_utils.rs`,
+  `find_options.rs`)
+- **Implicit RAM-derived cap for an uncapped full sort.** A required in-memory sort with **no
+  limit and no explicit `max_response_bytes`** would still materialize everything. Such a query
+  now applies an implicit RAM-derived response cap (the `with_safe_defaults` basis,
+  `calculate_safe_response_limit`), so the existing per-doc size guard turns a would-be OOM into a
+  typed, actionable error instead. On the top-k path the response-size guard applies to the
+  bounded ≤limit result rather than the whole scan. (`collection_core/mod.rs`,
+  `collection_core/index_ops.rs`)
+- **Stable top-k on tied keys.** The heap carries a scan-sequence tiebreaker, so on tied sort
+  keys it retains and orders the same documents as the old stable full sort + truncate (first-k by
+  scan order) — byte-for-byte. Without it the `BinaryHeap` could evict an arbitrary tied document
+  and return a different, run-to-run nondeterministic page. (`query_executor.rs`)
+- **Sort-direction validation is path-independent.** `validate_sort_directions` now runs at every
+  find entry point, so an invalid direction (e.g. `2`) is rejected whether or not a limit is
+  present. Previously only the full-sort path called `apply_sort`'s validator, so the top-k and
+  index-sorted paths silently accepted (and mis-sorted) invalid directions. (`find_options.rs`,
+  `collection_core/mod.rs`, `collection_core/index_ops.rs`)
+
 ### Fixed — vector index ceiling is RAM-derived, no longer a fixed 100K cap that could silently lose data (mcp-server v1.0.522, core v0.3.328)
 
 Scalability audit item **P0-2** (100GB+ roadmap). The hard `DEFAULT_MAX_VECTORS = 100_000`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.328"
+version = "0.3.329"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/index_ops.rs
+++ b/ironbase-core/src/collection_core/index_ops.rs
@@ -12,7 +12,7 @@ use crate::storage::{RawStorage, Storage};
 use crate::value_utils::{get_all_nested_values, get_nested_value, path_crosses_array};
 
 use super::index_persistence::persist_index_to_disk;
-use super::{CollectionCore, QueryExecutionContext};
+use super::{CollectionCore, QueryExecutionContext, TopKHeap};
 
 /// Index statistics information for monitoring
 #[derive(Debug, Clone)]
@@ -188,6 +188,12 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
         // Build execution context from options
         let ctx = QueryExecutionContext::from_options(&options);
 
+        // Reject invalid sort directions up front (the top-k heap path bypasses
+        // apply_sort, the only other validator).
+        if let Some(ref sort_spec) = ctx.sort_spec {
+            crate::find_options::validate_sort_directions(sort_spec)?;
+        }
+
         // Create plan using the hinted index (may fail if index dropped - graceful failure)
         let plan = self.create_plan_for_hint(query_json, hint, &field)?;
 
@@ -208,16 +214,42 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
 
         // Load documents with OOM protection
         let doc_count = doc_ids.len();
-        let mut docs = Vec::new();
-        docs.try_reserve(doc_count).map_err(|e| {
-            IronBaseError::InvalidQuery(format!(
-                "Out of memory: cannot allocate space for {} documents ({}). \
-                Solutions: 1) Add 'limit' to your query, 2) Use projection to reduce response size.",
-                doc_count, e
-            ))
-        })?;
 
-        let max_response_bytes = ctx.max_response_bytes;
+        // Top-K streaming (P1-5): the hinted index orders by the FILTER field, not
+        // the sort field, so any sort here is always an in-memory sort. With a
+        // positive limit, stream the scan into an O(k) heap (k = skip + limit)
+        // instead of materializing every matched doc and full-sorting it.
+        let mut topk_heap = match (&ctx.sort_spec, ctx.original_limit) {
+            (Some(sort), Some(limit)) if limit > 0 => {
+                Some(TopKHeap::new(ctx.original_skip, limit, sort))
+            }
+            _ => None,
+        };
+
+        // The top-k path bounds memory with the heap, so it must NOT pre-allocate
+        // O(n) for the Vec here.
+        let mut docs: Vec<Value> = Vec::new();
+        if topk_heap.is_none() {
+            docs.try_reserve(doc_count).map_err(|e| {
+                IronBaseError::InvalidQuery(format!(
+                    "Out of memory: cannot allocate space for {} documents ({}). \
+                    Solutions: 1) Add 'limit' to your query, 2) Use projection to reduce response size.",
+                    doc_count, e
+                ))
+            })?;
+        }
+
+        // P1-5 guard: a full in-memory sort (the hint orders by the filter field,
+        // not the sort field) with NO limit and NO explicit response cap would
+        // materialize every matched doc → OOM on large collections. Apply an
+        // implicit RAM-derived cap so the per-doc guard below fails typed instead.
+        let max_response_bytes = match ctx.max_response_bytes {
+            Some(explicit) => Some(explicit),
+            None if topk_heap.is_none() && ctx.sort_spec.is_some() => {
+                Some(crate::find_options::calculate_safe_response_limit())
+            }
+            None => None,
+        };
         let mut total_response_bytes: usize = 0;
 
         for (i, doc_id) in doc_ids.into_iter().enumerate() {
@@ -242,32 +274,60 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
             }
 
             if let Some(doc) = self.read_document_by_id(&doc_id)? {
-                // Track response size for OOM protection
-                if let Some(max_bytes) = max_response_bytes {
-                    let doc_size = crate::find_options::estimate_json_size(&doc);
-                    if total_response_bytes.saturating_add(doc_size) > max_bytes {
-                        return Err(IronBaseError::InvalidQuery(format!(
-                            "Response size limit exceeded: loaded {} documents ({} bytes), \
-                            next document would exceed {} byte limit. \
-                            Solutions: 1) Add 'limit', 2) Use 'projection' to exclude large fields.",
-                            i, total_response_bytes, max_bytes
-                        )));
+                if let Some(ref mut heap) = topk_heap {
+                    // Top-K path: heap keeps only k docs; the response-size guard is
+                    // applied to the final ≤limit result after the scan.
+                    heap.push(doc);
+                } else {
+                    // Track response size for OOM protection
+                    if let Some(max_bytes) = max_response_bytes {
+                        let doc_size = crate::find_options::estimate_json_size(&doc);
+                        if total_response_bytes.saturating_add(doc_size) > max_bytes {
+                            return Err(IronBaseError::InvalidQuery(format!(
+                                "Response size limit exceeded: loaded {} documents ({} bytes), \
+                                next document would exceed {} byte limit. \
+                                Solutions: 1) Add 'limit', 2) Use 'projection' to exclude large fields.",
+                                i, total_response_bytes, max_bytes
+                            )));
+                        }
+                        total_response_bytes += doc_size;
                     }
-                    total_response_bytes += doc_size;
+                    docs.push(doc);
                 }
-                docs.push(doc);
             }
         }
 
         // Post-processing pipeline (consistent with find_with_options)
-
-        // 1. Apply sort if specified
-        if let Some(ref sort_spec) = ctx.sort_spec {
-            crate::find_options::apply_sort(&mut docs, sort_spec)?;
-        }
-
-        // 2. Apply skip/limit after sorting
-        let docs = ctx.apply_post_sort_pagination(docs);
+        let docs = if let Some(heap) = topk_heap {
+            // Top-K already produced a sorted result with skip + limit applied;
+            // skip the in-memory sort and pagination. Apply the response-size guard
+            // to the bounded result.
+            let docs = heap.into_sorted();
+            if let Some(max_bytes) = max_response_bytes {
+                let mut total = 0usize;
+                for d in &docs {
+                    total = total.saturating_add(crate::find_options::estimate_json_size(d));
+                    if total > max_bytes {
+                        return Err(IronBaseError::InvalidQuery(format!(
+                            "Response size limit exceeded: top-{} result exceeds {} byte limit \
+                            ({}+ bytes). Solutions: 1) Reduce 'limit', \
+                            2) Use 'projection' to exclude large fields.",
+                            docs.len(),
+                            max_bytes,
+                            total
+                        )));
+                    }
+                }
+            }
+            docs
+        } else {
+            // 1. Apply sort if specified
+            if let Some(ref sort_spec) = ctx.sort_spec {
+                crate::find_options::apply_sort(&mut docs, sort_spec)?;
+            }
+            // 2. Apply skip/limit after sorting
+            ctx.apply_post_sort_pagination(docs)
+        };
 
         // 3. Apply projection
         let docs = ctx.apply_projection_to_docs(docs)?;

--- a/ironbase-core/src/collection_core/mod.rs
+++ b/ironbase-core/src/collection_core/mod.rs
@@ -226,7 +226,7 @@ pub use index_ops::IndexStatisticsInfo;
 // Public exports for Query Executor
 pub use query_executor::{
     compare_docs_by_sort, topk_documents, ExecutionMethod, ExecutionStats, QueryOptions,
-    QueryResult, SortDirection,
+    QueryResult, SortDirection, TopKHeap,
 };
 
 pub(crate) use self::constraints::BatchConstraintValidator;
@@ -980,6 +980,13 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
         // Phase 1: Build execution context (all setup logic centralized)
         let ctx = QueryExecutionContext::from_options(&options);
 
+        // Reject invalid sort directions up front, on EVERY sort path. The top-k
+        // heap path and the index-sorted path bypass apply_sort (which used to be
+        // the only validator), so validation must live here, before the split.
+        if let Some(ref sort_spec) = ctx.sort_spec {
+            crate::find_options::validate_sort_directions(sort_spec)?;
+        }
+
         // Phase 2: Collect document IDs (may use index for sorting)
         // Pass original skip/limit for index-based sort optimization (early termination)
         let (doc_ids, index_sorted) = self.collect_doc_ids_with_options(
@@ -1008,19 +1015,54 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
             );
         }
 
-        // Load documents with progress logging for very large sets
-        // Use try_reserve to detect OOM before it happens
-        let mut docs = Vec::new();
-        docs.try_reserve(doc_count).map_err(|e| {
-            IronBaseError::InvalidQuery(format!(
-                "Out of memory: cannot allocate space for {} documents ({}). \
-                Solutions: 1) Add 'limit' to your query, 2) Use an index, 3) Use find_streaming() for large results.",
-                doc_count, e
-            ))
-        })?;
+        // Top-K streaming (P1-5): when an in-memory sort is required AND the user
+        // gave a positive limit, stream the scan straight into an O(k) heap
+        // (k = skip + limit) instead of materializing every matched document.
+        // Without this a 50M-row unindexed sort+limit allocates O(n) below before
+        // truncating. When the index already sorted for us
+        // (needs_memory_sort == false) the doc_ids are pre-paginated, so the plain
+        // Vec path is both correct and cheap and we keep it.
+        let mut topk_heap = match (ctx.needs_memory_sort(index_sorted), ctx.original_limit) {
+            (true, Some(limit)) if limit > 0 => {
+                let sort = ctx
+                    .sort_spec
+                    .as_ref()
+                    .expect("needs_memory_sort() is only true when a sort spec is present");
+                Some(TopKHeap::new(ctx.original_skip, limit, sort))
+            }
+            _ => None,
+        };
 
-        // Response size tracking for OOM protection
-        let max_response_bytes = ctx.max_response_bytes;
+        // Load documents with progress logging for very large sets.
+        // Use try_reserve to detect OOM before it happens. The top-k path bounds
+        // memory with the heap, so it must NOT pre-allocate O(n) for the Vec here.
+        let mut docs: Vec<Value> = Vec::new();
+        if topk_heap.is_none() {
+            docs.try_reserve(doc_count).map_err(|e| {
+                IronBaseError::InvalidQuery(format!(
+                    "Out of memory: cannot allocate space for {} documents ({}). \
+                    Solutions: 1) Add 'limit' to your query, 2) Use an index, 3) Use find_streaming() for large results.",
+                    doc_count, e
+                ))
+            })?;
+        }
+
+        // Response size tracking for OOM protection.
+        //
+        // P1-5 guard: a full in-memory sort with NO limit and NO explicit response
+        // cap would materialize every matched document — on a large unindexed sort
+        // that means OOM. In that case apply an implicit RAM-derived cap (same basis
+        // as FindOptions::with_safe_defaults, find_options.rs) so the per-doc size
+        // guard below turns the OOM into a typed, actionable error instead. The
+        // top-k path bounds memory by itself, and limit-only / index-sorted paths
+        // don't need it.
+        let max_response_bytes = match ctx.max_response_bytes {
+            Some(explicit) => Some(explicit),
+            None if topk_heap.is_none() && ctx.needs_memory_sort(index_sorted) => {
+                Some(crate::find_options::calculate_safe_response_limit())
+            }
+            None => None,
+        };
         let mut total_response_bytes: usize = 0;
 
         // Early projection optimization:
@@ -1091,25 +1133,33 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                     doc
                 };
 
-                // Track response size if limit is set
-                // NOTE: With early projection, this checks the PROJECTED size (accurate)
-                // Without early projection, this checks the FULL document size
-                if let Some(max_bytes) = max_response_bytes {
-                    let doc_size = crate::find_options::estimate_json_size(&doc);
-                    if total_response_bytes.saturating_add(doc_size) > max_bytes {
-                        return Err(IronBaseError::InvalidQuery(format!(
-                            "Response size limit exceeded: loaded {} documents ({} bytes), \
-                            next document would exceed {} byte limit. \
-                            Solutions: 1) Add 'limit' to reduce results, \
-                            2) Use 'projection' to exclude large fields, \
-                            3) Use find_streaming() for large results.",
-                            loaded, total_response_bytes, max_bytes
-                        )));
+                if let Some(ref mut heap) = topk_heap {
+                    // Top-K path: the heap retains only k = skip + limit docs, so
+                    // memory stays bounded no matter how many match. The response-
+                    // size guard is applied to the final ≤limit result after the
+                    // scan (Phase 4), not per scanned doc.
+                    heap.push(doc);
+                } else {
+                    // Track response size if limit is set
+                    // NOTE: With early projection, this checks the PROJECTED size (accurate)
+                    // Without early projection, this checks the FULL document size
+                    if let Some(max_bytes) = max_response_bytes {
+                        let doc_size = crate::find_options::estimate_json_size(&doc);
+                        if total_response_bytes.saturating_add(doc_size) > max_bytes {
+                            return Err(IronBaseError::InvalidQuery(format!(
+                                "Response size limit exceeded: loaded {} documents ({} bytes), \
+                                next document would exceed {} byte limit. \
+                                Solutions: 1) Add 'limit' to reduce results, \
+                                2) Use 'projection' to exclude large fields, \
+                                3) Use find_streaming() for large results.",
+                                loaded, total_response_bytes, max_bytes
+                            )));
+                        }
+                        total_response_bytes += doc_size;
                     }
-                    total_response_bytes += doc_size;
-                }
 
-                docs.push(doc);
+                    docs.push(doc);
+                }
                 loaded += 1;
                 // Progress logging every 10,000 documents
                 if loaded % 10_000 == 0 && doc_count > LARGE_QUERY_WARNING_THRESHOLD {
@@ -1125,20 +1175,45 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
         }
 
         // Phase 4: Post-processing pipeline
-        // 4a. Apply sort if needed (index didn't sort for us)
-        if ctx.needs_memory_sort(index_sorted) {
-            if let Some(ref sort_spec) = ctx.sort_spec {
-                crate::find_options::apply_sort(&mut docs, sort_spec)?;
+        let docs = if let Some(heap) = topk_heap {
+            // 4-topk. The heap already produced a fully sorted result with skip +
+            // limit applied, so the regular in-memory sort (4a) and pagination
+            // (4b) are skipped. Apply the response-size guard to the bounded
+            // ≤limit result here (it was deferred during the scan).
+            let docs = heap.into_sorted();
+            if let Some(max_bytes) = max_response_bytes {
+                let mut total = 0usize;
+                for d in &docs {
+                    total = total.saturating_add(crate::find_options::estimate_json_size(d));
+                    if total > max_bytes {
+                        return Err(IronBaseError::InvalidQuery(format!(
+                            "Response size limit exceeded: top-{} result exceeds {} byte limit \
+                            ({}+ bytes). Solutions: 1) Reduce 'limit', \
+                            2) Use 'projection' to exclude large fields.",
+                            docs.len(),
+                            max_bytes,
+                            total
+                        )));
+                    }
+                }
             }
-        }
-
-        // 4b. Apply pagination after sorting
-        // SKIP if index already applied skip/limit (index_sorted + empty query)
-        let docs = if index_sorted && Self::query_matches_all(query_json) {
-            // Index-based sort already applied skip/limit - don't apply again
             docs
         } else {
-            ctx.apply_post_sort_pagination(docs)
+            // 4a. Apply sort if needed (index didn't sort for us)
+            if ctx.needs_memory_sort(index_sorted) {
+                if let Some(ref sort_spec) = ctx.sort_spec {
+                    crate::find_options::apply_sort(&mut docs, sort_spec)?;
+                }
+            }
+
+            // 4b. Apply pagination after sorting
+            // SKIP if index already applied skip/limit (index_sorted + empty query)
+            if index_sorted && Self::query_matches_all(query_json) {
+                // Index-based sort already applied skip/limit - don't apply again
+                docs
+            } else {
+                ctx.apply_post_sort_pagination(docs)
+            }
         };
 
         // 4c. Apply projection (skip if already applied early)

--- a/ironbase-core/src/collection_core/query_executor.rs
+++ b/ironbase-core/src/collection_core/query_executor.rs
@@ -20,6 +20,7 @@
 // ```
 
 use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -142,8 +143,18 @@ pub fn compare_docs_by_sort(a: &Value, b: &Value, sort: &[(String, i32)]) -> Ord
         let a_val = value_utils::get_nested_value(a, field);
         let b_val = value_utils::get_nested_value(b, field);
 
-        // Use compare_values_with_none to handle missing fields properly
-        let cmp = value_utils::compare_values_with_none(a_val, b_val);
+        // Match find_options::apply_sort EXACTLY: missing < present, compatible
+        // types use the core comparator, and incompatible/mixed types fall back to
+        // a stable type rank. This must agree with the full in-memory sort, or the
+        // top-k heap would evict the wrong documents on a mixed-type field (P1-5).
+        let cmp = match (a_val, b_val) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            (Some(av), Some(bv)) => value_utils::compare_values(av, bv).unwrap_or_else(|| {
+                value_utils::type_priority(av).cmp(&value_utils::type_priority(bv))
+            }),
+        };
 
         if cmp != Ordering::Equal {
             // Reverse comparison for descending order
@@ -184,67 +195,131 @@ pub fn topk_documents_streaming<I>(
 where
     I: Iterator<Item = Value>,
 {
-    use std::collections::BinaryHeap;
-
     if limit == 0 {
         return Vec::new();
     }
 
-    let k = skip + limit;
-    let sort_spec: Arc<[(String, i32)]> = Arc::from(sort.to_vec().into_boxed_slice());
-
-    // Wrapper for heap ordering
-    struct HeapItem {
-        doc: Value,
-        sort: Arc<[(String, i32)]>,
-    }
-
-    impl PartialEq for HeapItem {
-        fn eq(&self, other: &Self) -> bool {
-            compare_docs_by_sort(&self.doc, &other.doc, &self.sort) == Ordering::Equal
-        }
-    }
-
-    impl Eq for HeapItem {}
-
-    impl PartialOrd for HeapItem {
-        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-            Some(self.cmp(other))
-        }
-    }
-
-    impl Ord for HeapItem {
-        fn cmp(&self, other: &Self) -> Ordering {
-            // Max-heap: larger values at top (to be kicked first)
-            compare_docs_by_sort(&self.doc, &other.doc, &self.sort)
-        }
-    }
-
-    let mut heap: BinaryHeap<HeapItem> = BinaryHeap::with_capacity(k);
-
+    let mut heap = TopKHeap::new(skip, limit, sort);
     for doc in docs {
+        heap.push(doc);
+    }
+    heap.into_sorted()
+}
+
+/// Heap entry ordered by `(sort key, scan sequence)`.
+///
+/// `Ord` yields a **max-heap**: the document that sorts *last* — or, among equal
+/// sort keys, the one scanned *later* (higher `seq`) — sits at the top, so it is
+/// the first evicted once the heap is full. The `seq` tiebreaker makes the top-k
+/// **stable**: among tied keys the earliest-scanned documents are retained and
+/// ordered by scan order, byte-for-byte matching the old full stable
+/// `apply_sort` + truncate (which kept the first k in scan order on ties).
+struct HeapItem {
+    doc: Value,
+    /// Monotonic scan index; lower = scanned earlier. Tiebreaker for equal keys.
+    seq: u64,
+    sort: Arc<[(String, i32)]>,
+}
+
+impl PartialEq for HeapItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for HeapItem {}
+
+impl PartialOrd for HeapItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HeapItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Primary: sort spec. Tiebreaker: scan sequence (lower = earlier = kept).
+        // Max-heap → largest at top → evicted first; a later-scanned tie has a
+        // higher seq, so it ranks "larger" and is evicted before an earlier tie.
+        compare_docs_by_sort(&self.doc, &other.doc, &self.sort).then(self.seq.cmp(&other.seq))
+    }
+}
+
+/// Reusable O(k) top-k selector backed by a max-heap (k = skip + limit).
+///
+/// Streams documents through a heap that retains only the k smallest seen so far
+/// (per the sort spec, ties broken by scan order), so memory stays O(k) regardless
+/// of how many documents are offered. Use this when the input would otherwise
+/// materialize O(n) before being truncated to a limit — e.g. an unindexed `find`
+/// sort+limit scan.
+///
+/// `topk_documents_streaming` is the iterator-friendly wrapper; callers with a
+/// fallible loop (e.g. document loading that returns `Result`) can drive a
+/// `TopKHeap` directly via [`TopKHeap::push`].
+pub struct TopKHeap {
+    heap: BinaryHeap<HeapItem>,
+    k: usize,
+    skip: usize,
+    next_seq: u64,
+    sort_spec: Arc<[(String, i32)]>,
+}
+
+impl TopKHeap {
+    /// Create a selector that yields `limit` documents after skipping `skip`,
+    /// ordered by `sort`.
+    pub fn new(skip: usize, limit: usize, sort: &[(String, i32)]) -> Self {
+        let k = skip.saturating_add(limit);
+        let sort_spec: Arc<[(String, i32)]> = Arc::from(sort.to_vec().into_boxed_slice());
+        Self {
+            // Deliberately NOT `with_capacity(k)`: for deep pagination k = skip +
+            // limit can be enormous while only a handful of documents match, and
+            // `with_capacity` is infallible — it would eagerly allocate (and abort
+            // on failure, or panic on usize::MAX) gigabytes regardless of data
+            // size. Starting empty lets the heap grow lazily to the number of
+            // retained docs (≤ k), so a deep skip over few matches stays cheap.
+            heap: BinaryHeap::new(),
+            k,
+            skip,
+            next_seq: 0,
+            sort_spec,
+        }
+    }
+
+    /// Offer one document. O(log k). Documents that cannot enter the top-k are
+    /// dropped immediately, so the heap never holds more than k entries.
+    pub fn push(&mut self, doc: Value) {
+        if self.k == 0 {
+            return;
+        }
         let item = HeapItem {
             doc,
-            sort: Arc::clone(&sort_spec),
+            seq: self.next_seq,
+            sort: Arc::clone(&self.sort_spec),
         };
-
-        if heap.len() < k {
-            heap.push(item);
-        } else if let Some(top) = heap.peek() {
-            // If new item is "smaller" (should come before top in output)
-            if compare_docs_by_sort(&item.doc, &top.doc, &sort_spec) == Ordering::Less {
-                heap.pop();
-                heap.push(item);
+        // saturating_add: a single scan never approaches u64::MAX docs, but this
+        // avoids any overflow panic/wrap if it somehow did.
+        self.next_seq = self.next_seq.saturating_add(1);
+        if self.heap.len() < self.k {
+            self.heap.push(item);
+        } else if let Some(top) = self.heap.peek() {
+            // Keep `item` only if it ranks before the current worst-of-the-best.
+            // A tie never displaces an earlier doc: a later scan seq ranks larger.
+            if item.cmp(top) == Ordering::Less {
+                self.heap.pop();
+                self.heap.push(item);
             }
         }
     }
 
-    // Extract and sort
-    let mut result: Vec<Value> = heap.into_iter().map(|h| h.doc).collect();
-    result.sort_by(|a, b| compare_docs_by_sort(a, b, &sort_spec));
-
-    // Apply skip
-    result.into_iter().skip(skip).collect()
+    /// Drain into a fully sorted Vec with `skip` applied. O(k log k).
+    ///
+    /// Sorted by `(sort key, scan seq)` so ties resolve in scan order, reproducing
+    /// the old stable `apply_sort` + truncate output exactly. `into_iter` drains
+    /// the heap in arbitrary order, so the explicit sort is required.
+    pub fn into_sorted(self) -> Vec<Value> {
+        let mut items: Vec<HeapItem> = self.heap.into_iter().collect();
+        items.sort();
+        items.into_iter().skip(self.skip).map(|h| h.doc).collect()
+    }
 }
 
 /// Helper to convert RangeQueryResult to a count
@@ -372,6 +447,60 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0]["age"], 30);
         assert_eq!(result[1]["age"], 40);
+    }
+
+    #[test]
+    fn test_topk_heap_direct_bounded() {
+        // Drive the heap directly (the fallible-loop entry point used by `find`).
+        // Offer 1000 docs in arbitrary order but keep only the top 3 ascending —
+        // the heap must never hold more than k = skip + limit = 3 entries.
+        let sort = vec![("age".to_string(), 1)];
+        let mut heap = TopKHeap::new(0, 3, &sort);
+        for age in [500, 1, 999, 2, 3, 750, 4, 250] {
+            heap.push(json!({ "age": age }));
+            assert!(
+                heap.heap.len() <= 3,
+                "heap must stay bounded at k=3, got {}",
+                heap.heap.len()
+            );
+        }
+        let result = heap.into_sorted();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0]["age"], 1);
+        assert_eq!(result[1]["age"], 2);
+        assert_eq!(result[2]["age"], 3);
+    }
+
+    #[test]
+    fn test_topk_heap_direct_skip() {
+        // skip applied after the bounded selection: k = skip(2) + limit(2) = 4,
+        // then drop the first 2 → ages 30, 40.
+        let sort = vec![("age".to_string(), 1)];
+        let mut heap = TopKHeap::new(2, 2, &sort);
+        for age in [50, 10, 40, 20, 30] {
+            heap.push(json!({ "age": age }));
+        }
+        let result = heap.into_sorted();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0]["age"], 30);
+        assert_eq!(result[1]["age"], 40);
+    }
+
+    #[test]
+    fn test_topk_heap_stable_ties() {
+        // Many docs tie on age=5; tag records scan order. With limit 2 and the
+        // age-1 doc arriving last, the survivors must be the age-1 doc plus the
+        // FIRST-scanned age-5 doc (stable), not an arbitrary tied doc. The
+        // scan-seq tiebreaker guarantees this matches the old stable full sort.
+        let sort = vec![("age".to_string(), 1)];
+        let mut heap = TopKHeap::new(0, 2, &sort);
+        for (age, tag) in [(5, "a"), (5, "b"), (5, "c"), (1, "d")] {
+            heap.push(json!({ "age": age, "tag": tag }));
+        }
+        let result = heap.into_sorted();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0]["tag"], json!("d")); // age 1
+        assert_eq!(result[1]["tag"], json!("a")); // first-scanned age-5 tie
     }
 
     #[test]

--- a/ironbase-core/src/find_options.rs
+++ b/ironbase-core/src/find_options.rs
@@ -4,6 +4,7 @@
 use crate::error::{IronBaseError, Result};
 use crate::value_utils::{
     compare_values as compare_values_core, delete_nested_value, get_nested_value, set_nested_value,
+    type_priority,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -417,6 +418,26 @@ pub fn apply_projection(doc: &Value, projection: &HashMap<String, i32>) -> Resul
     }
 }
 
+/// Validate sort directions (MongoDB only accepts 1 or -1).
+///
+/// Path-independent: the top-k heap path and the index-sorted path do NOT call
+/// `apply_sort`, so every `find` entry point must call this up front to reject the
+/// same invalid input regardless of which sort executor ends up running.
+///
+/// # Errors
+/// Returns `InvalidQuery` if any sort direction is not 1 (ascending) or -1 (descending).
+pub fn validate_sort_directions(sort: &[(String, i32)]) -> Result<()> {
+    for (field, direction) in sort {
+        if *direction != 1 && *direction != -1 {
+            return Err(IronBaseError::InvalidQuery(format!(
+                "Invalid sort direction {} for field '{}'. Must be 1 (ascending) or -1 (descending).",
+                direction, field
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Apply sort to documents
 /// Supports dot notation for nested fields (e.g., "address.city")
 ///
@@ -427,15 +448,7 @@ pub fn apply_sort(docs: &mut [Value], sort: &[(String, i32)]) -> Result<()> {
         return Ok(());
     }
 
-    // Validate sort directions (MongoDB only accepts 1 or -1)
-    for (field, direction) in sort {
-        if *direction != 1 && *direction != -1 {
-            return Err(IronBaseError::InvalidQuery(format!(
-                "Invalid sort direction {} for field '{}'. Must be 1 (ascending) or -1 (descending).",
-                direction, field
-            )));
-        }
-    }
+    validate_sort_directions(sort)?;
 
     docs.sort_by(|a, b| {
         for (field, direction) in sort {
@@ -473,18 +486,6 @@ fn compare_values(a: Option<&Value>, b: Option<&Value>) -> std::cmp::Ordering {
                 type_priority(a_val).cmp(&type_priority(b_val))
             })
         }
-    }
-}
-
-/// Get type priority for mixed-type sorting
-fn type_priority(val: &Value) -> u8 {
-    match val {
-        Value::Null => 0,
-        Value::Number(_) => 1,
-        Value::String(_) => 2,
-        Value::Bool(_) => 3,
-        Value::Object(_) => 4,
-        Value::Array(_) => 5,
     }
 }
 

--- a/ironbase-core/src/value_utils.rs
+++ b/ironbase-core/src/value_utils.rs
@@ -441,6 +441,25 @@ pub fn compare_values_with_none(a: Option<&Value>, b: Option<&Value>) -> Orderin
     }
 }
 
+/// Type-ordering rank for mixed-type sorting.
+///
+/// When two values have incompatible types (`compare_values` returns `None`),
+/// sorting falls back to this stable per-type rank to keep a total order.
+/// Shared by the `find` in-memory sort (`find_options::apply_sort`) and the
+/// `find` top-k heap (`query_executor::compare_docs_by_sort`) so both rank
+/// mixed-type fields identically (P1-5: the heap's eviction decision must match
+/// the full sort, or the top-k set itself would differ).
+pub fn type_priority(val: &Value) -> u8 {
+    match val {
+        Value::Null => 0,
+        Value::Number(_) => 1,
+        Value::String(_) => 2,
+        Value::Bool(_) => 3,
+        Value::Object(_) => 4,
+        Value::Array(_) => 5,
+    }
+}
+
 /// Creates a fast hash for a JSON Value using ahash.
 ///
 /// This is much faster than canonical_json_string for deduplication,

--- a/ironbase-core/tests/collection_core_tests.rs
+++ b/ironbase-core/tests/collection_core_tests.rs
@@ -1264,6 +1264,385 @@ fn test_index_based_sort_for_empty_query() {
     assert_eq!(results[2]["timestamp"], 12);
 }
 
+/// P1-5: Top-K streaming for find sort+limit WITHOUT a usable sort index.
+///
+/// Mirrors `test_index_based_sort_for_empty_query` but creates NO index on the
+/// sort field, so `needs_memory_sort` is true and the new O(k) top-k heap path
+/// is exercised (collection scan → heap). Results MUST match the index path.
+#[test]
+fn test_find_topk_no_index_single_field_sort() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+
+    // NO index on "timestamp" -> collection scan + in-memory top-k.
+    // Zigzag covers every integer 0..1000 exactly once.
+    for i in 0..1000i64 {
+        let ts = if i % 2 == 0 { i } else { 1000 - i };
+        let mut doc = HashMap::new();
+        doc.insert("timestamp".to_string(), json!(ts));
+        doc.insert("data".to_string(), json!(format!("doc_{}", i)));
+        db.insert_one("test", doc).unwrap();
+    }
+
+    // Ascending top-5
+    let results = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new()
+                .with_sort(vec![("timestamp".to_string(), 1)])
+                .with_limit(5),
+        )
+        .unwrap();
+    assert_eq!(results.len(), 5);
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(r["timestamp"], json!(i as i64));
+    }
+
+    // Descending top-5
+    let results = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new()
+                .with_sort(vec![("timestamp".to_string(), -1)])
+                .with_limit(5),
+        )
+        .unwrap();
+    assert_eq!(results.len(), 5);
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(r["timestamp"], json!(999 - i as i64));
+    }
+
+    // skip + limit
+    let results = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new()
+                .with_sort(vec![("timestamp".to_string(), 1)])
+                .with_skip(10)
+                .with_limit(5),
+        )
+        .unwrap();
+    assert_eq!(results.len(), 5);
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(r["timestamp"], json!(10 + i as i64));
+    }
+}
+
+/// P1-5: A multi-field sort can never be satisfied by a single-field index, so
+/// it always takes the in-memory top-k heap path when a limit is present.
+/// Verifies ordering AND tie-breaking on the second field.
+#[test]
+fn test_find_topk_multi_field_sort() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+
+    let data = [
+        (2, 10),
+        (1, 5),
+        (2, 30),
+        (1, 99),
+        (3, 1),
+        (2, 20),
+        (1, 50),
+        (3, 7),
+        (2, 25),
+        (1, 1),
+    ];
+    for (g, r) in data {
+        let mut doc = HashMap::new();
+        doc.insert("group".to_string(), json!(g));
+        doc.insert("rank".to_string(), json!(r));
+        db.insert_one("test", doc).unwrap();
+    }
+
+    // group ASC, then rank DESC. group 1 is smallest → top-4 are all group 1,
+    // ranks 99, 50, 5, 1.
+    let results = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new()
+                .with_sort(vec![("group".to_string(), 1), ("rank".to_string(), -1)])
+                .with_limit(4),
+        )
+        .unwrap();
+    assert_eq!(results.len(), 4);
+    for r in &results {
+        assert_eq!(r["group"], json!(1));
+    }
+    assert_eq!(results[0]["rank"], json!(99));
+    assert_eq!(results[1]["rank"], json!(50));
+    assert_eq!(results[2]["rank"], json!(5));
+    assert_eq!(results[3]["rank"], json!(1));
+}
+
+/// P1-5 core invariant: the top-k path must produce EXACTLY the same result as
+/// the full-sort path truncated to skip+limit. Runs both code paths on the same
+/// data/query and asserts equality (id tiebreaker makes the order total).
+#[test]
+fn test_find_topk_matches_full_sort_reference() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+
+    for i in 0..500i64 {
+        let v = (i * 7919) % 1000; // spread with collisions
+        let mut doc = HashMap::new();
+        doc.insert("v".to_string(), json!(v));
+        doc.insert("id".to_string(), json!(i));
+        db.insert_one("test", doc).unwrap();
+    }
+
+    let sort = vec![("v".to_string(), 1), ("id".to_string(), 1)];
+    let skip = 5usize;
+    let limit = 17usize;
+
+    // Reference: full sort (no limit → non-top-k path), then manual skip+take.
+    let full = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new().with_sort(sort.clone()),
+        )
+        .unwrap();
+    let reference: Vec<_> = full.iter().skip(skip).take(limit).cloned().collect();
+
+    // Top-K path (skip + limit → heap).
+    let topk = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new()
+                .with_sort(sort)
+                .with_skip(skip)
+                .with_limit(limit),
+        )
+        .unwrap();
+
+    assert_eq!(topk.len(), reference.len());
+    assert_eq!(
+        topk, reference,
+        "top-k result must equal full-sort[skip..skip+limit]"
+    );
+}
+
+/// P1-5 regression guard: on a MIXED-TYPE sort field the heap's comparator must
+/// rank identically to `apply_sort` (type_priority fallback), or the heap would
+/// evict the wrong docs and the top-k set itself would diverge from the full
+/// sort. This test fails on the old `Ordering::Equal` fallback.
+#[test]
+fn test_find_topk_mixed_type_matches_full_sort() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+
+    let vals = [
+        json!(5),
+        json!("apple"),
+        json!(true),
+        json!(null),
+        json!(2),
+        json!("banana"),
+        json!(100),
+        json!(false),
+        json!(1),
+        json!("cherry"),
+    ];
+    for (i, v) in vals.iter().enumerate() {
+        let mut doc = HashMap::new();
+        doc.insert("k".to_string(), v.clone());
+        doc.insert("id".to_string(), json!(i as i64));
+        db.insert_one("test", doc).unwrap();
+    }
+    // A few docs with "k" missing entirely (None sorts before any present value).
+    for i in 100..103i64 {
+        let mut doc = HashMap::new();
+        doc.insert("id".to_string(), json!(i));
+        db.insert_one("test", doc).unwrap();
+    }
+
+    let sort = vec![("k".to_string(), 1), ("id".to_string(), 1)];
+    let full = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new().with_sort(sort.clone()),
+        )
+        .unwrap();
+
+    for limit in [1usize, 3, 7, 13] {
+        let topk = coll
+            .find_with_options(
+                &json!({}),
+                ironbase_core::FindOptions::new()
+                    .with_sort(sort.clone())
+                    .with_limit(limit),
+            )
+            .unwrap();
+        let reference: Vec<_> = full.iter().take(limit).cloned().collect();
+        assert_eq!(
+            topk, reference,
+            "mixed-type top-{} must equal full-sort prefix",
+            limit
+        );
+    }
+}
+
+/// P1-5: the response-size guard still fires on a full (no-limit) in-memory sort.
+/// The guard moved into the non-top-k branch but must stay effective there.
+#[test]
+fn test_find_full_sort_respects_response_limit() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+    for i in 0..2000i64 {
+        let mut doc = HashMap::new();
+        doc.insert("v".to_string(), json!(i));
+        doc.insert("blob".to_string(), json!("x".repeat(500)));
+        db.insert_one("test", doc).unwrap();
+    }
+    // No limit + tiny explicit cap → must error instead of materializing all.
+    let opts = ironbase_core::FindOptions {
+        sort: Some(vec![("v".to_string(), 1)]),
+        max_response_bytes: Some(50_000), // ~50KB << 2000 * 500B
+        ..Default::default()
+    };
+    assert!(
+        coll.find_with_options(&json!({}), opts).is_err(),
+        "full sort exceeding the response cap must error"
+    );
+}
+
+/// P1-5: with a small limit the top-k path bounds the result, so the SAME tiny
+/// response cap is satisfied — the guard applies to the ≤limit result, not the
+/// whole scan. (On the old materialize-then-truncate path this would also error.)
+#[test]
+fn test_find_topk_within_response_limit() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+    for i in 0..2000i64 {
+        let mut doc = HashMap::new();
+        doc.insert("v".to_string(), json!(i));
+        doc.insert("blob".to_string(), json!("x".repeat(500)));
+        db.insert_one("test", doc).unwrap();
+    }
+    // Same tiny cap, but limit 5 → top-5 (~2.6KB) fits comfortably.
+    let opts = ironbase_core::FindOptions {
+        sort: Some(vec![("v".to_string(), 1)]),
+        limit: Some(5),
+        max_response_bytes: Some(50_000),
+        ..Default::default()
+    };
+    let results = coll.find_with_options(&json!({}), opts).unwrap();
+    assert_eq!(results.len(), 5);
+    assert_eq!(results[0]["v"], json!(0));
+    assert_eq!(results[4]["v"], json!(4));
+}
+
+/// P1-5 review fix #3: the top-k heap is STABLE on tied sort keys — it returns the
+/// same set AND order as the old stable apply_sort+truncate (first-k by scan order
+/// on ties). Before the seq-tiebreaker fix the heap could return a different tied
+/// subset (e.g. {d,b} instead of {d,a}) and nondeterministically.
+#[test]
+fn test_find_topk_stable_on_ties() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+    // Many docs tie on age=5; tag records insertion (scan) order.
+    for (age, tag) in [(5, "a"), (5, "b"), (5, "c"), (1, "d"), (5, "e"), (1, "f")] {
+        let mut doc = HashMap::new();
+        doc.insert("age".to_string(), json!(age));
+        doc.insert("tag".to_string(), json!(tag));
+        db.insert_one("test", doc).unwrap();
+    }
+    let sort = vec![("age".to_string(), 1)];
+    // Reference: full stable sort (no limit → non-top-k path), truncated per limit.
+    let full = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new().with_sort(sort.clone()),
+        )
+        .unwrap();
+    for limit in [1usize, 2, 3, 4, 5, 6] {
+        let topk = coll
+            .find_with_options(
+                &json!({}),
+                ironbase_core::FindOptions::new()
+                    .with_sort(sort.clone())
+                    .with_limit(limit),
+            )
+            .unwrap();
+        let reference: Vec<_> = full.iter().take(limit).cloned().collect();
+        assert_eq!(
+            topk, reference,
+            "top-{} must equal the stable full-sort prefix on ties",
+            limit
+        );
+    }
+}
+
+/// P1-5 review fix #2: an invalid sort direction is rejected on EVERY path — both
+/// the top-k path (with a limit) and the full-sort path (no limit). Previously the
+/// top-k path bypassed apply_sort and silently treated direction=2 as ascending.
+#[test]
+fn test_find_invalid_sort_direction_rejected_all_paths() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+    for i in 0..10i64 {
+        let mut doc = HashMap::new();
+        doc.insert("age".to_string(), json!(i));
+        db.insert_one("test", doc).unwrap();
+    }
+    // direction 2 is invalid — must error WITH a limit (top-k path) ...
+    assert!(
+        coll.find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new()
+                .with_sort(vec![("age".to_string(), 2)])
+                .with_limit(3),
+        )
+        .is_err(),
+        "invalid direction must error on the top-k path"
+    );
+    // ... and WITHOUT a limit (full-sort path).
+    assert!(
+        coll.find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new().with_sort(vec![("age".to_string(), 2)]),
+        )
+        .is_err(),
+        "invalid direction must error on the full-sort path"
+    );
+    // Valid directions still succeed on the top-k path.
+    assert!(coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new()
+                .with_sort(vec![("age".to_string(), -1)])
+                .with_limit(3),
+        )
+        .is_ok());
+}
+
+/// P1-5 review fix #1: deep-pagination skip over few matches must NOT eagerly
+/// allocate O(skip) — the heap grows lazily to the retained docs. An extreme skip
+/// (which the old with_capacity(skip+limit) turned into a capacity-overflow panic)
+/// must complete and return the correct empty page.
+#[test]
+fn test_find_topk_extreme_skip_no_panic() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    let coll = db.collection("test").unwrap();
+    for i in 0..50i64 {
+        let mut doc = HashMap::new();
+        doc.insert("v".to_string(), json!(i));
+        db.insert_one("test", doc).unwrap();
+    }
+    // skip = usize::MAX would panic under BinaryHeap::with_capacity(usize::MAX);
+    // with the lazy heap it just yields an empty page (only 50 docs exist).
+    let results = coll
+        .find_with_options(
+            &json!({}),
+            ironbase_core::FindOptions::new()
+                .with_sort(vec![("v".to_string(), 1)])
+                .with_skip(usize::MAX)
+                .with_limit(10),
+        )
+        .unwrap();
+    assert_eq!(results.len(), 0);
+}
+
 /// FIX #23: Performance test for DESC sort with early termination
 /// This should be O(limit) not O(N) when using index-based sorting
 #[test]

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.522"
+version = "1.0.523"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## P1-5 · `find` sort+limit → O(k) top-k heap

Scalability audit **P1-5** (100GB+ roadmap, stacked on P0-1 #91 + P0-2 #92). When a `find` has a sort that no single-field index can satisfy (a multi-field sort, or a single-field sort with no index on that field), `QueryExecutionContext` defers the limit (`fetch_limit = None`) and the slow path loaded **every** matched document into a `Vec` — `try_reserve(doc_count)` included — before `apply_sort` sorted all of it and pagination truncated to the limit. A 50M-row unindexed `sort + limit 10` thus allocated O(n) and full-sorted just to return 10 rows. Root cause: there was no top-k path in `find` (only aggregation had one).

### Fix
- **Stream the scan into a bounded heap.** Both find paths — `find_with_options` and `find_with_hint_ext` — detect "in-memory sort required AND positive limit" and push documents into an O(k) `TopKHeap` (k = skip + limit) instead of the Vec; the O(n) `try_reserve` is skipped. The index-sorted / pre-paginated path is unchanged. (`collection_core/mod.rs`, `index_ops.rs`)
- **Reuse, not reinvent.** Extracted the `topk_documents_streaming` heap logic into a reusable `TopKHeap { new, push, into_sorted }` so the fallible document-loading loop can drive it directly. (`query_executor.rs`)
- **Comparator unified.** `compare_docs_by_sort` now uses the same `type_priority` fallback as `apply_sort` (shared via `value_utils::type_priority`), so top-k is byte-for-byte equal to the full-sort prefix on any field — the heap's eviction must agree with the full sort or the top-k *set* itself would differ on mixed-type fields.
- **Implicit RAM-derived cap.** A required in-memory sort with no limit and no explicit `max_response_bytes` applies an implicit `calculate_safe_response_limit` cap, turning a would-be OOM into a typed error.

### Review hardening (xhigh `/code-review`: 9 finders + adversarial verify + sweep)
The review caught **3 real, self-introduced bugs**, all fixed at root cause:
- **Lazy heap allocation.** `TopKHeap::new` uses `BinaryHeap::new()`, not `with_capacity(skip+limit)` — the eager capacity reserved O(skip) up front (gigabytes for deep pagination over few matches) and, being infallible, aborted/panicked on a huge or `usize::MAX` skip. The heap now grows lazily to the retained docs (≤k).
- **Stable top-k.** `HeapItem` carries a scan-sequence tiebreaker, so on tied sort keys the heap retains and orders the same documents as the old stable full sort + truncate (first-k by scan order), byte-for-byte. The plain `BinaryHeap` was otherwise nondeterministic on ties.
- **Path-independent sort-direction validation.** `validate_sort_directions` runs at every find entry point; previously the top-k and index-sorted paths bypassed `apply_sort`'s validator and silently mis-sorted invalid directions (e.g. `2`).

A fourth concern was **refuted**: `compare_docs_by_sort` / `topk_documents` have no callers outside the find top-k, so the comparator change is scoped (and is itself a pre-existing-inconsistency fix).

### Tests
Top-k correctness (no-index single/multi-field, full-sort & mixed-type reference equality, response-limit) + stable-ties (unit + integration), invalid-direction-rejected-all-paths, extreme-skip-no-panic, and 2 `TopKHeap` unit tests. Full `ironbase-core` suite (45 groups, 0 failed) + clippy + fmt green; `mcp-server` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

O(k) bonyolultságú top-k kupac bevezetése az in-memory `find()` sort+limit művelethez, hogy elkerüljük az összes egyező dokumentum materializálását a csonkolás előtt, miközben a viselkedés azonos marad a meglévő teljes rendezési útvonallal.

Bug Fixes:
- Biztosítja, hogy az in-memory `find()` sort+limit korlátozott memóriát használjon top-k kupacon keresztül, ahelyett hogy előre lefoglalná és rendezné az összes egyező dokumentumot.
- Egységesíti a vegyes típusú rendezési sorrendet a top-k kupac és a teljes in-memory rendezés között, így a top-k eredmények megegyeznek a teljes rendezés prefixével.
- Stabil, beolvasási-sorrend alapú tie-breakert alkalmaz a top-k kupacban, hogy az eredmények stabilak maradjanak azonos rendezési kulcsok esetén.
- Ellenőrzi a rendezési irányokat a `find()` minden belépési pontján, így az érvénytelen irányokat következetesen elutasítja minden végrehajtási útvonalon.
- Implicit, RAM-alapú válaszméret-korlátot vezet be a nem capped in-memory rendezésekre, hogy a potenciális OOM-okat típusos hibákká alakítsa.

Enhancements:
- Egy újrafelhasználható `TopKHeap` absztrakció kinyerése és újrafelhasználása a streaming top-k kiválasztáshoz a `find()` esetén.

Build:
- Az `ironbase-core` és `mcp-ironbase-server` verziók emelése az új viselkedés tükrözésére.

Documentation:
- A top-k kupac új viselkedésének és a `find()` sort+limit védőkorlátainak dokumentálása a changelogban.

Tests:
- Kiterjedt tesztek hozzáadása a top-k helyesség (egymezejű, többmezejű, vegyes típusú), a stabilitás holtverseny esetén, a válaszméret-korlátok, az érvénytelen rendezési irányok, a szélsőséges `skip` viselkedés és a közvetlen `TopKHeap` használat lefedésére.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an O(k) top-k heap for in-memory find() sort+limit to avoid materializing all matched documents before truncation, while keeping behavior identical to the existing full-sort path.

Bug Fixes:
- Ensure find() in-memory sort+limit uses bounded memory via a top-k heap instead of preallocating and sorting all matched documents.
- Unify mixed-type sort ordering between the top-k heap and full in-memory sort so top-k results match the full-sort prefix.
- Apply a stable scan-sequence tiebreaker in the top-k heap so results remain stable on tied sort keys.
- Validate sort directions at all find() entry points so invalid directions are rejected consistently across execution paths.
- Guard uncapped in-memory sorts with an implicit RAM-derived response-size limit to turn potential OOMs into typed errors.

Enhancements:
- Extract a reusable TopKHeap abstraction and reuse it in streaming top-k selection for find().

Build:
- Bump ironbase-core and mcp-ironbase-server versions to reflect the new behavior.

Documentation:
- Document the new top-k heap behavior and safeguards for find() sort+limit in the changelog.

Tests:
- Add extensive tests covering top-k correctness (single-field, multi-field, mixed-type), stability on ties, response-size limits, invalid sort directions, extreme skip behavior, and direct TopKHeap usage.

</details>