### PR TITLE
refactor(fulltext): delegate top_k_scored to the shared generic top-k (P1-4 follow-up, v1.0.525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — fulltext `top_k_scored` now delegates to the shared generic top-k instead of a private heap (mcp-server v1.0.525, core v0.3.331)
+
+P1-4 code-review follow-up. The previous commit added a fulltext-private `BinaryHeap<(Reverse<OrderedScore>, DocumentId)>` for `top_k_scored`, but the codebase already has a generic comparator-based bounded top-k (`collection_core::topk::topk_select_with_skip`) that the sibling `collection_core/search.rs` already uses for score-based `(doc_id, f64)` selection. This commit removes the duplicate, finishing the consolidation the P1-4 change set out to do.
+
+- **Delegate to the generic helper.** `FulltextIndex::top_k_scored` now calls `topk_select_with_skip(scored.filter(|s| s >= min), skip, limit, cmp)` with a `(score desc, doc_id asc)` comparator. `mod topk` is now `pub(crate)` so `fulltext.rs` can reach it. One bounded-top-k implementation fewer to keep in sync. (`fulltext.rs`, `collection_core/mod.rs`)
+- **Dead code removed.** The private `OrderedScore` wrapper and the now-unused `BinaryHeap` import are gone (the comparator closure subsumes them).
+- **NaN handling restored to the OR-path's original semantics.** The pre-filter `filter(|(_, s)| *s >= min)` drops NaN scores (`NaN >= min` is false), matching the OR paths' behaviour before P1-4 (the interim private heap had kept NaN and sorted it last). Unreachable in practice — BM25 `term_score` cannot produce NaN — but it removes a latent semantic drift the review flagged.
+
 ### Changed — fulltext search top-k unified into one bounded helper; the OR path no longer full-sorts every match (mcp-server v1.0.524, core v0.3.330)
 
 Scalability audit item **P1-4** (100GB+ roadmap). The audit's billing was largely already

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.330"
+version = "0.3.331"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/mod.rs
+++ b/ironbase-core/src/collection_core/mod.rs
@@ -209,7 +209,7 @@ mod query_executor;
 mod raw_operations;
 pub(crate) mod schema;
 mod search;
-mod topk;
+pub(crate) mod topk;
 mod tx;
 mod update_operators;
 mod vector_ops;

--- a/ironbase-core/src/fulltext.rs
+++ b/ironbase-core/src/fulltext.rs
@@ -19,7 +19,7 @@ use crate::error::{IronBaseError, Result};
 use crate::log_error;
 use rust_stemmers::{Algorithm, Stemmer};
 use serde::{Deserialize, Serialize};
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
@@ -921,32 +921,6 @@ pub struct FtsSearchResult {
     pub doc_id: DocumentId,
     pub score: f64,
     pub matched_tokens: Vec<String>,
-}
-
-/// Wrapper for f64 scores that implements Ord (required for BinaryHeap).
-/// NaN is treated as less than any valid score.
-#[derive(Clone, Debug, PartialEq)]
-struct OrderedScore(f64);
-
-impl Eq for OrderedScore {}
-
-impl PartialOrd for OrderedScore {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for OrderedScore {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0
-            .partial_cmp(&other.0)
-            .unwrap_or_else(|| match (self.0.is_nan(), other.0.is_nan()) {
-                (true, true) => std::cmp::Ordering::Equal,
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                _ => unreachable!(),
-            })
-    }
 }
 
 /// BM25 scoring context — shared across all fulltext search methods.
@@ -2520,49 +2494,35 @@ impl FulltextIndex {
             .collect())
     }
 
-    /// Bounded top-k selection over scored doc_ids — O(N log k) time, O(k) memory.
+    /// Bounded top-k selection over scored doc_ids — O((skip+limit) memory),
+    /// O(N log(skip+limit)) time.
     ///
     /// Returns the best `skip + limit` results ranked by score descending, then
-    /// doc_id ascending on ties (NaN scores sorted last via `OrderedScore`), with
-    /// `skip` applied. Shared by every search path (OR `search`/`search_with_ctx`
-    /// and AND `search_and_with_ctx`) so they bound memory identically and agree on
-    /// tie ordering — no full-result `Vec` + O(N log N) sort.
+    /// doc_id ascending on ties, with `skip` applied. Sub-threshold scores are
+    /// filtered first; `NaN >= min` is false, so NaN scores are excluded — matching
+    /// the OR path's former `filter(|s| s >= min)`. Shared by every search path
+    /// (OR `search`/`search_with_ctx`/`search_for_doc_ids_with_ctx` and AND
+    /// `search_and_with_ctx`) so they agree on tie ordering and memory bounds — no
+    /// full-result `Vec` + O(N log N) sort.
     ///
-    /// The heap grows lazily (no eager `with_capacity(skip+limit)`, which could
-    /// over-allocate or panic on a pathological skip — see the `find` top-k fix).
+    /// Delegates to the crate-wide generic `topk_select_with_skip` (one bounded
+    /// top-k implementation) rather than a fulltext-private heap.
     fn top_k_scored<I>(scored: I, skip: usize, limit: usize, min: f64) -> Vec<(DocumentId, f64)>
     where
         I: IntoIterator<Item = (DocumentId, f64)>,
     {
-        use std::cmp::Reverse;
-        let k = skip.saturating_add(limit);
-        if k == 0 {
-            return Vec::new();
-        }
-        // Max-heap keyed by (Reverse<score>, doc_id): the top is the WORST of the
-        // current best-k (lowest score, or highest doc_id on a tie) and is evicted
-        // first. A smaller key = a better result, so `into_sorted_vec` (ascending)
-        // yields best-first = score desc, doc_id asc (NaN scores sort last).
-        let mut heap: BinaryHeap<(Reverse<OrderedScore>, DocumentId)> = BinaryHeap::new();
-        for (doc_id, score) in scored {
-            if score < min {
-                continue;
-            }
-            let key = (Reverse(OrderedScore(score)), doc_id);
-            if heap.len() < k {
-                heap.push(key);
-            } else if let Some(top) = heap.peek() {
-                if key < *top {
-                    heap.pop();
-                    heap.push(key);
-                }
-            }
-        }
-        heap.into_sorted_vec()
-            .into_iter()
-            .skip(skip)
-            .map(|(Reverse(score), doc_id)| (doc_id, score.0))
-            .collect()
+        crate::collection_core::topk::topk_select_with_skip(
+            scored.into_iter().filter(|(_, score)| *score >= min),
+            skip,
+            limit,
+            // Score descending, doc_id ascending on ties (matches the former
+            // compare_search_results; NaN is already excluded by the filter).
+            |a: &(DocumentId, f64), b: &(DocumentId, f64)| {
+                b.1.partial_cmp(&a.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.0.cmp(&b.0))
+            },
+        )
     }
 
     /// Check if a document is in the index

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.524"
+version = "1.0.525"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
P1-4 `/code-review` follow-up (finding #1, REUSE). The P1-4 commit added a fulltext-private bounded heap, but the codebase already has a generic comparator-based bounded top-k (`collection_core::topk::topk_select_with_skip`) that the sibling `search.rs` already uses for score-based `(doc_id, f64)` selection. This finishes the consolidation — one bounded-top-k impl fewer.

- `top_k_scored` delegates to `topk_select_with_skip(scored.filter(|s| s >= min), skip, limit, score-desc/doc_id-asc cmp)`; `mod topk` is now `pub(crate)`.
- Removed the private `OrderedScore` wrapper + unused `BinaryHeap` import.
- The `filter(|s| s >= min)` drops NaN, restoring the OR paths' pre-P1-4 semantics (unreachable in practice — BM25 can't produce NaN — but removes the drift the review flagged).

Net −66/+34. Full core + mcp-server suites + clippy + fmt green; fulltext suite unchanged and green (behavior-identical for finite scores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

A teljes szöveges (fulltext) top-k kiválasztást áthelyezzük a megosztott, generikus, korlátos top-k segédfüggvényre, és a NaN-kezelést, valamint a holtverseny-felbontást (tie-breaking) összehangoljuk a gyűjtemény-mag (collection core) többi részével.

Fejlesztések:
- A `FulltextIndex::top_k_scored` refaktorálása úgy, hogy egy privát, `BinaryHeap`-alapú implementáció helyett a `collection_core::topk::topk_select_with_skip`-et használja, egységesítve a korlátos top-k logikát a modulok között.
- A fulltext-specifikus `OrderedScore` wrapper és a hozzá kapcsolódó, immár fölösleges kód eltávolítása, mivel ezeket a generikus, komparátor-alapú segédfüggvény váltja ki.
- A `collection_core::topk` modul `pub(crate)`-ként való kiexportálása, hogy a fulltext keresés újra tudja használni, miközben a belső láthatóság megmarad.

Build:
- Az `ironbase-core` crate verziójának frissítése 0.3.331-re és a `mcp-ironbase-server`-é 1.0.525-re, a refaktor tükrözéseként.

Dokumentáció:
- A top-k refaktor és a viselkedés-összehangolás dokumentálása a changelogban, beleértve a NaN szűrési szemantikáját, valamint a core és az mcp-server verziónöveléseit.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Delegate fulltext top-k selection to the shared generic bounded top-k helper and align NaN handling and tie-breaking with the rest of the collection core.

Enhancements:
- Refactor `FulltextIndex::top_k_scored` to use `collection_core::topk::topk_select_with_skip` instead of a private BinaryHeap-based implementation, unifying bounded top-k logic across modules.
- Remove the fulltext-specific `OrderedScore` wrapper and related dead code now subsumed by the generic comparator-based helper.
- Expose the `collection_core::topk` module as `pub(crate)` so it can be reused by fulltext search while preserving internal visibility.

Build:
- Bump `ironbase-core` crate version to 0.3.331 and `mcp-ironbase-server` to 1.0.525 to reflect the refactor.

Documentation:
- Document the top-k refactor and behavior alignment in the changelog, including NaN filtering semantics and version bumps for core and mcp-server.

</details>