### PR TITLE
fix(query): query-planner correctness — 11 count/find divergence & incomplete-result bugs (v1.0.527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — query-planner correctness: 11 count/find divergence & incomplete-result bugs (mcp-server v1.0.527, core v0.3.333)
+
+A multi-agent review of the query planner (`ironbase-core/src/query_planner.rs` and its
+consumers `count.rs` / `collection_core/mod.rs` / `cursor.rs` / `index/btree.rs` / `index/key.rs`)
+found and fixed 11 verified bugs. The umbrella cause for most: `count_documents`'s
+fully-covered fast path trusts the index plan **without re-verifying** against the query, while
+`find` always post-filters — so the two silently diverged.
+
+- **`$in` with an object/array element** collapsed to `IndexKey::Null` (the audit #27-A
+  `is_indexable_value` guard existed only for equality). `collect_in_candidates` now skips the
+  candidate so the collection scan does proper deep equality.
+- **`$in` with duplicate values** double-counted on the fast path → planner now dedups keys.
+- **`$and` of two same-field membership ops** (`{$in}∧{$in}`, `{$ne}∧{$ne}`) silently dropped
+  the first via a serde-map overwrite → `resolve_range_conditions` bails out on operator collision.
+- **`query_fully_covered_by_plan`** only checked the field *name*; an operator the plan does not
+  encode (e.g. `{$gte,$ne}`, `{$in,$gte}`, `{$gte,$type}`) was dropped → it now requires the plan
+  to cover **every** operator on the field, else routes through the post-filter path.
+- **Case-insensitive index** was eligible for case-sensitive equality/range/regex selection (its
+  lowercased keys miss uppercase values) → CI indexes are now excluded from CS index selection
+  (usable only in the `(?i)` regex branch).
+- **Regex prefix upper bound** was `prefix + U+10FFFF` *inclusive*, dropping values of the form
+  `prefix + U+10FFFF + …` → now a true half-open `[prefix, successor)` bound.
+- **Non-exact / case-insensitive regex count** used the raw range count (no pattern re-check) →
+  now routed through the index-narrowed post-filter (also makes `explain` honest and uses the
+  index for `^a.*` counts instead of a full scan).
+- **Numeric range over a field mixing integers and floats**: `IndexKey` orders all `Int` below
+  all `Float`, so `[Int(18), Int(65)]` never reached `Float` keys — `find`/`count` silently
+  dropped fractional/`x.0`-float docs. Range scans now cover **both** the Int and Float buckets
+  (`numeric_range_buckets`), in find, count, and the streaming cursor.
+- **Mixed-type range** (`{$gte: 5, $lte: "z"}`) over-counted the fast path → `analyze_range_query_v2`
+  now rejects type-mismatched bounds (mirrors the merge-path guard).
+- **Multikey (array) index** counted index *entries*, not distinct documents, on the fast path →
+  multikey plans now use the index-narrowed path, which dedups doc_ids up front.
+
+Internal-only: all new helpers are `pub(crate)`; the public crate API is unchanged. Known
+limitation (documented, not fixed): a case-insensitive index keys with `str::to_lowercase` while
+`(?i)` regex matches with Unicode case folding — they diverge for a few non-ASCII scalars
+(Greek final sigma, `İ`, `ß`); no impact on ASCII / Hungarian-accented data.
+
 ### Fixed — `find` `_id` fast path now applies `projection` (was silently ignored) (mcp-server v1.0.526, core v0.3.332)
 
 A code-review of the core fast-path system found that `find_with_options`'s `_id` and `_id $in`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.332"
+version = "0.3.333"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/count.rs
+++ b/ironbase-core/src/collection_core/count.rs
@@ -26,22 +26,49 @@ fn max_string_key() -> IndexKey {
 use crate::document::{Document, DocumentId};
 use crate::error::{IronBaseError, Result};
 use crate::execution::ExecutionContext;
-use crate::index::{IndexKey, RangeQueryMode, ScanOrder};
+use crate::index::{
+    numeric_range_buckets, prefix_scan_upper_bound, IndexKey, IndexManager, RangeQueryMode,
+    ScanOrder,
+};
 use crate::query::Query;
 use crate::query_planner::{QueryPlan, QueryPlanner};
 use crate::storage::{RawStorage, Storage};
 
 use super::CollectionCore;
 
+/// Operators that a plan provably encodes in its index range/keys.
+///
+/// The fully-covered count fast path (`count_range_validated`) does NOT
+/// post-filter, so it is only safe when EVERY operator on the indexed field is
+/// in this set. Any other operator (e.g. a `$ne` next to a range, a second
+/// membership op, a `$type`) would be silently dropped, making count diverge
+/// from `find` (audit 2026-06-06 finding B).
+fn plan_covered_operators(plan: &QueryPlan) -> &'static [&'static str] {
+    match plan {
+        QueryPlan::IndexScan { .. } => &["$eq"],
+        QueryPlan::MultiValueScan { .. } => &["$in"],
+        QueryPlan::IndexRangeScan { .. } => &["$gt", "$gte", "$lt", "$lte"],
+        QueryPlan::RegexPrefixScan { .. } | QueryPlan::MultiRegexPrefixScan { .. } => {
+            &["$regex", "$options"]
+        }
+        QueryPlan::SparseIndexScan { .. } => &["$exists"],
+    }
+}
+
 /// Check if the query is fully covered by the index plan's field.
 ///
-/// Returns true when the query only has conditions on the field that the
-/// index covers — meaning the index count alone is accurate.
-/// Returns false when additional conditions exist (e.g., $regex on another
-/// field) that require post-filtering the index results.
+/// Returns true when the query constrains ONLY the indexed field AND every
+/// operator on that field is provably encoded by the chosen plan — meaning the
+/// O(1) `count_range_validated` fast path (which does not post-filter) is
+/// accurate. Returns false when additional conditions exist, so count routes
+/// through the index-narrowed post-filter path instead.
 ///
-/// This prevents the bug where `count_documents({"doc_type": "X", "content": {"$regex": "..."}})}`
-/// would return the index count for doc_type without applying the $regex filter.
+/// This prevents two bug classes:
+/// - cross-field residual, e.g. `{"doc_type": "X", "content": {"$regex": "..."}}`
+///   returning the doc_type index count without applying the $regex; and
+/// - same-field residual, e.g. `{"f": {"$gte": 5, "$ne": 7}}` or
+///   `{"f": {"$in": [..], "$gte": 5}}`, where the plan encodes only one operator
+///   and the others would be silently dropped (audit 2026-06-06 finding B).
 fn query_fully_covered_by_plan(query_json: &Value, plan: &QueryPlan) -> bool {
     let map = match query_json.as_object() {
         Some(m) => m,
@@ -57,8 +84,48 @@ fn query_fully_covered_by_plan(query_json: &Value, plan: &QueryPlan) -> bool {
         QueryPlan::SparseIndexScan { ref field, .. } => field,
     };
 
-    // Query is fully covered when it only has conditions on the indexed field
-    map.len() == 1 && map.contains_key(plan_field)
+    // Must constrain ONLY the indexed field.
+    if map.len() != 1 || !map.contains_key(plan_field) {
+        return false;
+    }
+
+    // The single field's condition must be fully ENCODED by the plan, not just
+    // present on the field. A bare scalar / plain-object equality is covered
+    // only by an equality IndexScan; an operator object is covered only when
+    // every $-operator key is in the plan's covered set.
+    let cond = match map[plan_field].as_object() {
+        None => return matches!(plan, QueryPlan::IndexScan { .. }),
+        Some(c) => c,
+    };
+    if cond.keys().all(|k| !k.starts_with('$')) {
+        // Plain nested-object value (no operators) — an object equality, which
+        // is never index-covered (is_indexable_value blocks it); treat like a
+        // scalar equality.
+        return matches!(plan, QueryPlan::IndexScan { .. });
+    }
+
+    let covered = plan_covered_operators(plan);
+    cond.keys().all(|k| covered.contains(&k.as_str()))
+}
+
+/// Whether the plan's index is multikey (array-valued). The fully-covered count
+/// fast path (`count_range_validated` / `count_numeric_buckets`) counts index
+/// ENTRIES, so a multikey document indexed under several matching keys would be
+/// over-counted. Such plans must take the index-narrowed path instead, which
+/// deduplicates doc_ids before counting — matching find()'s multikey dedup.
+fn plan_index_is_multikey(indexes: &IndexManager, plan: &QueryPlan) -> bool {
+    let index_name = match plan {
+        QueryPlan::IndexScan { index_name, .. }
+        | QueryPlan::IndexRangeScan { index_name, .. }
+        | QueryPlan::RegexPrefixScan { index_name, .. }
+        | QueryPlan::MultiRegexPrefixScan { index_name, .. }
+        | QueryPlan::MultiValueScan { index_name, .. }
+        | QueryPlan::SparseIndexScan { index_name, .. } => index_name,
+    };
+    indexes
+        .get_btree_index(index_name)
+        .map(|i| i.metadata.multikey)
+        .unwrap_or(false)
 }
 
 impl<S: Storage + RawStorage> CollectionCore<S> {
@@ -206,7 +273,8 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                 if let Some((_, plan)) =
                     QueryPlanner::analyze_query_with_fields(&merged_query, &index_fields)
                 {
-                    let fully_covered = query_fully_covered_by_plan(&merged_query, &plan);
+                    let fully_covered = query_fully_covered_by_plan(&merged_query, &plan)
+                        && !plan_index_is_multikey(&indexes, &plan);
 
                     // Handle fully-covered merged plans with O(1) memory count
                     match &plan {
@@ -219,6 +287,13 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                             ..
                         } => {
                             if let Some(index) = indexes.get_btree_index(index_name) {
+                                // Numeric range: count both Int + Float buckets (D).
+                                let buckets = numeric_range_buckets(
+                                    start.as_ref(),
+                                    end.as_ref(),
+                                    *inclusive_start,
+                                    *inclusive_end,
+                                );
                                 let default_start = IndexKey::Null;
                                 let default_end = max_string_key();
                                 let start_key = start.as_ref().unwrap_or(&default_start);
@@ -228,29 +303,39 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                     let meta = storage.get_collection_meta(&self.name).ok_or_else(
                                         || IronBaseError::CollectionNotFound(self.name.clone()),
                                     )?;
-                                    let count = index.count_range_validated(
-                                        start_key,
-                                        end_key,
-                                        *inclusive_start,
-                                        *inclusive_end,
-                                        &meta.document_catalog,
-                                    );
-                                    return Ok(count as u64);
-                                } else {
-                                    let mode = RangeQueryMode::Scan {
-                                        skip: 0,
-                                        limit: None,
-                                        order: ScanOrder::Asc,
-                                    };
-                                    let doc_ids = index
-                                        .range_query(
+                                    let count = match &buckets {
+                                        Some(b) => {
+                                            index.count_numeric_buckets(b, &meta.document_catalog)
+                                        }
+                                        None => index.count_range_validated(
                                             start_key,
                                             end_key,
                                             *inclusive_start,
                                             *inclusive_end,
-                                            mode,
-                                        )
-                                        .unwrap_docs();
+                                            &meta.document_catalog,
+                                        ),
+                                    };
+                                    return Ok(count as u64);
+                                } else {
+                                    let doc_ids = match &buckets {
+                                        Some(b) => index.scan_numeric_buckets(b),
+                                        None => {
+                                            let mode = RangeQueryMode::Scan {
+                                                skip: 0,
+                                                limit: None,
+                                                order: ScanOrder::Asc,
+                                            };
+                                            index
+                                                .range_query(
+                                                    start_key,
+                                                    end_key,
+                                                    *inclusive_start,
+                                                    *inclusive_end,
+                                                    mode,
+                                                )
+                                                .unwrap_docs()
+                                        }
+                                    };
                                     drop(indexes);
                                     drop(storage);
                                     return self.count_index_narrowed(doc_ids, query_json, ctx);
@@ -407,7 +492,8 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
 
         if let Some((_, plan)) = QueryPlanner::analyze_query_with_fields(query_json, &index_fields)
         {
-            let fully_covered = query_fully_covered_by_plan(query_json, &plan);
+            let fully_covered = query_fully_covered_by_plan(query_json, &plan)
+                && !plan_index_is_multikey(&indexes, &plan);
 
             match &plan {
                 QueryPlan::IndexScan {
@@ -462,6 +548,13 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                     ..
                 } => {
                     if let Some(index) = indexes.get_btree_index(index_name) {
+                        // Numeric range: count both Int + Float buckets (D).
+                        let buckets = numeric_range_buckets(
+                            start.as_ref(),
+                            end.as_ref(),
+                            *inclusive_start,
+                            *inclusive_end,
+                        );
                         let default_start = IndexKey::Null;
                         let default_end = max_string_key();
                         let start_key = start.as_ref().unwrap_or(&default_start);
@@ -473,30 +566,38 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 storage.get_collection_meta(&self.name).ok_or_else(|| {
                                     IronBaseError::CollectionNotFound(self.name.clone())
                                 })?;
-                            let count = index.count_range_validated(
-                                start_key,
-                                end_key,
-                                *inclusive_start,
-                                *inclusive_end,
-                                &meta.document_catalog,
-                            );
-                            return Ok(count as u64);
-                        } else {
-                            // FIX #36: narrow via index, then post-filter
-                            let mode = RangeQueryMode::Scan {
-                                skip: 0,
-                                limit: None,
-                                order: ScanOrder::Asc,
-                            };
-                            let doc_ids = index
-                                .range_query(
+                            let count = match &buckets {
+                                Some(b) => index.count_numeric_buckets(b, &meta.document_catalog),
+                                None => index.count_range_validated(
                                     start_key,
                                     end_key,
                                     *inclusive_start,
                                     *inclusive_end,
-                                    mode,
-                                )
-                                .unwrap_docs();
+                                    &meta.document_catalog,
+                                ),
+                            };
+                            return Ok(count as u64);
+                        } else {
+                            // FIX #36: narrow via index, then post-filter
+                            let doc_ids = match &buckets {
+                                Some(b) => index.scan_numeric_buckets(b),
+                                None => {
+                                    let mode = RangeQueryMode::Scan {
+                                        skip: 0,
+                                        limit: None,
+                                        order: ScanOrder::Asc,
+                                    };
+                                    index
+                                        .range_query(
+                                            start_key,
+                                            end_key,
+                                            *inclusive_start,
+                                            *inclusive_end,
+                                            mode,
+                                        )
+                                        .unwrap_docs()
+                                }
+                            };
                             drop(indexes);
                             drop(storage);
                             return self.count_index_narrowed(doc_ids, query_json, ctx);
@@ -507,41 +608,50 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                     ref index_name,
                     ref prefix,
                     exact,
+                    case_insensitive,
                     ..
                 } => {
-                    if *exact {
-                        if let Some(index) = indexes.get_btree_index(index_name) {
-                            let start = IndexKey::String(prefix.clone());
-                            let end = IndexKey::String(format!("{}\u{10ffff}", prefix));
+                    if let Some(index) = indexes.get_btree_index(index_name) {
+                        let start = IndexKey::String(prefix.clone());
+                        // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
+                        let end = prefix_scan_upper_bound(prefix);
 
-                            if fully_covered {
-                                // Fast path: validate index entries against catalog — O(1) memory
-                                let meta =
-                                    storage.get_collection_meta(&self.name).ok_or_else(|| {
-                                        IronBaseError::CollectionNotFound(self.name.clone())
-                                    })?;
-                                let count = index.count_range_validated(
-                                    &start,
-                                    &end,
-                                    true,
-                                    true,
-                                    &meta.document_catalog,
-                                );
-                                return Ok(count as u64);
-                            } else {
-                                // FIX #36: narrow via index, then post-filter
-                                let mode = RangeQueryMode::Scan {
-                                    skip: 0,
-                                    limit: None,
-                                    order: ScanOrder::Asc,
-                                };
-                                let doc_ids = index
-                                    .range_query(&start, &end, true, true, mode)
-                                    .unwrap_docs();
-                                drop(indexes);
-                                drop(storage);
-                                return self.count_index_narrowed(doc_ids, query_json, ctx);
-                            }
+                        // The O(1) count_range_validated fast path counts the raw key
+                        // range without re-applying the pattern, so it is correct ONLY
+                        // for an exact, case-sensitive prefix. A non-exact regex
+                        // (`^a.*b`) over-counts the range, and a case-insensitive
+                        // `(?i)` regex (whose Unicode case-folding differs from the
+                        // index's to_lowercase keys) mis-counts; both must be
+                        // re-verified per document via the narrowed path (audit
+                        // 2026-06-06 findings F + I). The narrowed path also USES the
+                        // index range for non-exact regexes instead of a full scan.
+                        if *exact && !*case_insensitive && fully_covered {
+                            // Fast path: validate index entries against catalog — O(1) memory
+                            let meta =
+                                storage.get_collection_meta(&self.name).ok_or_else(|| {
+                                    IronBaseError::CollectionNotFound(self.name.clone())
+                                })?;
+                            let count = index.count_range_validated(
+                                &start,
+                                &end,
+                                true,
+                                false,
+                                &meta.document_catalog,
+                            );
+                            return Ok(count as u64);
+                        } else {
+                            // Narrow via index range, then post-filter the full query.
+                            let mode = RangeQueryMode::Scan {
+                                skip: 0,
+                                limit: None,
+                                order: ScanOrder::Asc,
+                            };
+                            let doc_ids = index
+                                .range_query(&start, &end, true, false, mode)
+                                .unwrap_docs();
+                            drop(indexes);
+                            drop(storage);
+                            return self.count_index_narrowed(doc_ids, query_json, ctx);
                         }
                     }
                 }
@@ -560,12 +670,12 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                             let mut total_count = 0usize;
                             for prefix in prefixes {
                                 let start = IndexKey::String(prefix.clone());
-                                let end = IndexKey::String(format!("{}\u{10ffff}", prefix));
+                                let end = prefix_scan_upper_bound(prefix);
                                 total_count += index.count_range_validated(
                                     &start,
                                     &end,
                                     true,
-                                    true,
+                                    false,
                                     &meta.document_catalog,
                                 );
                             }
@@ -577,13 +687,13 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                                 .iter()
                                 .map(|prefix| {
                                     let start = IndexKey::String(prefix.clone());
-                                    let end = IndexKey::String(format!("{}\u{10ffff}", prefix));
+                                    let end = prefix_scan_upper_bound(prefix);
                                     index
                                         .range_query(
                                             &start,
                                             &end,
                                             true,
-                                            true,
+                                            false,
                                             RangeQueryMode::Count,
                                         )
                                         .unwrap_count()
@@ -598,14 +708,14 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                             })?;
                             for prefix in prefixes {
                                 let start = IndexKey::String(prefix.clone());
-                                let end = IndexKey::String(format!("{}\u{10ffff}", prefix));
+                                let end = prefix_scan_upper_bound(prefix);
                                 let mode = RangeQueryMode::Scan {
                                     skip: 0,
                                     limit: None,
                                     order: ScanOrder::Asc,
                                 };
                                 let ids = index
-                                    .range_query(&start, &end, true, true, mode)
+                                    .range_query(&start, &end, true, false, mode)
                                     .unwrap_docs();
                                 all_doc_ids.extend(ids);
                             }
@@ -737,6 +847,15 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
     ) -> Result<u64> {
         /// Max documents per chunk — matches count_with_scan() for consistency
         const CHUNK_SIZE: usize = 1000;
+
+        // Dedup doc_ids up front: a multikey index can yield the same doc_id
+        // multiple times (one per matching array element, or across the Int and
+        // Float numeric buckets). This counts one match per occurrence, so without
+        // dedup a multikey doc would be over-counted. Single chokepoint covering
+        // every narrowed plan path (IndexRangeScan/MultiValue/MultiRegex/Regex).
+        let mut doc_ids = doc_ids;
+        doc_ids.sort_unstable();
+        doc_ids.dedup();
 
         let parsed_query = Query::from_json(query_json)?;
         let mut total_count = 0u64;

--- a/ironbase-core/src/collection_core/cursor.rs
+++ b/ironbase-core/src/collection_core/cursor.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use crate::document::{Document, DocumentId};
 use crate::error::{IronBaseError, Result};
-use crate::index::{IndexKey, ScanOrder};
+use crate::index::{numeric_range_buckets, prefix_scan_upper_bound, IndexKey, ScanOrder};
 use crate::query::Query;
 use crate::query_planner::QueryPlan;
 use crate::storage::{RawStorage, Storage, HEADER_SIZE};
@@ -243,6 +243,22 @@ impl<'a, S: Storage + RawStorage> FindCursor<'a, S> {
                 inclusive_end,
                 ..
             } => {
+                // A numeric range spans two disjoint key buckets (all Int sort
+                // below all Float), which a single contiguous streaming cursor
+                // range cannot cover. Fall back to the non-streaming
+                // collect_doc_ids_from_plan path, which scans BOTH buckets via
+                // scan_numeric_buckets — otherwise the streaming path (and
+                // aggregation $match) silently drops Float-keyed docs (finding D).
+                if numeric_range_buckets(
+                    start.as_ref(),
+                    end.as_ref(),
+                    inclusive_start,
+                    inclusive_end,
+                )
+                .is_some()
+                {
+                    return Ok(None);
+                }
                 let default_start = IndexKey::Null;
                 let default_end = IndexKey::MaxKey;
                 let start_key = start.unwrap_or(default_start);
@@ -261,9 +277,10 @@ impl<'a, S: Storage + RawStorage> FindCursor<'a, S> {
                 index_name, prefix, ..
             } => {
                 let start = IndexKey::String(prefix.clone());
-                let end = IndexKey::String(format!("{}\u{10ffff}", prefix));
+                // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
+                let end = prefix_scan_upper_bound(&prefix);
                 Ok(Some(FindCursor::new_index_scan(
-                    collection, query_json, index_name, start, end, true, true,
+                    collection, query_json, index_name, start, end, true, false,
                 )?))
             }
             QueryPlan::SparseIndexScan { index_name, .. } => Ok(Some(FindCursor::new_index_scan(

--- a/ironbase-core/src/collection_core/mod.rs
+++ b/ironbase-core/src/collection_core/mod.rs
@@ -190,7 +190,10 @@ use std::collections::{HashMap, HashSet};
 use crate::document::{Document, DocumentId};
 use crate::error::{IronBaseError, Result};
 use crate::execution::ExecutionContext;
-use crate::index::{IndexKey, IndexManager, RangeQueryMode, ScanOrder};
+use crate::index::{
+    numeric_range_buckets, prefix_scan_upper_bound, IndexKey, IndexManager, RangeQueryMode,
+    ScanOrder,
+};
 use crate::query::Query;
 use crate::query_cache::{QueryCache, QueryHash};
 use crate::query_planner::{LogicalOperator, QueryPlan, QueryPlanner};
@@ -2837,19 +2840,38 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                     ..
                 } => {
                     if let Some(index) = indexes.get_btree_index(index_name) {
-                        let default_start = IndexKey::Null;
-                        let default_end = IndexKey::String("\u{10ffff}".repeat(100));
+                        if let Some(buckets) = numeric_range_buckets(
+                            start.as_ref(),
+                            end.as_ref(),
+                            inclusive_start,
+                            inclusive_end,
+                        ) {
+                            // Numeric range: scan BOTH the Int and Float key
+                            // buckets so float-valued docs are not missed (D).
+                            // The post-filter (parsed_query.matches) below makes
+                            // the final set exact.
+                            index.scan_numeric_buckets(&buckets)
+                        } else {
+                            let default_start = IndexKey::Null;
+                            let default_end = IndexKey::String("\u{10ffff}".repeat(100));
 
-                        let start_key = start.as_ref().unwrap_or(&default_start);
-                        let end_key = end.as_ref().unwrap_or(&default_end);
-                        let mode = RangeQueryMode::Scan {
-                            skip: 0,
-                            limit: None,
-                            order: ScanOrder::Asc,
-                        };
-                        index
-                            .range_query(start_key, end_key, inclusive_start, inclusive_end, mode)
-                            .unwrap_docs()
+                            let start_key = start.as_ref().unwrap_or(&default_start);
+                            let end_key = end.as_ref().unwrap_or(&default_end);
+                            let mode = RangeQueryMode::Scan {
+                                skip: 0,
+                                limit: None,
+                                order: ScanOrder::Asc,
+                            };
+                            index
+                                .range_query(
+                                    start_key,
+                                    end_key,
+                                    inclusive_start,
+                                    inclusive_end,
+                                    mode,
+                                )
+                                .unwrap_docs()
+                        }
                     } else {
                         vec![]
                     }
@@ -2872,14 +2894,15 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                             (0, None)
                         };
                         let start = IndexKey::String(prefix.clone());
-                        let end = IndexKey::String(format!("{}\u{10ffff}", prefix));
+                        // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
+                        let end = prefix_scan_upper_bound(prefix);
                         let mode = RangeQueryMode::Scan {
                             skip: scan_skip,
                             limit: scan_limit,
                             order: ScanOrder::Asc,
                         };
                         index
-                            .range_query(&start, &end, true, true, mode)
+                            .range_query(&start, &end, true, false, mode)
                             .unwrap_docs()
                     } else {
                         vec![]
@@ -2915,14 +2938,15 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                         let mut all_doc_ids = Vec::new();
                         for prefix in prefixes {
                             let start = IndexKey::String(prefix.clone());
-                            let end = IndexKey::String(format!("{}\u{10ffff}", prefix));
+                            // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
+                            let end = prefix_scan_upper_bound(prefix);
                             let mode = RangeQueryMode::Scan {
                                 skip: 0,
                                 limit: None,
                                 order: ScanOrder::Asc,
                             };
                             let ids = index
-                                .range_query(&start, &end, true, true, mode)
+                                .range_query(&start, &end, true, false, mode)
                                 .unwrap_docs();
                             all_doc_ids.extend(ids);
                         }

--- a/ironbase-core/src/index/btree.rs
+++ b/ironbase-core/src/index/btree.rs
@@ -2402,6 +2402,51 @@ impl BPlusTree {
         results
     }
 
+    /// Count documents matching a NUMERIC range across BOTH the Int and Float
+    /// key buckets. Numbers split across two disjoint key ranges (all Int sort
+    /// below all Float), but a numeric range matches only numbers, so summing
+    /// the two bucket counts is exact. O(1) memory; validates against `catalog`.
+    /// See [`super::key::numeric_range_buckets`] (audit 2026-06-06 finding D).
+    pub(crate) fn count_numeric_buckets(
+        &self,
+        buckets: &super::key::NumericBucketRanges,
+        catalog: &std::collections::HashMap<DocumentId, u64>,
+    ) -> usize {
+        let mut total = 0;
+        if let Some((s, e, is, ie)) = &buckets.int_range {
+            total += self.count_range_validated(s, e, *is, *ie, catalog);
+        }
+        let (fs, fe, fis, fie) = &buckets.float_range;
+        total += self.count_range_validated(fs, fe, *fis, *fie, catalog);
+        total
+    }
+
+    /// Scan document ids matching a NUMERIC range across BOTH the Int and Float
+    /// key buckets (see [`Self::count_numeric_buckets`] / finding D).
+    pub(crate) fn scan_numeric_buckets(
+        &self,
+        buckets: &super::key::NumericBucketRanges,
+    ) -> Vec<DocumentId> {
+        let mut ids = Vec::new();
+        let mode = || RangeQueryMode::Scan {
+            skip: 0,
+            limit: None,
+            order: ScanOrder::Asc,
+        };
+        if let Some((s, e, is, ie)) = &buckets.int_range {
+            ids.extend(self.range_query(s, e, *is, *ie, mode()).unwrap_docs());
+        }
+        let (fs, fe, fis, fie) = &buckets.float_range;
+        ids.extend(self.range_query(fs, fe, *fis, *fie, mode()).unwrap_docs());
+        // Dedup across the two buckets: a multikey doc with elements in BOTH the
+        // Int and Float bucket would otherwise appear twice and double-count on
+        // the index-narrowed count path (siblings MultiValueScan/MultiRegex dedup
+        // likewise). find() dedups again downstream, which is harmless.
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
+
     /// Range scan that returns (key, doc_id) pairs for resumable streaming.
     pub fn range_query_pairs(
         &self,

--- a/ironbase-core/src/index/key.rs
+++ b/ironbase-core/src/index/key.rs
@@ -142,6 +142,184 @@ impl From<serde_json::Value> for IndexKey {
     }
 }
 
+/// Next Unicode scalar value after `c`, skipping the UTF-16 surrogate gap.
+/// Returns `None` when `c == char::MAX` (no successor exists).
+fn next_scalar(c: char) -> Option<char> {
+    let mut cp = c as u32 + 1;
+    if cp == 0xD800 {
+        cp = 0xE000; // 0xD800..=0xDFFF are surrogates, not valid scalar values
+    }
+    char::from_u32(cp)
+}
+
+/// Exclusive upper bound for a "starts-with `prefix`" range scan: the smallest
+/// key strictly greater than every string that starts with `prefix`. Use it
+/// with a half-open `[prefix, upper)` range (inclusive start, exclusive end).
+///
+/// The earlier bound `prefix + '\u{10ffff}'` combined with an *inclusive* end
+/// silently dropped any stored value of the form `prefix + '\u{10ffff}' + …`,
+/// because such a value sorts strictly above `prefix + '\u{10ffff}'` (audit
+/// 2026-06-06 finding H). This computes the true successor by incrementing the
+/// last scalar of `prefix` (skipping the surrogate gap), carrying when it is
+/// already `char::MAX`. Returns [`IndexKey::MaxKey`] (scan to the end of the
+/// key space) when no finite successor exists — an empty prefix, or one made
+/// up solely of `char::MAX`.
+pub(crate) fn prefix_scan_upper_bound(prefix: &str) -> IndexKey {
+    let mut chars: Vec<char> = prefix.chars().collect();
+    while let Some(last) = chars.pop() {
+        if let Some(next) = next_scalar(last) {
+            let mut s: String = chars.into_iter().collect();
+            s.push(next);
+            return IndexKey::String(s);
+        }
+        // `last` was char::MAX — drop it and carry into the previous scalar.
+    }
+    IndexKey::MaxKey
+}
+
+/// A numeric query interval split onto the two disjoint key buckets the B+ tree
+/// stores numbers in. `IndexKey` orders ALL `Int` below ALL `Float`, so a single
+/// range like `[Int(18), Int(65)]` cannot contain any `Float` key — yet the
+/// range operators compare numerically and `compare_values` only ever compares
+/// numbers to numbers (cross-type → `None` → no match). Scanning/counting BOTH
+/// buckets therefore matches operator semantics exactly (audit 2026-06-06
+/// finding D). One bucket may be empty.
+#[derive(Debug, Clone)]
+pub(crate) struct NumericBucketRanges {
+    /// `(start, end, inclusive_start, inclusive_end)` for the Int bucket, or
+    /// `None` when no integer falls inside the interval.
+    pub int_range: Option<(IndexKey, IndexKey, bool, bool)>,
+    /// `(start, end, inclusive_start, inclusive_end)` for the Float bucket.
+    pub float_range: (IndexKey, IndexKey, bool, bool),
+}
+
+fn index_key_as_f64(k: &IndexKey) -> Option<f64> {
+    match k {
+        IndexKey::Int(n) => Some(*n as f64),
+        IndexKey::Float(f) => Some(f.0),
+        _ => None,
+    }
+}
+
+/// Split an `IndexRangeScan`'s bounds into Int + Float buckets when they describe
+/// a NUMERIC interval (each present bound is `Int`/`Float`, and at least one bound
+/// is present). Returns `None` for non-numeric ranges (e.g. string ranges), which
+/// must use the ordinary single-range scan. See [`NumericBucketRanges`].
+pub(crate) fn numeric_range_buckets(
+    start: Option<&IndexKey>,
+    end: Option<&IndexKey>,
+    inclusive_start: bool,
+    inclusive_end: bool,
+) -> Option<NumericBucketRanges> {
+    // Any present bound that is not numeric disqualifies this as a numeric range.
+    if let Some(s) = start {
+        index_key_as_f64(s)?;
+    }
+    if let Some(e) = end {
+        index_key_as_f64(e)?;
+    }
+    let lo = start.and_then(index_key_as_f64);
+    let hi = end.and_then(index_key_as_f64);
+    // Require at least one numeric bound (a fully unbounded range is not numeric).
+    if lo.is_none() && hi.is_none() {
+        return None;
+    }
+
+    // Float bucket: the same numeric interval expressed in float key space.
+    let float_start = IndexKey::Float(OrderedFloat(lo.unwrap_or(f64::NEG_INFINITY)));
+    let float_end = IndexKey::Float(OrderedFloat(hi.unwrap_or(f64::INFINITY)));
+    let float_incl_start = lo.is_none() || inclusive_start;
+    let float_incl_end = hi.is_none() || inclusive_end;
+
+    // Int bucket: integers inside the interval, derived EXACTLY from the original
+    // keys. An Int bound is used verbatim — NOT round-tripped through f64, which
+    // mis-rounded integer bounds beyond ±2^53 and saturated bounds beyond the i64
+    // range to a spurious boundary key (both made the no-post-filter count fast
+    // path diverge from find). A Float bound is rounded toward the interval
+    // interior with i64-range detection: an out-of-range Float collapses the Int
+    // bucket to empty so only the Float bucket carries the (correct) match.
+    let int_lo = int_bound_low(start, inclusive_start);
+    let int_hi = int_bound_high(end, inclusive_end);
+    let int_range = match (int_lo, int_hi) {
+        (Some(lo_i), Some(hi_i)) if lo_i <= hi_i => {
+            Some((IndexKey::Int(lo_i), IndexKey::Int(hi_i), true, true))
+        }
+        _ => None,
+    };
+
+    Some(NumericBucketRanges {
+        int_range,
+        float_range: (float_start, float_end, float_incl_start, float_incl_end),
+    })
+}
+
+// i64 range endpoints as f64 — note `i64::MAX as f64` rounds UP to 2^63, which is
+// why the low-bound check below uses `>=` (no i64 is >= 2^63).
+const I64_MIN_F: f64 = i64::MIN as f64;
+const I64_MAX_F: f64 = i64::MAX as f64;
+
+/// Smallest i64 satisfying the lower bound (`>= v` if inclusive, `> v` if not),
+/// or `None` if no i64 satisfies it (bound above the i64 range / overflow).
+fn int_bound_low(start: Option<&IndexKey>, inclusive: bool) -> Option<i64> {
+    match start {
+        None => Some(i64::MIN),
+        Some(IndexKey::Int(n)) => {
+            if inclusive {
+                Some(*n)
+            } else {
+                n.checked_add(1) // n > i64::MAX → no i64 qualifies
+            }
+        }
+        Some(IndexKey::Float(f)) => {
+            // smallest integer >= v (incl) or > v (excl)
+            let b = if inclusive {
+                f.0.ceil()
+            } else {
+                f.0.floor() + 1.0
+            };
+            if b >= I64_MAX_F {
+                None
+            } else if b < I64_MIN_F {
+                Some(i64::MIN)
+            } else {
+                Some(b as i64)
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Largest i64 satisfying the upper bound (`<= v` if inclusive, `< v` if not),
+/// or `None` if no i64 satisfies it (bound below the i64 range / overflow).
+fn int_bound_high(end: Option<&IndexKey>, inclusive: bool) -> Option<i64> {
+    match end {
+        None => Some(i64::MAX),
+        Some(IndexKey::Int(n)) => {
+            if inclusive {
+                Some(*n)
+            } else {
+                n.checked_sub(1) // n < i64::MIN → no i64 qualifies
+            }
+        }
+        Some(IndexKey::Float(f)) => {
+            // largest integer <= v (incl) or < v (excl)
+            let b = if inclusive {
+                f.0.floor()
+            } else {
+                f.0.ceil() - 1.0
+            };
+            if b < I64_MIN_F {
+                None
+            } else if b > I64_MAX_F {
+                Some(i64::MAX)
+            } else {
+                Some(b as i64)
+            }
+        }
+        _ => None,
+    }
+}
+
 impl IndexKey {
     /// Convert IndexKey back to serde_json::Value
     ///

--- a/ironbase-core/src/index/mod.rs
+++ b/ironbase-core/src/index/mod.rs
@@ -73,6 +73,10 @@ pub use fuzzy::{
     FuzzyAlgorithm, FuzzyIndex, FuzzyIndexMetadata, FuzzySearchOptions, FuzzySearchResult,
 };
 pub use key::{IndexKey, IndexPrefixInfo, OrderedFloat};
+// Crate-internal query-planner helpers (audit 2026-06-06 fixes) — NOT part of
+// the public crate API. NumericBucketRanges is referenced directly via
+// super::key in btree.rs, so it is not re-exported here.
+pub(crate) use key::{numeric_range_buckets, prefix_scan_upper_bound};
 pub use legacy::{Index, IndexDefinition, IndexType};
 pub use manager::IndexManager;
 pub use traits::{calculate_lazy_threshold, IndexTrait, LazyLoadable};

--- a/ironbase-core/src/query_planner.rs
+++ b/ironbase-core/src/query_planner.rs
@@ -486,8 +486,17 @@ impl QueryPlanner {
                 "$eq" => {
                     eq_vals.push(val);
                 }
-                // Pass through other operators as-is ($ne, $in, $nin, $exists, $type)
+                // Pass through other operators as-is ($ne, $in, $nin, $exists, $type).
+                // If the same operator already appears for this field, two $and
+                // clauses collided (e.g. {$in:[a,b]} AND {$in:[b,c]}). A serde_json
+                // Map holds one value per key, so inserting would silently OVERWRITE
+                // the first with the second — turning the AND intersection into just
+                // the second set and over-counting on the fully-covered count path.
+                // Bail out so the per-clause logical handler intersects + re-verifies.
                 other => {
+                    if result.contains_key(other) {
+                        return None;
+                    }
                     result.insert(other.to_string(), val.clone());
                 }
             }
@@ -618,6 +627,22 @@ impl QueryPlanner {
         }
     }
 
+    /// Coarse type bucket for an `IndexKey`, where `Int` and `Float` share one
+    /// bucket (numbers compare numerically). Range bounds of different buckets
+    /// can never overlap into a valid range, so a mixed-type range (e.g.
+    /// `{$gte: 5, $lte: "z"}`) matches nothing — the `IndexKey` equivalent of
+    /// `value_type_rank` (audit 2026-06-06 finding: mixed-type range over-count).
+    fn index_key_type_bucket(k: &IndexKey) -> u8 {
+        match k {
+            IndexKey::Null => 0,
+            IndexKey::Bool(_) => 1,
+            IndexKey::Int(_) | IndexKey::Float(_) => 2,
+            IndexKey::String(_) => 3,
+            IndexKey::Compound(_) => 4,
+            IndexKey::MaxKey => 5,
+        }
+    }
+
     /// Compare two JSON values for bound tightening (used in conflicting range resolution).
     ///
     /// Supports Number and String comparisons.
@@ -645,6 +670,12 @@ impl QueryPlanner {
     ///
     /// Skips indexes that are currently being built (building == true).
     ///
+    /// Excludes case-insensitive indexes: a CI index stores keys lowercased, so
+    /// a case-sensitive range/equality/regex plan built against it scans the
+    /// wrong key range and silently misses documents (audit 2026-06-06 finding
+    /// E). CI indexes are only valid for the dedicated `(?i)` regex branch,
+    /// which selects them via its own `case_insensitive` lookup.
+    ///
     /// Returns (index_name, is_compound) if found.
     fn find_index_for_field(
         field: &str,
@@ -659,13 +690,31 @@ impl QueryPlanner {
         // (audit #27 finding B).
         index_fields
             .iter()
-            .find(|info| info.prefix_field == field && !info.building && !info.is_compound)
+            .find(|info| {
+                info.prefix_field == field
+                    && !info.building
+                    && !info.is_compound
+                    && !info.case_insensitive
+            })
             .or_else(|| {
-                index_fields
-                    .iter()
-                    .find(|info| info.prefix_field == field && !info.building)
+                index_fields.iter().find(|info| {
+                    info.prefix_field == field && !info.building && !info.case_insensitive
+                })
             })
             .map(|info| (info.index_name.clone(), info.is_compound))
+    }
+
+    /// Whether a JSON value can serve as a B+ tree index key.
+    ///
+    /// `IndexKey::from` collapses both objects and arrays to `IndexKey::Null`
+    /// (key.rs), so picking an index for an object/array-valued equality — or a
+    /// `$in` element — produces a `{ key: Null }` plan that matches NULL-valued
+    /// docs, not docs whose field deep-equals the object/array. Such candidates
+    /// must be skipped so the collection-scan path performs proper deep equality.
+    /// Originally fixed for equality only (audit #27 finding A, b9209f7d); the
+    /// `$in` path (`collect_in_candidates`) needs the same guard.
+    fn is_indexable_value(v: &Value) -> bool {
+        !matches!(v, Value::Object(_) | Value::Array(_))
     }
 
     /// Analyze a query with compound-index-aware field matching (v2)
@@ -801,10 +850,9 @@ impl QueryPlanner {
         candidates: &mut Vec<CandidatePlan>,
     ) {
         if let Some((field, plan)) = Self::analyze_in_with_regex(query_json, index_fields) {
-            if let Some(info) = index_fields
-                .iter()
-                .find(|i| i.prefix_field == field && !i.is_compound && !i.building)
-            {
+            if let Some(info) = index_fields.iter().find(|i| {
+                i.prefix_field == field && !i.is_compound && !i.building && !i.case_insensitive
+            }) {
                 // Multi-regex scan cost depends on number of prefixes
                 let prefix_count = match &plan {
                     QueryPlan::MultiRegexPrefixScan { prefixes, .. } => prefixes.len(),
@@ -865,14 +913,34 @@ impl QueryPlanner {
                             continue;
                         }
 
-                        // Find matching index for this field (skip building indexes)
-                        if let Some(info) = index_fields
-                            .iter()
-                            .find(|i| i.prefix_field == *field && !i.is_compound && !i.building)
-                        {
-                            // Convert values to IndexKeys
-                            let keys: Vec<IndexKey> =
+                        // Object/array $in elements collapse to IndexKey::Null
+                        // (see is_indexable_value): a MultiValueScan on Null would
+                        // silently miss / mis-count docs whose field deep-equals the
+                        // object/array. Skip the whole candidate so the collection
+                        // scan performs proper deep equality (same defect class as
+                        // audit #27 finding A, fixed there only for equality).
+                        if in_values.iter().any(|v| !Self::is_indexable_value(v)) {
+                            continue;
+                        }
+
+                        // Find matching index for this field (skip building and
+                        // case-insensitive indexes — a CI index stores lowercased
+                        // keys and would miss case-sensitive $in values, audit E).
+                        if let Some(info) = index_fields.iter().find(|i| {
+                            i.prefix_field == *field
+                                && !i.is_compound
+                                && !i.building
+                                && !i.case_insensitive
+                        }) {
+                            // Convert values to IndexKeys, deduplicated: duplicate
+                            // $in values (e.g. machine-generated filters) are summed
+                            // per-key by the fully-covered count fast path, which
+                            // would double-count matching docs. Dedup also corrects
+                            // the keys.len() cost term below.
+                            let mut keys: Vec<IndexKey> =
                                 in_values.iter().map(IndexKey::from).collect();
+                            keys.sort();
+                            keys.dedup();
 
                             let plan = QueryPlan::MultiValueScan {
                                 index_name: info.index_name.clone(),
@@ -911,10 +979,9 @@ impl QueryPlanner {
         candidates: &mut Vec<CandidatePlan>,
     ) {
         if let Some((field, plan)) = Self::analyze_range_query_v2(query_json, index_fields) {
-            if let Some(info) = index_fields
-                .iter()
-                .find(|i| i.prefix_field == field && !i.is_compound && !i.building)
-            {
+            if let Some(info) = index_fields.iter().find(|i| {
+                i.prefix_field == field && !i.is_compound && !i.building && !i.case_insensitive
+            }) {
                 // Extract start/end from the plan for histogram-based estimation
                 // Clone the keys since we need to move plan later
                 let (start_key, end_key) = match &plan {
@@ -966,14 +1033,12 @@ impl QueryPlanner {
                 // short-circuit (count.rs:215) the planner returns the wrong
                 // count silently. Skip the candidate; the `$eq` operator on
                 // the collection-scan path performs proper deep equality.
-                let is_indexable_value =
-                    |v: &Value| -> bool { !matches!(v, Value::Object(_) | Value::Array(_)) };
                 let equality_value: Option<&Value> = if let Value::Object(ref val_map) = value {
                     if val_map.len() == 1 {
                         if let Some(eq_val) = val_map.get("$eq") {
                             // Explicit $eq operator: {"field": {"$eq": X}}
                             // — the inner value must itself be indexable.
-                            if is_indexable_value(eq_val) {
+                            if Self::is_indexable_value(eq_val) {
                                 Some(eq_val)
                             } else {
                                 None
@@ -1006,10 +1071,13 @@ impl QueryPlanner {
                     None => continue,
                 };
 
-                // Find ALL matching indexes for this field (not just first, skip building)
+                // Find ALL matching indexes for this field (not just first, skip
+                // building and case-insensitive indexes — equality is case-sensitive,
+                // and a CI index stores lowercased keys, so it would miss any value
+                // with uppercase characters, audit 2026-06-06 finding E).
                 for info in index_fields
                     .iter()
-                    .filter(|i| i.prefix_field == *field && !i.building)
+                    .filter(|i| i.prefix_field == *field && !i.building && !i.case_insensitive)
                 {
                     let key = IndexKey::from(eq_val);
                     let plan = QueryPlan::IndexScan {
@@ -1145,6 +1213,18 @@ impl QueryPlanner {
                             (None, Some(lte_val)) => (Some(IndexKey::from(lte_val)), true),
                             (None, None) => (None, true),
                         };
+
+                        // Mixed-type bounds (e.g. {$gte: 5, $lte: "z"}) can never
+                        // form an overlapping range — operators compare cross-type
+                        // as no-match — so an index range scan over [Int, String]
+                        // would over-count the no-post-filter count fast path. Skip
+                        // the index plan for this field (the merge path's
+                        // resolve_range_conditions already has the analogous guard).
+                        if let (Some(s), Some(e)) = (&start, &end) {
+                            if Self::index_key_type_bucket(s) != Self::index_key_type_bucket(e) {
+                                continue;
+                            }
+                        }
 
                         return Some((
                             field.clone(),

--- a/ironbase-core/tests/common/mod.rs
+++ b/ironbase-core/tests/common/mod.rs
@@ -1,0 +1,76 @@
+//! Shared oracle helpers for query-planner correctness regression tests
+//! (audit 2026-06-06).
+//!
+//! Oracle pattern: insert the SAME documents into an indexed collection and a
+//! non-indexed one. `count_documents` and `find` must agree with the
+//! ground-truth collection scan (the non-indexed collection). Any divergence
+//! is a planner/index correctness bug.
+#![allow(dead_code)]
+
+use ironbase_core::storage::MemoryStorage;
+use ironbase_core::DatabaseCore;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub fn doc(v: &Value) -> HashMap<String, Value> {
+    v.as_object()
+        .expect("doc must be a JSON object")
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+fn build(docs: &[Value]) -> DatabaseCore<MemoryStorage> {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("idx").unwrap();
+    db.collection("noidx").unwrap();
+    for d in docs {
+        db.insert_one("idx", doc(d)).unwrap();
+        db.insert_one("noidx", doc(d)).unwrap();
+    }
+    db
+}
+
+fn compare(db: &DatabaseCore<MemoryStorage>, query: &Value) {
+    let cidx = db.get_collection("idx").unwrap();
+    let cno = db.get_collection("noidx").unwrap();
+
+    let count_idx = cidx.count_documents(query).unwrap();
+    let count_scan = cno.count_documents(query).unwrap();
+    let find_idx = cidx.find(query).unwrap().len() as u64;
+    let find_scan = cno.find(query).unwrap().len() as u64;
+
+    // Ground truth: scan count == scan find (sanity).
+    assert_eq!(
+        count_scan, find_scan,
+        "ground-truth count/find disagree (no index) for {query}"
+    );
+    assert_eq!(
+        count_idx, count_scan,
+        "indexed count_documents diverges from collection scan for {query}: {count_idx} != {count_scan}"
+    );
+    assert_eq!(
+        find_idx, find_scan,
+        "indexed find diverges from collection scan for {query}: {find_idx} != {find_scan}"
+    );
+}
+
+/// Single-field B+ tree index (non-unique, non-sparse) on `index_field`.
+pub fn assert_index_matches_scan(docs: &[Value], index_field: &str, query: &Value) {
+    let db = build(docs);
+    db.get_collection("idx")
+        .unwrap()
+        .create_index(index_field.to_string(), false, false)
+        .unwrap();
+    compare(&db, query);
+}
+
+/// Case-insensitive B+ tree index (non-unique) on `index_field`.
+pub fn assert_ci_index_matches_scan(docs: &[Value], index_field: &str, query: &Value) {
+    let db = build(docs);
+    db.get_collection("idx")
+        .unwrap()
+        .create_ci_index(index_field.to_string(), false)
+        .unwrap();
+    compare(&db, query);
+}

--- a/ironbase-core/tests/qp_ci_index_test.rs
+++ b/ironbase-core/tests/qp_ci_index_test.rs
@@ -1,0 +1,61 @@
+//! Query-planner correctness regression tests — PR3 (audit 2026-06-06, finding E).
+//!
+//! A case-insensitive index stores keys lowercased. A case-sensitive query
+//! (equality / range / non-(?i) regex / $in) must NOT be planned against it,
+//! or the index scan misses documents. After the fix such queries fall back to
+//! the collection scan; only `(?i)` regex uses the CI index.
+
+mod common;
+use common::assert_ci_index_matches_scan;
+use serde_json::json;
+
+fn name_docs() -> Vec<serde_json::Value> {
+    vec![
+        json!({"name": "Alice"}),
+        json!({"name": "alice"}),
+        json!({"name": "Bob"}),
+        json!({"name": "albert"}),
+    ]
+}
+
+#[test]
+fn cs_equality_on_ci_index_matches_scan() {
+    // {name:"Alice"} is exact (case-sensitive) → only "Alice" → 1.
+    assert_ci_index_matches_scan(&name_docs(), "name", &json!({"name": "Alice"}));
+}
+
+#[test]
+fn cs_eq_operator_on_ci_index_matches_scan() {
+    assert_ci_index_matches_scan(&name_docs(), "name", &json!({"name": {"$eq": "alice"}}));
+}
+
+#[test]
+fn cs_regex_prefix_on_ci_index_matches_scan() {
+    // ^Al (case-sensitive) → only "Alice" → 1.
+    assert_ci_index_matches_scan(&name_docs(), "name", &json!({"name": {"$regex": "^Al"}}));
+}
+
+#[test]
+fn cs_range_on_ci_index_matches_scan() {
+    assert_ci_index_matches_scan(&name_docs(), "name", &json!({"name": {"$gte": "M"}}));
+}
+
+#[test]
+fn cs_in_on_ci_index_matches_scan() {
+    assert_ci_index_matches_scan(
+        &name_docs(),
+        "name",
+        &json!({"name": {"$in": ["Alice", "Bob"]}}),
+    );
+}
+
+#[test]
+fn ci_regex_on_ci_index_still_correct() {
+    // (?i)^al → "Alice","alice","albert" → 3. The CI index IS used here and must
+    // still agree with the scan.
+    assert_ci_index_matches_scan(
+        &name_docs(),
+        "name",
+        &json!({"name": {"$regex": "(?i)^al"}}),
+    );
+}

--- a/ironbase-core/tests/qp_count_coverage_test.rs
+++ b/ironbase-core/tests/qp_count_coverage_test.rs
@@ -1,0 +1,91 @@
+//! Query-planner correctness regression tests — PR2 (audit 2026-06-06, finding B).
+//!
+//! `count_documents` fully-covered fast path must not be taken when the single
+//! indexed field carries an operator the chosen plan does not encode (residual
+//! predicate). Otherwise count over-counts vs find/collection scan.
+
+mod common;
+use common::assert_index_matches_scan;
+use serde_json::json;
+
+#[test]
+fn range_plus_ne_same_field() {
+    let docs = (5..=9).map(|n| json!({ "f": n })).collect::<Vec<_>>();
+    // $gte:5 AND $ne:7 → {5,6,8,9} → 4 (not 5).
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$gte": 5, "$ne": 7}}));
+}
+
+#[test]
+fn in_plus_ne_same_field() {
+    let docs = (1..=3).map(|n| json!({ "f": n })).collect::<Vec<_>>();
+    // $in:[1,2] AND $ne:1 → {2} → 1.
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$in": [1, 2], "$ne": 1}}));
+}
+
+#[test]
+fn range_plus_nin_same_field() {
+    let docs = (5..=9).map(|n| json!({ "f": n })).collect::<Vec<_>>();
+    // $gte:5 AND $nin:[7,8] → {5,6,9} → 3.
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$gte": 5, "$nin": [7, 8]}}));
+}
+
+#[test]
+fn in_plus_range_same_field() {
+    let docs = ["a", "b", "c", "d"]
+        .iter()
+        .map(|s| json!({ "status": s }))
+        .collect::<Vec<_>>();
+    // $in:[b,d] AND $gte:b → {b,d} → 2.
+    assert_index_matches_scan(
+        &docs,
+        "status",
+        &json!({"status": {"$in": ["b", "d"], "$gte": "b"}}),
+    );
+}
+
+#[test]
+fn range_plus_type_same_field() {
+    let docs = vec![
+        json!({"f": 5}),
+        json!({"f": 6}),
+        json!({"f": "hello"}),
+        json!({"f": "world"}),
+        json!({"f": 7}),
+    ];
+    // $gte:5 AND $type:"string" — residual $type must be applied.
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$gte": 5, "$type": "string"}}));
+}
+
+#[test]
+fn and_in_plus_nin_same_field() {
+    let docs = ["a", "b", "c"]
+        .iter()
+        .map(|s| json!({ "status": s }))
+        .collect::<Vec<_>>();
+    // $in:[a,b,c] AND $nin:[b] → {a,c} → 2.
+    assert_index_matches_scan(
+        &docs,
+        "status",
+        &json!({"$and": [
+            {"status": {"$in": ["a", "b", "c"]}},
+            {"status": {"$nin": ["b"]}}
+        ]}),
+    );
+}
+
+// --- Pure (fully-covered) cases must remain correct ---
+
+#[test]
+fn pure_range_still_correct() {
+    let docs = (1..=10).map(|n| json!({ "f": n })).collect::<Vec<_>>();
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$gte": 5}}));
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$gte": 3, "$lt": 8}}));
+}
+
+#[test]
+fn pure_equality_and_in_still_correct() {
+    let docs = (1..=10).map(|n| json!({ "f": n })).collect::<Vec<_>>();
+    assert_index_matches_scan(&docs, "f", &json!({"f": 5}));
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$eq": 5}}));
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$in": [2, 4, 6]}}));
+}

--- a/ironbase-core/tests/qp_in_and_merge_test.rs
+++ b/ironbase-core/tests/qp_in_and_merge_test.rs
@@ -1,0 +1,107 @@
+//! Query-planner correctness regression tests — PR1 (audit 2026-06-06).
+//!
+//! Covers:
+//! - A: `$in` with an object/array element collapsing to IndexKey::Null
+//!   (collect_in_candidates was missing the audit #27-A is_indexable_value guard).
+//! - C: `$and` of two same-field membership operators ($in/$ne/$nin) where the
+//!   clause merge silently overwrote the first (resolve_range_conditions).
+//! - G: `$in` with duplicate values double-counted by the fully-covered count path.
+
+mod common;
+use common::assert_index_matches_scan;
+use serde_json::json;
+
+// ----- A: $in with non-indexable (object/array) elements -----
+
+#[test]
+fn in_with_object_element_matches_scan() {
+    let docs = vec![
+        json!({"meta": {"a": 1}}),
+        json!({"meta": {"a": 2}}),
+        json!({"meta": "plain"}),
+    ];
+    // Correct answer: 1 (only {"a":1}).
+    assert_index_matches_scan(&docs, "meta", &json!({"meta": {"$in": [{"a": 1}]}}));
+}
+
+#[test]
+fn in_with_mixed_scalar_and_object_element_matches_scan() {
+    let docs = vec![
+        json!({"meta": {"a": 1}}),
+        json!({"meta": "x"}),
+        json!({"meta": "y"}),
+    ];
+    // Object element mixed with a scalar element: must still fall back to scan.
+    assert_index_matches_scan(&docs, "meta", &json!({"meta": {"$in": ["x", {"a": 1}]}}));
+}
+
+// ----- G: $in with duplicate values -----
+
+#[test]
+fn in_with_duplicate_values_not_double_counted() {
+    let docs = vec![
+        json!({"status": "active"}),
+        json!({"status": "active"}),
+        json!({"status": "active"}),
+        json!({"status": "inactive"}),
+    ];
+    // Correct answer: 3 (each active doc counted once), not 6.
+    assert_index_matches_scan(
+        &docs,
+        "status",
+        &json!({"status": {"$in": ["active", "active"]}}),
+    );
+}
+
+#[test]
+fn in_with_duplicate_and_distinct_values() {
+    let docs = vec![
+        json!({"status": "a"}),
+        json!({"status": "b"}),
+        json!({"status": "b"}),
+        json!({"status": "c"}),
+    ];
+    assert_index_matches_scan(
+        &docs,
+        "status",
+        &json!({"status": {"$in": ["a", "b", "b", "a"]}}),
+    );
+}
+
+// ----- C: $and clause-merge collisions -----
+
+#[test]
+fn and_two_in_same_field_intersects() {
+    let docs = vec![
+        json!({"status": "a"}),
+        json!({"status": "b"}),
+        json!({"status": "c"}),
+    ];
+    // Intersection of {a,b} and {b,c} is {b} → 1.
+    assert_index_matches_scan(
+        &docs,
+        "status",
+        &json!({"$and": [
+            {"status": {"$in": ["a", "b"]}},
+            {"status": {"$in": ["b", "c"]}}
+        ]}),
+    );
+}
+
+#[test]
+fn and_two_ne_same_field() {
+    let docs = vec![
+        json!({"status": "a"}),
+        json!({"status": "b"}),
+        json!({"status": "c"}),
+    ];
+    // status != a AND status != b → only c → 1.
+    assert_index_matches_scan(
+        &docs,
+        "status",
+        &json!({"$and": [
+            {"status": {"$ne": "a"}},
+            {"status": {"$ne": "b"}}
+        ]}),
+    );
+}

--- a/ironbase-core/tests/qp_numeric_range_test.rs
+++ b/ironbase-core/tests/qp_numeric_range_test.rs
@@ -1,0 +1,195 @@
+//! Query-planner correctness regression tests — PR5 (audit 2026-06-06, finding D).
+//!
+//! `IndexKey` orders ALL Int below ALL Float, so a single `[Int(a), Int(b)]`
+//! range scan never reaches Float keys — but range operators compare
+//! numerically. A field mixing integers and fractional/x.0 floats therefore
+//! silently dropped matching docs from indexed find/count. The fix scans BOTH
+//! the Int and Float key buckets.
+
+mod common;
+use common::assert_index_matches_scan;
+use serde_json::{json, Value};
+
+fn mixed_ages() -> Vec<Value> {
+    vec![
+        json!({"age": 20}),   // Int
+        json!({"age": 30.5}), // Float (fractional)
+        json!({"age": 40}),   // Int
+        json!({"age": 50.0}), // Float (whole-number)
+    ]
+}
+
+#[test]
+fn bounded_range_spans_int_and_float() {
+    // $gte:18 ∧ $lt:65 → all 4.
+    assert_index_matches_scan(
+        &mixed_ages(),
+        "age",
+        &json!({"age": {"$gte": 18, "$lt": 65}}),
+    );
+}
+
+#[test]
+fn inclusive_both_bounds() {
+    assert_index_matches_scan(
+        &mixed_ages(),
+        "age",
+        &json!({"age": {"$gte": 20, "$lte": 50.0}}),
+    );
+}
+
+#[test]
+fn exclusive_lower_bound() {
+    // $gt:20 → 30.5, 40, 50.0 → 3.
+    assert_index_matches_scan(&mixed_ages(), "age", &json!({"age": {"$gt": 20}}));
+}
+
+#[test]
+fn exclusive_upper_float_bound() {
+    // $lt:50.0 → 20, 30.5, 40 → 3.
+    assert_index_matches_scan(&mixed_ages(), "age", &json!({"age": {"$lt": 50.0}}));
+}
+
+#[test]
+fn half_bounded_float_lower() {
+    // $gte:30.5 → 30.5, 40, 50.0 → 3.
+    assert_index_matches_scan(&mixed_ages(), "age", &json!({"age": {"$gte": 30.5}}));
+}
+
+#[test]
+fn int_upper_bound_does_not_drop_floats() {
+    // $lt:40 → 20, 30.5 → 2 (the float 30.5 must not be dropped).
+    assert_index_matches_scan(&mixed_ages(), "age", &json!({"age": {"$lt": 40}}));
+}
+
+#[test]
+fn float_only_bounds() {
+    // $gte:30.5 ∧ $lte:40.5 → 30.5, 40 → 2.
+    assert_index_matches_scan(
+        &mixed_ages(),
+        "age",
+        &json!({"age": {"$gte": 30.5, "$lte": 40.5}}),
+    );
+}
+
+#[test]
+fn whole_number_float_inclusive_with_int_bound() {
+    // $lte:50 (Int bound) must still include the Float 50.0 → all 4.
+    assert_index_matches_scan(&mixed_ages(), "age", &json!({"age": {"$lte": 50}}));
+}
+
+#[test]
+fn negative_mixed_range() {
+    let docs = vec![
+        json!({"age": -5}),
+        json!({"age": -2.5}),
+        json!({"age": 0}),
+        json!({"age": 3.5}),
+    ];
+    // $gte:-3 ∧ $lt:1 → -2.5, 0 → 2.
+    assert_index_matches_scan(&docs, "age", &json!({"age": {"$gte": -3, "$lt": 1}}));
+}
+
+#[test]
+fn pure_int_range_regression() {
+    let docs = (1..=10).map(|n| json!({ "age": n })).collect::<Vec<_>>();
+    assert_index_matches_scan(&docs, "age", &json!({"age": {"$gte": 3, "$lt": 8}}));
+    assert_index_matches_scan(&docs, "age", &json!({"age": {"$gt": 3, "$lte": 8}}));
+}
+
+#[test]
+fn pure_float_range_regression() {
+    let docs = vec![
+        json!({"age": 1.1}),
+        json!({"age": 2.2}),
+        json!({"age": 3.3}),
+        json!({"age": 4.4}),
+    ];
+    assert_index_matches_scan(&docs, "age", &json!({"age": {"$gte": 2.0, "$lt": 4.0}}));
+}
+
+/// Many ranges over a richer mixed dataset — broad oracle sweep.
+#[test]
+fn sweep_mixed_dataset() {
+    let docs = vec![
+        json!({"age": 0}),
+        json!({"age": 1.5}),
+        json!({"age": 2}),
+        json!({"age": 2.5}),
+        json!({"age": 3}),
+        json!({"age": 10.0}),
+        json!({"age": 10}),
+        json!({"age": 100.25}),
+        json!({"age": -1}),
+        json!({"age": -1.5}),
+    ];
+    let queries = [
+        json!({"age": {"$gte": 0, "$lte": 10}}),
+        json!({"age": {"$gt": 0, "$lt": 10}}),
+        json!({"age": {"$gte": 2, "$lte": 2.5}}),
+        json!({"age": {"$lt": 0}}),
+        json!({"age": {"$gte": 10}}),
+        json!({"age": {"$gt": 2.5, "$lt": 100.25}}),
+        json!({"age": {"$gte": -1.5, "$lte": -1}}),
+    ];
+    for q in &queries {
+        assert_index_matches_scan(&docs, "age", q);
+    }
+}
+
+// --- Int bound precision beyond ±2^53 (review follow-up: f64 round-trip bug) ---
+
+#[test]
+fn integer_bound_beyond_2pow53() {
+    let base: i64 = 1 << 53; // 2^53 = 9007199254740992
+    let docs = (0..4)
+        .map(|i| json!({ "age": base + i }))
+        .collect::<Vec<_>>();
+    // $gte: 2^53+1 → {2^53+1, 2^53+2, 2^53+3} = 3; must NOT include 2^53.
+    assert_index_matches_scan(&docs, "age", &json!({"age": {"$gte": base + 1}}));
+    assert_index_matches_scan(&docs, "age", &json!({"age": {"$lte": base + 1}}));
+    assert_index_matches_scan(
+        &docs,
+        "age",
+        &json!({"age": {"$gt": base + 1, "$lt": base + 3}}),
+    );
+    assert_index_matches_scan(&docs, "age", &json!({"age": {"$lt": base + 2}}));
+}
+
+// --- Float bound outside i64 range must collapse the Int bucket (saturation bug) ---
+
+#[test]
+fn float_bound_outside_i64_range() {
+    let docs = vec![
+        json!({"age": i64::MAX}),
+        json!({"age": 5}),
+        json!({"age": 2e30}),
+    ];
+    // $gte:1e30 matches only the Float 2e30 (1) — i64::MAX (≈9.2e18) is NOT ≥ 1e30.
+    assert_index_matches_scan(&docs, "age", &json!({"age": {"$gte": 1e30}}));
+
+    let docs2 = vec![
+        json!({"age": i64::MIN}),
+        json!({"age": -5}),
+        json!({"age": -2e30}),
+    ];
+    // $lte:-1e30 matches only -2e30 (1) — i64::MIN is NOT ≤ -1e30.
+    assert_index_matches_scan(&docs2, "age", &json!({"age": {"$lte": -1e30}}));
+}
+
+// --- Multikey [int, float] array must not double-count on the narrowed path ---
+
+#[test]
+fn multikey_cross_bucket_no_double_count_narrowed() {
+    // Two-field query → NOT fully covered → index-narrowed path (scan_numeric_buckets).
+    let docs = vec![
+        json!({"age": [20, 30.5], "k": "x"}), // both elements in range → count ONCE
+        json!({"age": [40], "k": "x"}),
+        json!({"age": [5], "k": "x"}),
+    ];
+    assert_index_matches_scan(
+        &docs,
+        "age",
+        &json!({"age": {"$gte": 18, "$lte": 65}, "k": "x"}),
+    );
+}

--- a/ironbase-core/tests/qp_preexisting_fixes_test.rs
+++ b/ironbase-core/tests/qp_preexisting_fixes_test.rs
@@ -1,0 +1,83 @@
+//! Pre-existing query-planner bugs surfaced by the 2026-06-06 code-review and
+//! fixed in the follow-up:
+//! - #10: mixed-type range bounds ({$gte: num, $lte: str}) over-counted the
+//!   fully-covered count fast path (analyze_range_query_v2 lacked the
+//!   value_type_rank guard the merge path has).
+//! - #5: a multikey (array) index counted index ENTRIES, not distinct docs, on
+//!   the fully-covered count fast path (range / $in / regex-prefix), so a doc
+//!   with several matching array elements was over-counted vs find().
+
+mod common;
+use common::assert_index_matches_scan;
+use serde_json::json;
+
+// ---- #10: mixed-type range bounds ----
+
+#[test]
+fn mixed_type_range_numeric_lower_string_upper() {
+    // {$gte:5, $lte:"z"} — Int(5) < String("z") is a valid-direction key range
+    // spanning Int+Float+String, but operator semantics match nothing (cross-type
+    // compare → no match). Correct answer: 0.
+    let docs = vec![
+        json!({"f": 5}),
+        json!({"f": 10}),
+        json!({"f": "a"}),
+        json!({"f": "z"}),
+    ];
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$gte": 5, "$lte": "z"}}));
+}
+
+#[test]
+fn same_type_numeric_range_still_indexed() {
+    // Regression: a genuine same-type range must still work after the guard.
+    let docs = (1..=10).map(|n| json!({ "f": n })).collect::<Vec<_>>();
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$gte": 3, "$lte": 8}}));
+}
+
+#[test]
+fn same_type_string_range_still_indexed() {
+    let docs = vec![
+        json!({"f": "apple"}),
+        json!({"f": "banana"}),
+        json!({"f": "cherry"}),
+    ];
+    assert_index_matches_scan(&docs, "f", &json!({"f": {"$gte": "a", "$lte": "c"}}));
+}
+
+// ---- #5: multikey fully-covered count must count distinct docs, not entries ----
+
+#[test]
+fn multikey_range_fully_covered() {
+    // Doc with two array elements BOTH in range must count once (not twice).
+    let docs = vec![
+        json!({"tags": [20, 30]}),
+        json!({"tags": [40]}),
+        json!({"tags": [5]}),
+    ];
+    assert_index_matches_scan(&docs, "tags", &json!({"tags": {"$gte": 18, "$lte": 65}}));
+}
+
+#[test]
+fn multikey_in_fully_covered() {
+    // $in matching two array elements of one doc must count once.
+    let docs = vec![json!({"tags": ["a", "b"]}), json!({"tags": ["c"]})];
+    assert_index_matches_scan(&docs, "tags", &json!({"tags": {"$in": ["a", "b"]}}));
+}
+
+#[test]
+fn multikey_cross_bucket_fully_covered() {
+    // Mixed [int, float] array, both in range → Int bucket + Float bucket both
+    // hit the same doc → must count once.
+    let docs = vec![json!({"tags": [20, 30.5]}), json!({"tags": [40]})];
+    assert_index_matches_scan(&docs, "tags", &json!({"tags": {"$gte": 18, "$lte": 65}}));
+}
+
+#[test]
+fn multikey_regex_prefix_fully_covered() {
+    // Two array string elements both match the prefix → must count once.
+    let docs = vec![
+        json!({"name": ["alpha", "apex"]}),
+        json!({"name": ["beta"]}),
+    ];
+    assert_index_matches_scan(&docs, "name", &json!({"name": {"$regex": "^a"}}));
+}

--- a/ironbase-core/tests/qp_regex_prefix_test.rs
+++ b/ironbase-core/tests/qp_regex_prefix_test.rs
@@ -1,0 +1,107 @@
+//! Query-planner correctness regression tests — PR4 (audit 2026-06-06, H+F+I).
+//!
+//! - H: prefix range upper bound was `prefix + U+10FFFF` *inclusive*, dropping a
+//!   stored value `prefix + U+10FFFF + …`. Now a true half-open [prefix, succ).
+//! - I: non-exact prefix regex (`^Hello.*`) count fell through to a full scan;
+//!   now it uses the index range + post-filter (and explain is accurate).
+//! - F: a `(?i)` regex over a case-insensitive index counted the raw key range
+//!   without re-applying the pattern; Unicode case-folding (U+0130 etc.) differs
+//!   from to_lowercase, so it over-counted. Now routed through the post-filter.
+
+mod common;
+use common::{assert_ci_index_matches_scan, assert_index_matches_scan};
+use serde_json::json;
+
+// ----- exact case-sensitive prefix: fast path must stay correct -----
+
+#[test]
+fn exact_cs_prefix_correct() {
+    let docs = vec![
+        json!({"name": "Hello"}),
+        json!({"name": "Hello World"}),
+        json!({"name": "Help"}),
+        json!({"name": "hello"}),
+        json!({"name": "Bye"}),
+    ];
+    // ^Hel → Hello, Hello World, Help → 3 (case-sensitive).
+    assert_index_matches_scan(&docs, "name", &json!({"name": {"$regex": "^Hel"}}));
+}
+
+// ----- I: non-exact prefix regex -----
+
+#[test]
+fn non_exact_prefix_regex_correct() {
+    let docs = vec![
+        json!({"name": "Hello"}),
+        json!({"name": "Hello World"}),
+        json!({"name": "Help"}),
+        json!({"name": "hello"}),
+        json!({"name": "Bye"}),
+    ];
+    // ^Hello.* → Hello, Hello World → 2. count must equal find (not full-scan path).
+    assert_index_matches_scan(&docs, "name", &json!({"name": {"$regex": "^Hello.*"}}));
+}
+
+#[test]
+fn non_exact_prefix_with_charclass() {
+    let docs = vec![
+        json!({"name": "item1"}),
+        json!({"name": "item2"}),
+        json!({"name": "itemX"}),
+        json!({"name": "other"}),
+    ];
+    // ^item[0-9] → item1, item2 → 2.
+    assert_index_matches_scan(&docs, "name", &json!({"name": {"$regex": "^item[0-9]"}}));
+}
+
+// ----- H: value containing the maximum Unicode scalar after the prefix -----
+
+#[test]
+fn prefix_upper_bound_includes_max_scalar_suffix() {
+    let docs = vec![
+        json!({"name": "abc\u{10ffff}X"}),
+        json!({"name": "abc\u{10ffff}"}),
+        json!({"name": "abcdef"}),
+        json!({"name": "abc"}),
+        json!({"name": "abz"}),
+        json!({"name": "abd"}),
+    ];
+    // ^abc → abc, abcdef, abc+U+10FFFF, abc+U+10FFFF+X → 4 (abd/abz excluded).
+    assert_index_matches_scan(&docs, "name", &json!({"name": {"$regex": "^abc"}}));
+}
+
+#[test]
+fn prefix_ending_in_max_scalar() {
+    let docs = vec![
+        json!({"name": "z\u{10ffff}"}),
+        json!({"name": "z\u{10ffff}tail"}),
+        json!({"name": "z"}),
+    ];
+    // Prefix itself ends in U+10FFFF (carry path in prefix_scan_upper_bound).
+    assert_index_matches_scan(&docs, "name", &json!({"name": {"$regex": "^z\u{10ffff}"}}));
+}
+
+// ----- F: (?i) regex over a case-insensitive index, Unicode case folding -----
+
+#[test]
+fn ci_regex_unicode_case_folding_correct() {
+    let docs = vec![
+        json!({"name": "\u{0130}stanbul"}), // İ (U+0130) — folds differently than to_lowercase
+        json!({"name": "ice"}),
+        json!({"name": "Item"}),
+        json!({"name": "Apple"}),
+    ];
+    // (?i)^i — regex Unicode folding does NOT match U+0130 → ice, Item → 2.
+    assert_ci_index_matches_scan(&docs, "name", &json!({"name": {"$regex": "(?i)^i"}}));
+}
+
+#[test]
+fn ci_regex_ascii_correct() {
+    let docs = vec![
+        json!({"name": "Apple"}),
+        json!({"name": "apricot"}),
+        json!({"name": "Banana"}),
+    ];
+    // (?i)^ap → Apple, apricot → 2.
+    assert_ci_index_matches_scan(&docs, "name", &json!({"name": {"$regex": "(?i)^ap"}}));
+}

--- a/ironbase-core/tests/qp_streaming_numeric_test.rs
+++ b/ironbase-core/tests/qp_streaming_numeric_test.rs
@@ -1,0 +1,81 @@
+//! Review follow-up regression — streaming/cursor numeric IndexRangeScan (finding D).
+//!
+//! PR5 applied the Int/Float two-bucket scan to the non-streaming
+//! collect_doc_ids_from_plan path only. The streaming cursor
+//! (FindCursor::new_index_scan_from_plan, used by find_streaming and aggregation
+//! $match) kept a single contiguous range scan and silently dropped Float-keyed
+//! docs for bounded numeric ranges. The cursor now falls back to the
+//! bucket-aware non-streaming path for numeric ranges.
+//!
+//! Requires file-backed storage: MemoryStorage early-returns find_streaming to
+//! the (already-fixed) doc_ids path, so the cursor bug only surfaces on a real
+//! .mlite file.
+
+use ironbase_core::StorageEngine;
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+type DatabaseCore = ironbase_core::DatabaseCore<StorageEngine>;
+
+fn insert(db: &DatabaseCore, coll: &str, doc: serde_json::Value) {
+    if let serde_json::Value::Object(m) = doc {
+        db.insert_one(coll, m.into_iter().collect::<HashMap<_, _>>())
+            .unwrap();
+    }
+}
+
+#[test]
+fn streaming_numeric_range_spans_int_and_float() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("stream_numeric.mlite");
+    let db = DatabaseCore::open(&path).unwrap();
+    for v in [json!(20), json!(30.5), json!(40), json!(50.0)] {
+        insert(&db, "items", json!({ "age": v }));
+    }
+    let coll = db.collection("items").unwrap();
+    coll.create_index("age".to_string(), false, false).unwrap();
+
+    let q = json!({"age": {"$gte": 18, "$lt": 65}});
+
+    // Non-streaming find (already-fixed path) sees all 4.
+    let find_n = coll.find(&q).unwrap().len();
+    assert_eq!(find_n, 4, "find() should see all 4 (incl. Float docs)");
+
+    // Streaming cursor must agree — previously dropped 30.5 and 50.0.
+    let mut cursor = coll.find_streaming(&q).unwrap();
+    let mut stream_n = 0;
+    while cursor.next().unwrap().is_some() {
+        stream_n += 1;
+    }
+    assert_eq!(
+        stream_n, find_n,
+        "streaming cursor must match find() — Float-keyed docs not dropped"
+    );
+}
+
+#[test]
+fn streaming_half_bounded_and_exclusive() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("stream_numeric2.mlite");
+    let db = DatabaseCore::open(&path).unwrap();
+    for v in [json!(-5), json!(-2.5), json!(0), json!(3.5), json!(10)] {
+        insert(&db, "items", json!({ "age": v }));
+    }
+    let coll = db.collection("items").unwrap();
+    coll.create_index("age".to_string(), false, false).unwrap();
+
+    for q in [
+        json!({"age": {"$gte": 0}}),
+        json!({"age": {"$lt": 3.5}}),
+        json!({"age": {"$gt": -5, "$lte": 3.5}}),
+    ] {
+        let find_n = coll.find(&q).unwrap().len();
+        let mut cursor = coll.find_streaming(&q).unwrap();
+        let mut stream_n = 0;
+        while cursor.next().unwrap().is_some() {
+            stream_n += 1;
+        }
+        assert_eq!(stream_n, find_n, "streaming must match find for {q}");
+    }
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.526"
+version = "1.0.527"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Multi-agent review of the query planner found **11 verified bugs** where `count_documents` diverged from `find` or returned incomplete results. Umbrella cause: count's fully-covered fast path trusted the plan without re-verifying; `find` always post-filters.

## Fixed
- `$in` object/array element → `IndexKey::Null` (is_indexable_value guard for `$in`)
- `$in` duplicate-value double-count (planner key dedup)
- `$and` same-field membership collision (`resolve_range_conditions` bail-out)
- `query_fully_covered_by_plan` operator coverage (residual predicate was dropped)
- CI index excluded from case-sensitive equality/range/regex selection
- regex prefix exclusive upper bound (was inclusive `prefix+U+10FFFF`)
- non-exact / CI regex count via index-narrowed post-filter (+ `explain` honesty)
- numeric range Int/Float **two-bucket** scan (find + count + streaming cursor)
- mixed-type range guard in `analyze_range_query_v2`
- multikey count: distinct docs not entries (gate + narrowed dedup chokepoint)

Includes self-introduced regressions from the first review round (streaming-cursor float-drop, `numeric_range_buckets` f64 precision/saturation) — both fixed + tested.

## Verification
Full `cargo test -p ironbase-core` green (**78 binaries, 0 failures**), `clippy` + `fmt` clean, `cargo check --workspace` clean. New oracle tests (indexed vs collection-scan parity) under `tests/qp_*.rs` + `tests/common/mod.rs`.

## Notes
All new helpers are `pub(crate)`; the public crate API is unchanged. Deferred (documented): the 4-executor plan-dispatch refactor (next session) and the CI `to_lowercase` vs regex `(?i)` Unicode-fold limitation (no impact on ASCII / Hungarian data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Több lekérdezés‑tervező és index‑helyességi hibát javít, ahol az indexelt count és find eredményei eltérhettek, különösen numerikus tartományok, regex előtagok, multikey indexek és reziduális operátorok esetén, valamint bővíti a regressziós lefedettséget.

Hibajavítások:
- Biztosítja, hogy a teljesen lefedett count „gyors útvonal” csak akkor érvényesüljön, ha az indexelt mezőn lévő összes operátort a választott terv kódolja, és az index nem multikey; ellenkező esetben index‑szűkített utószűrésre vált.
- Megakadályozza a count és find eltérését vegyes típusú és numerikus tartományoknál azzal, hogy a numerikus bejárásokat/számlálást szétosztja az egész és lebegőpontos kulcs‑bucketek között, és védi a vegyes típusú határértékeket.
- Javítja a regex előtag tartománykezelését egy helyes, félig nyílt felső határ segédfüggvény használatával, és azzal, hogy a nem pontos és kis‑/nagybetű‑érzéketlen regexeket index‑szűkített utószűrésen keresztül vezeti át ahelyett, hogy a nyers tartomány‑számlálásban bízna.
- Elkerüli a kis‑/nagybetű‑érzéketlen indexek hibás használatát kis‑/nagybetű‑érzékeny egyenlőség, tartomány, regex és `$in` lekérdezésekhez, így ezek a lekérdezések biztonságos tervekre esnek vissza, miközben a `(?i)` regex továbbra is CI indexeket használ.
- Megakadályozza, hogy objektum/tömb elemeket és duplikált értékeket tartalmazó `$in` hibás index terveket vagy duplán beszámolt eredményeket okozzon azzal, hogy védi a nem indexelhető értékeket és deduplikálja a tervező kulcsait.
- Elkerüli az azonos mezőre vonatkozó operátorütközést és a reziduálisok (pl. `$in` + `$in`, tartomány + `$ne`/`$nin`/`$type`) eldobását az összefésülés során, biztosítva, hogy ezeket újraellenőrizzük vagy helyesen metsszük (metszeteljük).
- Biztosítja, hogy a multikey index tervek a dokumentumokat számolják meg, ne az index bejegyzéseket, azzal, hogy az ilyen terveket deduplikáló, szűkített útra kényszeríti tartomány, `$in` és regex előtag lekérdezéseknél.
- Javítja a streaming numerikus `IndexRangeScan` kurzorokat, hogy megegyezzenek a nem streaming find/count viselkedéssel, és ne dobják el a lebegőpontos kulcsú dokumentumokat.

Fejlesztések:
- Belső segédfüggvényeket ad a prefix bejárások felső határainak, a numerikus bucket tartományoknak és az index‑lefedettség ellenőrzésének kiszámításához, hogy a tervező helyességi logikája központosított legyen, miközben a publikus API változatlan marad.

Build:
- Növeli az `ironbase-core` és `mcp-ironbase-server` crate‑ek verzióját, hogy tükrözze a lekérdezés‑tervező helyességi javításait.

Dokumentáció:
- Dokumentálja a lekérdezés‑tervező helyességi javításait és azok gyökérokait a changelogban, beleértve a core és server crate‑ek új verzióemeléseit.

Tesztelés:
- Oracle‑szerű regressziós tesztcsomagot ad hozzá, amely indexelt kollekciókat hasonlít össze teljes kollekció‑szkenneléssel `$in`, tartomány, regex, numerikus, multikey és kis‑/nagybetű‑érzéketlen index scenariók esetén, beleértve a streaming kurzor viselkedését és a szélső eseteket, mint az Unicode és nagy egész határértékek.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix multiple query planner and index correctness issues where indexed count and find could diverge, especially for numeric ranges, regex prefixes, multikey indexes, and residual operators, and extend regression coverage.

Bug Fixes:
- Ensure fully-covered count fast path only applies when all operators on the indexed field are encoded by the chosen plan and the index is not multikey, otherwise fall back to index-narrowed post-filtering.
- Prevent count and find divergence on mixed-type and numeric ranges by splitting numeric scans/counts across integer and float key buckets and guarding against mixed-type bounds.
- Fix regex prefix range handling by using a correct half-open upper bound helper and by routing non-exact and case-insensitive regexes through index-narrowed post-filtering rather than trusting raw range counts.
- Avoid incorrect use of case-insensitive indexes for case-sensitive equality, range, regex, and $in queries so such queries fall back to safe plans while (?i) regex continues to use CI indexes.
- Prevent `$in` with object/array elements and duplicate values from producing incorrect index plans or double-counted results by guarding non-indexable values and deduplicating planner keys.
- Avoid same-field operator collision and residuals (e.g. `$in` + `$in`, range + `$ne`/`$nin`/`$type`) from being dropped during clause merge, ensuring they are re-verified or intersected correctly.
- Ensure multikey index plans count distinct documents rather than index entries by forcing such plans through a deduplicating narrowed path for range, $in, and regex prefix queries.
- Fix streaming numeric IndexRangeScan cursors so they match non-streaming find/count behaviour and do not drop float-keyed documents.

Enhancements:
- Add internal helpers for computing prefix scan upper bounds, numeric bucket ranges, and index coverage checks to centralize planner correctness logic and keep the public API unchanged.

Build:
- Bump crate versions for ironbase-core and mcp-ironbase-server to reflect the query-planner correctness fixes.

Documentation:
- Document the query planner correctness fixes and their root causes in the changelog, including the new version bumps for core and server crates.

Tests:
- Add an oracle-style regression test suite comparing indexed collections to collection scans for `$in`, range, regex, numeric, multikey, and case-insensitive index scenarios, including streaming cursor behaviour and edge cases like Unicode and large integer bounds.

</details>