### PR TITLE
perf(fulltext): unify search top-k into one bounded helper (P1-4, v1.0.524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — fulltext search top-k unified into one bounded helper; the OR path no longer full-sorts every match (mcp-server v1.0.524, core v0.3.330)
+
+Scalability audit item **P1-4** (100GB+ roadmap). The audit's billing was largely already
+addressed: the smallest-first AND-merge it called for already existed in `search_and_with_ctx`
+(rarest-token-first intersection, scoring only the intersection candidates, plus a Phase-4 top-k
+heap), and the "candidate cap on `doc_scores`" is not applicable — the BM25 score of a doc is the
+sum of its per-token contributions, so every matching doc must be scored (the `doc_scores` /
+`matched` maps are O(N) by nature, as `calculate_candidate_limit`'s own comment notes). The real
+remaining gap was the **OR path** (`search` / `search_with_ctx`, which the `fulltext_search` tool
+uses), which still materialized every scored match into a `Vec` and `sort_unstable_by` + truncated.
+
+- **One bounded top-k helper.** New `FulltextIndex::top_k_scored` selects the best `skip + limit`
+  scored doc_ids via a lazy `BinaryHeap` (no eager `with_capacity(skip+limit)`, mirroring the
+  `find` top-k fix) in O(N log k) time / O(k) memory, ranked score-descending then doc_id-ascending
+  (NaN scores last). All four search paths — `search`, `search_with_ctx`,
+  `search_for_doc_ids_with_ctx`, and the AND `search_and_with_ctx` Phase-4 — now use it, so the
+  full-result `Vec` + O(N log N) sort is gone from the OR paths. (`fulltext.rs`)
+- **Unified tie ordering.** The AND path's old `(OrderedScore, DocumentId)`-reverse heap ordered
+  ties doc_id-*descending*, diverging from the OR path's doc_id-*ascending*. All paths now share
+  `top_k_scored`'s doc_id-ascending tie-break — one deterministic ordering across fulltext search.
+- **Dead code removed.** `compare_search_results` is gone; the heap key reproduces its ordering, so
+  there is one top-k implementation instead of three. The `doc_scores` / `matched` maps remain
+  O(N) — that is fundamental to BM25, not debt.
+
 ### Fixed — `find` sort+limit uses an O(k) top-k heap, no longer materializes every matched doc before truncating (mcp-server v1.0.523, core v0.3.329)
 
 Scalability audit item **P1-5** (100GB+ roadmap). When a `find` has a sort that no single-field

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.329"
+version = "0.3.330"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/fulltext.rs
+++ b/ironbase-core/src/fulltext.rs
@@ -2190,26 +2190,18 @@ impl FulltextIndex {
             return Vec::new();
         }
 
-        let scores = doc_scores;
-
-        // Apply min_score filter
         let min = min_score.unwrap_or(0.0);
 
-        // Sort by score descending
-        let mut results: Vec<_> = scores
+        // Bounded top-k (O(k) memory) instead of materializing + sorting every
+        // matched doc. matched_tokens is attached only to the surviving top-k.
+        Self::top_k_scored(doc_scores, skip, limit, min)
             .into_iter()
-            .filter(|(_, score)| *score >= min)
             .map(|(doc_id, score)| FtsSearchResult {
                 matched_tokens: matched.remove(&doc_id).unwrap_or_default(),
                 doc_id,
                 score,
             })
-            .collect();
-
-        results.sort_unstable_by(Self::compare_search_results);
-
-        // Apply skip and limit
-        results.into_iter().skip(skip).take(limit).collect()
+            .collect()
     }
 
     /// Tokenize query using this index's config (accent folding + stop words + stemming).
@@ -2302,19 +2294,16 @@ impl FulltextIndex {
 
         let min = min_score.unwrap_or(0.0);
 
-        let mut results: Vec<_> = doc_scores
+        // Bounded top-k (O(k) memory) instead of materializing + sorting every
+        // matched doc. matched_tokens is attached only to the surviving top-k.
+        Ok(Self::top_k_scored(doc_scores, skip, limit, min)
             .into_iter()
-            .filter(|(_, score)| *score >= min)
             .map(|(doc_id, score)| FtsSearchResult {
                 matched_tokens: matched.remove(&doc_id).unwrap_or_default(),
                 doc_id,
                 score,
             })
-            .collect();
-
-        results.sort_unstable_by(Self::compare_search_results);
-
-        Ok(results.into_iter().skip(skip).take(limit).collect())
+            .collect())
     }
 
     /// Fulltext search pre-filtered by target doc_ids using chunk_doc_mapping.
@@ -2407,19 +2396,16 @@ impl FulltextIndex {
 
         let min = min_score.unwrap_or(0.0);
 
-        let mut results: Vec<_> = doc_scores
+        // Bounded top-k (O(k) memory) instead of materializing + sorting every
+        // matched doc. matched_tokens is attached only to the surviving top-k.
+        Ok(Self::top_k_scored(doc_scores, skip, limit, min)
             .into_iter()
-            .filter(|(_, score)| *score >= min)
             .map(|(doc_id, score)| FtsSearchResult {
                 matched_tokens: matched.remove(&doc_id).unwrap_or_default(),
                 doc_id,
                 score,
             })
-            .collect();
-
-        results.sort_unstable_by(Self::compare_search_results);
-
-        Ok(results.into_iter().skip(skip).take(limit).collect())
+            .collect())
     }
 
     /// AND-optimized fulltext search: intersects posting lists before scoring.
@@ -2520,69 +2506,63 @@ impl FulltextIndex {
 
         let min = min_score.unwrap_or(0.0);
         let all_tokens: Vec<String> = query_tokens;
-        let effective_limit = skip + limit;
 
-        // Phase 4: Top-K selection with BinaryHeap (O(N log k) instead of O(N log N))
-        // Heap stores (Reverse(score), doc_id) — min-heap by score so we can evict smallest
-        let mut heap: BinaryHeap<std::cmp::Reverse<(OrderedScore, DocumentId)>> =
-            BinaryHeap::with_capacity(effective_limit + 1);
+        // Phase 4: bounded top-k, shared with the OR paths via top_k_scored for
+        // identical tie ordering (score desc, doc_id asc) and memory bounds. Every
+        // AND-qualified doc matches all query tokens, so matched_tokens = all_tokens.
+        Ok(Self::top_k_scored(doc_scores, skip, limit, min)
+            .into_iter()
+            .map(|(doc_id, score)| FtsSearchResult {
+                matched_tokens: all_tokens.clone(),
+                doc_id,
+                score,
+            })
+            .collect())
+    }
 
-        for (doc_id, score) in &doc_scores {
-            if *score < min {
+    /// Bounded top-k selection over scored doc_ids — O(N log k) time, O(k) memory.
+    ///
+    /// Returns the best `skip + limit` results ranked by score descending, then
+    /// doc_id ascending on ties (NaN scores sorted last via `OrderedScore`), with
+    /// `skip` applied. Shared by every search path (OR `search`/`search_with_ctx`
+    /// and AND `search_and_with_ctx`) so they bound memory identically and agree on
+    /// tie ordering — no full-result `Vec` + O(N log N) sort.
+    ///
+    /// The heap grows lazily (no eager `with_capacity(skip+limit)`, which could
+    /// over-allocate or panic on a pathological skip — see the `find` top-k fix).
+    fn top_k_scored<I>(scored: I, skip: usize, limit: usize, min: f64) -> Vec<(DocumentId, f64)>
+    where
+        I: IntoIterator<Item = (DocumentId, f64)>,
+    {
+        use std::cmp::Reverse;
+        let k = skip.saturating_add(limit);
+        if k == 0 {
+            return Vec::new();
+        }
+        // Max-heap keyed by (Reverse<score>, doc_id): the top is the WORST of the
+        // current best-k (lowest score, or highest doc_id on a tie) and is evicted
+        // first. A smaller key = a better result, so `into_sorted_vec` (ascending)
+        // yields best-first = score desc, doc_id asc (NaN scores sort last).
+        let mut heap: BinaryHeap<(Reverse<OrderedScore>, DocumentId)> = BinaryHeap::new();
+        for (doc_id, score) in scored {
+            if score < min {
                 continue;
             }
-            let ordered = OrderedScore(*score);
-            if heap.len() < effective_limit {
-                heap.push(std::cmp::Reverse((ordered, doc_id.clone())));
-            } else if let Some(&std::cmp::Reverse((ref min_in_heap, _))) = heap.peek() {
-                if ordered > *min_in_heap {
+            let key = (Reverse(OrderedScore(score)), doc_id);
+            if heap.len() < k {
+                heap.push(key);
+            } else if let Some(top) = heap.peek() {
+                if key < *top {
                     heap.pop();
-                    heap.push(std::cmp::Reverse((ordered, doc_id.clone())));
+                    heap.push(key);
                 }
             }
         }
-
-        // Extract results from heap in descending score order
-        let mut results: Vec<FtsSearchResult> = heap
-            .into_sorted_vec()
+        heap.into_sorted_vec()
             .into_iter()
-            .map(
-                |std::cmp::Reverse((ordered_score, doc_id))| FtsSearchResult {
-                    matched_tokens: all_tokens.clone(),
-                    doc_id,
-                    score: ordered_score.0,
-                },
-            )
-            .collect();
-
-        // Reverse because into_sorted_vec gives ascending order
-        results.reverse();
-
-        // Apply skip
-        Ok(results.into_iter().skip(skip).take(limit).collect())
-    }
-
-    /// Compare two search results for sorting (score descending, doc_id ascending)
-    ///
-    /// Handles NaN scores by treating them as lowest relevance (sorted to end).
-    /// This ensures deterministic ordering even with corrupted/invalid scores.
-    fn compare_search_results(a: &FtsSearchResult, b: &FtsSearchResult) -> std::cmp::Ordering {
-        use std::cmp::Ordering;
-
-        match (a.score.is_nan(), b.score.is_nan()) {
-            // Both NaN: fall back to doc_id ordering
-            (true, true) => a.doc_id.cmp(&b.doc_id),
-            // a is NaN: a goes to end (is "greater" in descending sort)
-            (true, false) => Ordering::Greater,
-            // b is NaN: b goes to end (a is "less" = comes first)
-            (false, true) => Ordering::Less,
-            // Normal comparison: score descending, doc_id ascending as tiebreaker
-            (false, false) => b
-                .score
-                .partial_cmp(&a.score)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| a.doc_id.cmp(&b.doc_id)),
-        }
+            .skip(skip)
+            .map(|(Reverse(score), doc_id)| (doc_id, score.0))
+            .collect()
     }
 
     /// Check if a document is in the index
@@ -4059,6 +4039,42 @@ mod tests {
         assert_eq!(last2.len(), 2);
 
         // Cleanup
+        let _ = std::fs::remove_file(&temp_dir);
+    }
+
+    /// P1-4: the bounded top-k (top_k_scored) must (a) break score ties
+    /// deterministically by doc_id ascending, and (b) return exactly the full-sort
+    /// prefix for any limit — i.e. the heap changes neither the set nor the order
+    /// vs the old materialize+sort+truncate.
+    #[test]
+    fn test_fulltext_topk_bounded_and_stable_ties() {
+        let options = FtsOptions::new(FtsLanguage::None);
+        let temp_dir = std::env::temp_dir().join("fts_test_topk_ties.ftidx");
+        let mut index =
+            FulltextIndex::new_with_storage("idx", "content", options, temp_dir.clone()).unwrap();
+
+        // 9 docs with identical content → identical BM25 score → all tie on score.
+        for i in 1..=9 {
+            index.insert(&DocumentId::Int(i), "apple").unwrap();
+        }
+
+        // (a) all-tie top-3 is deterministic, doc_id ascending.
+        let top3 = index.search("apple", 3, 0, None);
+        assert_eq!(top3.len(), 3);
+        assert_eq!(top3[0].doc_id, DocumentId::Int(1));
+        assert_eq!(top3[1].doc_id, DocumentId::Int(2));
+        assert_eq!(top3[2].doc_id, DocumentId::Int(3));
+
+        // (b) bounded top-k == full-sort prefix for every limit.
+        let full = index.search("apple", 100, 0, None);
+        assert_eq!(full.len(), 9);
+        for k in [1usize, 4, 8] {
+            let topk = index.search("apple", k, 0, None);
+            let ref_ids: Vec<_> = full.iter().take(k).map(|r| r.doc_id.clone()).collect();
+            let topk_ids: Vec<_> = topk.iter().map(|r| r.doc_id.clone()).collect();
+            assert_eq!(topk_ids, ref_ids, "top-{} must equal full-sort prefix", k);
+        }
+
         let _ = std::fs::remove_file(&temp_dir);
     }
 

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.523"
+version = "1.0.524"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## P1-4 · Fulltext search top-k unified into one bounded helper

Scalability audit **P1-4** (100GB+ roadmap). The audit's billing was largely **already addressed** — the smallest-first AND-merge it called for already existed in `search_and_with_ctx` (rarest-token-first intersection, scoring only the intersection candidates, plus a Phase-4 top-k heap), and the "candidate cap on `doc_scores`" is **not applicable**: a doc's BM25 score is the sum of its per-token contributions, so every matching doc must be scored (the `doc_scores`/`matched` maps are O(N) by nature, as `calculate_candidate_limit`'s own comment notes).

The real remaining gap was the **OR path** (`search`/`search_with_ctx`, used by the `fulltext_search` tool), which still materialized every scored match into a `Vec`, `sort_unstable_by`, then truncated.

### Following the least-tech-debt principle, this consolidates rather than adds
- **One bounded top-k helper.** New `FulltextIndex::top_k_scored` selects the best `skip + limit` scored doc_ids via a lazy `BinaryHeap` (no eager `with_capacity(skip+limit)`, mirroring the `find` top-k fix) in O(N log k) time / O(k) memory, ranked score-descending then doc_id-ascending (NaN scores last). All **four** search paths (`search`, `search_with_ctx`, `search_for_doc_ids_with_ctx`, and the AND `search_and_with_ctx` Phase-4) now use it — the full-result `Vec` + O(N log N) sort is gone from the OR paths.
- **Unified tie ordering.** The AND path's old `(OrderedScore, DocumentId)`-reverse heap ordered ties doc_id-*descending*, diverging from the OR path's doc_id-*ascending*. All paths now share `top_k_scored`'s doc_id-ascending tie-break — one deterministic ordering across fulltext search.
- **Dead code removed.** `compare_search_results` is gone (the heap key reproduces its ordering), so there is **one** top-k implementation instead of three.

`doc_scores`/`matched` stay O(N) — fundamental to BM25, not debt.

### Tests
New `test_fulltext_topk_bounded_and_stable_ties` (all-tie set → doc_id-ascending top-k; bounded top-k == full-sort prefix for every limit). Full `ironbase-core` suite + `mcp-server` tests (hybrid search consumes `search_and`) + clippy + fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Egységesíti a fulltext keresés top-k kiválasztását az OR és AND ágak között egy közös, korlátozott segédfüggvény használatával a memóriahasználat csökkentése és a konzisztens rendezés biztosítása érdekében.

Fejlesztések:
- Lecseréli a fulltext OR és AND keresési eredmények materializálását és teljes rendezését egy közös, korlátozott top-k kupac segédfüggvényre, amely csak a kért eredményablakot adja vissza determinisztikus döntetlenfeloldással.
- Egységesíti a döntetlenfeloldást minden fulltext keresési ágon úgy, hogy pontszám szerint csökkenő, majd `doc_id` szerint növekvő rendezést használ, beleértve a NaN-kezelést is, és eltávolítja a mostanra feleslegessé vált összehasonlító segédfüggvényt.
- Hozzáad egy regressziós tesztet a korlátozott top-k viselkedés és a stabil döntetlenkezelés ellenőrzésére a fulltext keresési eredményeknél.

Dokumentáció:
- Dokumentálja az egységesített, korlátozott top-k viselkedést és az OR-ág teljesítményváltozását a changelogban.

Teszek:
- Hozzáad egy fulltext keresési tesztet, amely ellenőrzi a determinisztikus döntetlenfeloldást, valamint azt, hogy a korlátozott top-k eredmények megegyeznek a teljesen rendezett eredmények prefixével.

Karbantartás:
- Frissíti a core crate verzióját 0.3.330-ra és az mcp szerver verzióját 1.0.524-re.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify fulltext search top-k selection across OR and AND paths using a shared bounded helper to reduce memory usage and ensure consistent ordering.

Enhancements:
- Replace fulltext OR and AND search result materialization and full sorting with a shared bounded top-k heap helper that returns only the requested window of results with deterministic tie-breaking.
- Align tie-breaking across all fulltext search paths to use score-descending and doc_id-ascending ordering, including NaN-handling, and remove the now-redundant comparison helper.
- Add a regression test to verify bounded top-k behavior and stable tie ordering for fulltext search results.

Documentation:
- Document the unified bounded top-k behavior and OR-path performance change in the changelog.

Tests:
- Add a fulltext search test that validates deterministic tie-breaking and that bounded top-k results match the prefix of the fully sorted results.

Chores:
- Bump core crate version to 0.3.330 and mcp server version to 1.0.524.

</details>