### PR TITLE
fix(find): apply projection on the _id fast path (was silently ignored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `find` `_id` fast path now applies `projection` (was silently ignored) (mcp-server v1.0.526, core v0.3.332)
+
+A code-review of the core fast-path system found that `find_with_options`'s `_id` and `_id $in`
+fast paths (taken when `sort` is absent) returned the **full document**, never applying
+`options.projection` — the projection was only *validated* at the function top, then dropped. The
+slow path (taken when a sort is present) applies it. So the same `{"_id": 5}` query with a
+projection returned different shapes depending on whether a sort was present, and a caller
+projecting out a large/sensitive field would still receive it on the fast path.
+
+- **Fix:** both `_id` fast-path branches now apply the existing `find_options::apply_projection`
+  (a no-op when no projection is set) before returning — identical to the slow path. The common
+  projection-less `_id` lookup stays O(1) with zero overhead. (`collection_core/mod.rs`)
+- **Test:** new `test_id_fast_path_applies_projection` asserts the fast path projects and that the
+  fast-path and slow-path (`+sort`) results are byte-identical — the path that was previously
+  uncovered by any test.
+- **Doc cleanup:** removed a stale `search_and_with_ctx` comment that still referenced the private
+  top-k heap deleted in the v1.0.525 delegation. (`fulltext.rs`)
+
 ### Changed — fulltext `top_k_scored` now delegates to the shared generic top-k instead of a private heap (mcp-server v1.0.525, core v0.3.331)
 
 P1-4 code-review follow-up. The previous commit added a fulltext-private `BinaryHeap<(Reverse<OrderedScore>, DocumentId)>` for `top_k_scored`, but the codebase already has a generic comparator-based bounded top-k (`collection_core::topk::topk_select_with_skip`) that the sibling `collection_core/search.rs` already uses for score-based `(doc_id, f64)` selection. This commit removes the duplicate, finishing the consolidation the P1-4 change set out to do.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.331"
+version = "0.3.332"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/mod.rs
+++ b/ironbase-core/src/collection_core/mod.rs
@@ -932,19 +932,29 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
         // FAST PATH: Direct _id lookup O(1)
         // FIX #5-6: When query is {"_id": value}, skip catalog scanning entirely.
         // Uses normalize_document_id to handle string/int conversion.
-        // Note: _id queries always return max 1 doc, so skip/limit don't matter.
+        // Note: _id queries always return max 1 doc, so skip/limit don't matter,
+        // but `projection` still applies — it must match the slow path exactly,
+        // else the same query yields a different shape with vs without a sort.
         // ====================================================================
         // Single _id query - always fast path (returns 0 or 1 doc)
         if options.sort.is_none() {
+            // Apply the same projection the slow path would (no-op when unset).
+            let project = |doc: Value| -> Result<Value> {
+                match &options.projection {
+                    Some(proj) => crate::find_options::apply_projection(&doc, proj),
+                    None => Ok(doc),
+                }
+            };
+
             if let Some(doc_id) = Self::extract_id_query(query_json) {
                 // Try original ID first
                 if let Some(doc) = self.read_document_by_id(&doc_id)? {
-                    return Ok(vec![doc]);
+                    return Ok(vec![project(doc)?]);
                 }
                 // Try normalized version (string "123" → int 123)
                 if let Some(normalized) = Self::normalize_document_id(&doc_id) {
                     if let Some(doc) = self.read_document_by_id(&normalized)? {
-                        return Ok(vec![doc]);
+                        return Ok(vec![project(doc)?]);
                     }
                 }
                 return Ok(Vec::new());
@@ -962,10 +972,10 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                 })?;
                 for doc_id in doc_ids {
                     if let Some(doc) = self.read_document_by_id(&doc_id)? {
-                        results.push(doc);
+                        results.push(project(doc)?);
                     } else if let Some(normalized) = Self::normalize_document_id(&doc_id) {
                         if let Some(doc) = self.read_document_by_id(&normalized)? {
-                            results.push(doc);
+                            results.push(project(doc)?);
                         }
                     }
                 }

--- a/ironbase-core/src/fulltext.rs
+++ b/ironbase-core/src/fulltext.rs
@@ -2390,7 +2390,8 @@ impl FulltextIndex {
     /// O(sum_posting_sizes) to O(min_posting_size * num_tokens) for the
     /// intersection phase, plus O(intersection_size * num_tokens) for scoring.
     ///
-    /// Uses a Top-K binary heap instead of full sort for O(N log k) vs O(N log N).
+    /// Uses bounded top-k selection (`top_k_scored`) instead of a full sort for
+    /// O(N log k) vs O(N log N).
     ///
     /// Falls back to `search_with_ctx` for single-token queries.
     pub fn search_and_with_ctx(

--- a/ironbase-core/tests/early_projection_tests.rs
+++ b/ironbase-core/tests/early_projection_tests.rs
@@ -67,6 +67,63 @@ fn test_early_projection_no_sort() {
     }
 }
 
+/// Fast-path projection (review fix): an `_id` query with a projection must APPLY
+/// the projection — the `_id` fast path previously returned the FULL document —
+/// and the result must be identical with vs without a sort (fast path vs slow path).
+#[test]
+fn test_id_fast_path_applies_projection() {
+    let db = create_memory_db();
+    let coll_name = "test";
+    let id = db
+        .insert_one(
+            coll_name,
+            HashMap::from([
+                ("name".to_string(), json!("Alice")),
+                ("secret".to_string(), json!("hidden")),
+                ("age".to_string(), json!(30)),
+            ]),
+        )
+        .unwrap();
+    let id_q = match id {
+        ironbase_core::DocumentId::Int(n) => json!(n),
+        ironbase_core::DocumentId::String(s) => json!(s),
+        other => panic!("unexpected id type: {:?}", other),
+    };
+
+    let coll = db.collection(coll_name).unwrap();
+    let proj = HashMap::from([("name".to_string(), 1)]);
+
+    // _id fast path (no sort): projection MUST apply → only _id + name.
+    let fast = coll
+        .find_with_options(
+            &json!({ "_id": id_q }),
+            FindOptions::new().with_projection(proj.clone()),
+        )
+        .unwrap();
+    assert_eq!(fast.len(), 1);
+    assert!(fast[0].get("name").is_some());
+    assert!(fast[0].get("_id").is_some());
+    assert!(
+        fast[0].get("secret").is_none(),
+        "secret must be projected out on the _id fast path"
+    );
+    assert!(fast[0].get("age").is_none());
+
+    // Same query WITH a sort → slow path; the shape must be identical.
+    let slow = coll
+        .find_with_options(
+            &json!({ "_id": id_q }),
+            FindOptions::new()
+                .with_projection(proj)
+                .with_sort(vec![("name".to_string(), 1)]),
+        )
+        .unwrap();
+    assert_eq!(
+        slow, fast,
+        "fast-path and slow-path _id projection must agree"
+    );
+}
+
 #[test]
 fn test_early_projection_sort_included_in_projection() {
     // Early projection should be applied when sort field is in projection

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.525"
+version = "1.0.526"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
A `/code-review` of the core fast-path system found that `find_with_options`'s `_id` / `_id $in` fast paths (taken when no sort) returned the **full document**, never applying `options.projection` — only validated, then dropped. The slow path (sort present) applies it, so the same `{"_id":5}` + projection returned different shapes with vs without a sort, and a caller projecting out a large/sensitive field still received it.

- Both `_id` fast-path branches now apply `find_options::apply_projection` (no-op when unset) before returning — identical to the slow path. Projection-less `_id` lookup stays O(1), zero overhead.
- New `test_id_fast_path_applies_projection`: fast path projects + fast==slow(+sort) byte-for-byte (the previously uncovered path).
- Doc cleanup: stale `search_and_with_ctx` comment referencing the removed private heap.

Audit also flagged a CountByField count-loop lacking catalog-validation — left as documented defense-in-depth debt (does NOT bypass $match; a guard there is lock-order-sensitive vs the storage lock, #75 ABBA class).

Full ironbase-core suite + clippy + fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Biztosítja, hogy az `_id` gyorsított elérési útvonalat használó `find` lekérdezések figyelembe vegyék a projekciókat, és a viselkedésük összhangban maradjon a lassú útvonallal, miközben ennek megfelelően frissülnek a dokumentációk, a tesztek és a verziók.

Hibajavítások:
- A konfigurált projekciók alkalmazása az `_id` és `_id $in` gyorsított elérési útvonalat használó lekérdezésekre a `find_with_options` függvényben, hogy többé ne teljes dokumentumokat adjanak vissza, amikor projekció van megadva.

Build:
- A workspace csomag verziójának frissítése 0.3.332-re, valamint az mcp-ironbase-server frissítése 1.0.526-ra a változások tükrözése érdekében.

Dokumentáció:
- A teljes szöveges `search_and_with_ctx` dokumentáció pontosítása, hogy bináris kupac helyett korlátozott top-k kiválasztásra hivatkozzon.
- Az `_id` gyorsított elérési útvonal projekciós javításának dokumentálása, valamint az új core és server verziók alatti kiadás feltüntetése a changelogban.

Tesztek:
- Regressziós teszt hozzáadása annak ellenőrzésére, hogy az `_id` gyorsított elérési útvonal alkalmazza a projekciót, és bájtonként egyező eredmény-struktúrát ad a lassú útvonallal (+rendezés) összevetve.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure find `_id` fast-path queries honor projections and keep behavior consistent with the slow path, while updating docs, tests, and versions accordingly.

Bug Fixes:
- Apply configured projections to `_id` and `_id $in` fast-path lookups in `find_with_options` so they no longer return full documents when a projection is specified.

Build:
- Bump workspace package version to 0.3.332 and mcp-ironbase-server to 1.0.526 to reflect the changes.

Documentation:
- Clarify full-text `search_and_with_ctx` documentation to reference bounded top-k selection instead of a binary heap.
- Document the `_id` fast-path projection fix and release it under new core and server versions in the changelog.

Tests:
- Add a regression test verifying the `_id` fast path applies projection and matches the slow-path (+sort) result shape byte-for-byte.

</details>