### PR TITLE
refactor(query): unify the 4 QueryPlan executors behind one range chokepoint (#8) (v1.0.528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored — unify the four QueryPlan executors behind one range chokepoint (mcp-server v1.0.528, core v0.3.334)
+
+Audit finding #8: a single `QueryPlan` was interpreted by **four** hand-synced executors — the two
+`count_with_plan` blocks (`collection_core/count.rs`), `collect_doc_ids_from_plan`
+(`collection_core/mod.rs`), and `FindCursor::new_index_scan_from_plan` (`collection_core/cursor.rs`).
+Every plan→index-range fix had to be mirrored 2–4×, and the numeric Int/Float two-bucket fix once
+missed the cursor, shipping a bug where `find_streaming` (and aggregation `$match`) silently dropped
+Float-keyed docs.
+
+The plan→index key-range derivation now lives **once** in `ironbase-core/src/index/plan_ranges.rs`
+(`PlanRanges::from_plan` + the `BPlusTree::count_exact` / `scan_ranges` consumers), read by three thin
+modes: count-exact (O(1), no post-filter), materialized find, and the streaming cursor (single
+contiguous range only). The four call sites collapse to adapters; `count_numeric_buckets` /
+`scan_numeric_buckets` / `max_string_key` are subsumed and removed. Net ~−600 lines of duplicated
+derivation. Behavior-preserving, with a new 3-way `count == find == cursor == scan` parity oracle
+(file-backed streaming) that guards the cursor path the suite never exercised before. The
+unbounded-end non-numeric range now uses `IndexKey::MaxKey` consistently across all three executors
+(was `max_string_key()` in count/find vs `MaxKey` in the cursor).
+
+### Fixed — two pre-existing count/find divergences surfaced by the #8 review (mcp-server v1.0.528, core v0.3.334)
+
+- **Single-sided non-numeric range over-counted on `count`.** A typed range with a defaulted open
+  end that crosses key-type buckets (e.g. `{f: {$lt: "z"}}` → `[Null, "z"]`) was treated as exact,
+  so `count_documents` summed the Int/Float/Bool keys the operator can never match (`count = 6` vs
+  `find = 1` on mixed-type data). `PlanRanges::from_plan` now marks such a range non-exact via a
+  type-homogeneity check (`QueryPlanner::index_key_type_bucket`), routing `count` through the
+  index-narrowed post-filter to match `find`.
+- **Numeric range `find(...).sort({field})` returned DocumentId order.** A numeric Int/Float
+  two-bucket scan yields DocumentId-sorted ids, but `collect_doc_ids_from_plan` reported
+  `uses_index_sort = true`, skipping the in-memory sort. Index-sort is now claimed only for a single
+  contiguous (index-ordered) scan, so multi-bucket numeric ranges (and multi-regex unions) re-sort
+  correctly.
+
 ### Fixed — query-planner correctness: 11 count/find divergence & incomplete-result bugs (mcp-server v1.0.527, core v0.3.333)
 
 A multi-agent review of the query planner (`ironbase-core/src/query_planner.rs` and its

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.333"
+version = "0.3.334"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/count.rs
+++ b/ironbase-core/src/collection_core/count.rs
@@ -2,37 +2,15 @@
 
 use serde_json::Value;
 
-/// Maximum repetitions of the max Unicode codepoint for "string infinity".
-///
-/// This value is used in range queries to create an upper bound that sorts
-/// after any realistic string value. 100 repetitions is arbitrary but
-/// exceeds any practical field length (MongoDB max is 1024 chars for index keys).
-const MAX_STRING_KEY_LENGTH: usize = 100;
-
-/// Build an IndexKey representing "string infinity" for range queries.
-///
-/// Uses the maximum Unicode codepoint (U+10FFFF) repeated to create a string
-/// that lexicographically sorts after any realistic string value.
-/// Used as the exclusive upper bound to capture all strings in a range.
-///
-/// # Why U+10FFFF?
-/// - It's the highest valid Unicode code point
-/// - Any real string will sort before it
-/// - Works correctly with UTF-8 collation
-fn max_string_key() -> IndexKey {
-    IndexKey::String("\u{10ffff}".repeat(MAX_STRING_KEY_LENGTH))
-}
-
 use crate::document::{Document, DocumentId};
 use crate::error::{IronBaseError, Result};
 use crate::execution::ExecutionContext;
-use crate::index::{
-    numeric_range_buckets, prefix_scan_upper_bound, IndexKey, IndexManager, RangeQueryMode,
-    ScanOrder,
-};
+use crate::index::plan_ranges::PlanRanges;
+use crate::index::{BPlusTree, IndexManager};
 use crate::query::Query;
 use crate::query_planner::{QueryPlan, QueryPlanner};
 use crate::storage::{RawStorage, Storage};
+use std::collections::HashMap;
 
 use super::CollectionCore;
 
@@ -114,18 +92,51 @@ fn query_fully_covered_by_plan(query_json: &Value, plan: &QueryPlan) -> bool {
 /// over-counted. Such plans must take the index-narrowed path instead, which
 /// deduplicates doc_ids before counting — matching find()'s multikey dedup.
 fn plan_index_is_multikey(indexes: &IndexManager, plan: &QueryPlan) -> bool {
-    let index_name = match plan {
-        QueryPlan::IndexScan { index_name, .. }
-        | QueryPlan::IndexRangeScan { index_name, .. }
-        | QueryPlan::RegexPrefixScan { index_name, .. }
-        | QueryPlan::MultiRegexPrefixScan { index_name, .. }
-        | QueryPlan::MultiValueScan { index_name, .. }
-        | QueryPlan::SparseIndexScan { index_name, .. } => index_name,
-    };
     indexes
-        .get_btree_index(index_name)
+        .get_btree_index(plan.index_name())
         .map(|i| i.metadata.multikey)
         .unwrap_or(false)
+}
+
+/// The two ways a fully-planned count resolves. Returned by [`count_for_plan`]
+/// so the **caller** owns the lock-drop discipline: `Exact` is computed while
+/// `storage`+`indexes` are held (it reads the document catalog), whereas
+/// `Narrow` hands the index-matched candidate doc_ids back so the caller can
+/// drop BOTH guards (issue #75 storage→indexes order) before delegating to the
+/// re-entrant `count_index_narrowed`.
+enum CountOutcome {
+    /// O(1)-memory catalog-validated count — the plan's ranges are exact, no
+    /// post-filter needed.
+    Exact(u64),
+    /// Index-narrowed candidate doc_ids — the caller must post-filter the full
+    /// query against them.
+    Narrow(Vec<DocumentId>),
+}
+
+/// Resolve a plan to a [`CountOutcome`] via the shared range chokepoint (audit
+/// finding #8 — the single `PlanRanges::from_plan` derivation that count, find
+/// and the cursor all share). Pure index math plus a catalog read; acquires NO
+/// locks itself.
+///
+/// The exact O(1) fast path is taken only when the caller's coverage + multikey
+/// gates pass (`fully_covered`) AND the plan's raw ranges are exact
+/// ([`PlanRanges::exact`], which folds in the regex `exact && !case_insensitive`
+/// rule). Otherwise the ranges are materialized into candidate doc_ids for the
+/// caller to post-filter.
+fn count_for_plan(
+    index: &BPlusTree,
+    plan: &QueryPlan,
+    catalog: &HashMap<DocumentId, u64>,
+    fully_covered: bool,
+) -> Result<CountOutcome> {
+    let ranges = PlanRanges::from_plan(plan, index);
+    if fully_covered && ranges.exact {
+        Ok(CountOutcome::Exact(
+            index.count_exact(&ranges, catalog) as u64
+        ))
+    } else {
+        Ok(CountOutcome::Narrow(index.scan_ranges(&ranges)?))
+    }
 }
 
 impl<S: Storage + RawStorage> CollectionCore<S> {
@@ -276,193 +287,25 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
                     let fully_covered = query_fully_covered_by_plan(&merged_query, &plan)
                         && !plan_index_is_multikey(&indexes, &plan);
 
-                    // Handle fully-covered merged plans with O(1) memory count
-                    match &plan {
-                        QueryPlan::IndexRangeScan {
-                            ref index_name,
-                            ref start,
-                            ref end,
-                            inclusive_start,
-                            inclusive_end,
-                            ..
-                        } => {
-                            if let Some(index) = indexes.get_btree_index(index_name) {
-                                // Numeric range: count both Int + Float buckets (D).
-                                let buckets = numeric_range_buckets(
-                                    start.as_ref(),
-                                    end.as_ref(),
-                                    *inclusive_start,
-                                    *inclusive_end,
-                                );
-                                let default_start = IndexKey::Null;
-                                let default_end = max_string_key();
-                                let start_key = start.as_ref().unwrap_or(&default_start);
-                                let end_key = end.as_ref().unwrap_or(&default_end);
-
-                                if fully_covered {
-                                    let meta = storage.get_collection_meta(&self.name).ok_or_else(
-                                        || IronBaseError::CollectionNotFound(self.name.clone()),
-                                    )?;
-                                    let count = match &buckets {
-                                        Some(b) => {
-                                            index.count_numeric_buckets(b, &meta.document_catalog)
-                                        }
-                                        None => index.count_range_validated(
-                                            start_key,
-                                            end_key,
-                                            *inclusive_start,
-                                            *inclusive_end,
-                                            &meta.document_catalog,
-                                        ),
-                                    };
-                                    return Ok(count as u64);
-                                } else {
-                                    let doc_ids = match &buckets {
-                                        Some(b) => index.scan_numeric_buckets(b),
-                                        None => {
-                                            let mode = RangeQueryMode::Scan {
-                                                skip: 0,
-                                                limit: None,
-                                                order: ScanOrder::Asc,
-                                            };
-                                            index
-                                                .range_query(
-                                                    start_key,
-                                                    end_key,
-                                                    *inclusive_start,
-                                                    *inclusive_end,
-                                                    mode,
-                                                )
-                                                .unwrap_docs()
-                                        }
-                                    };
-                                    drop(indexes);
-                                    drop(storage);
-                                    return self.count_index_narrowed(doc_ids, query_json, ctx);
-                                }
+                    // Single shared derivation (audit finding #8). A merged
+                    // $and/$or plan references an index that exists in this same
+                    // locked `indexes`, so get_btree_index always succeeds here;
+                    // count_for_plan resolves every variant uniformly.
+                    if let Some(index) = indexes.get_btree_index(plan.index_name()) {
+                        let outcome = {
+                            let meta =
+                                storage.get_collection_meta(&self.name).ok_or_else(|| {
+                                    IronBaseError::CollectionNotFound(self.name.clone())
+                                })?;
+                            count_for_plan(index, &plan, &meta.document_catalog, fully_covered)?
+                        };
+                        match outcome {
+                            CountOutcome::Exact(n) => return Ok(n),
+                            CountOutcome::Narrow(doc_ids) => {
+                                drop(indexes);
+                                drop(storage);
+                                return self.count_index_narrowed(doc_ids, query_json, ctx);
                             }
-                        }
-                        QueryPlan::MultiValueScan {
-                            ref index_name,
-                            ref keys,
-                            ..
-                        } => {
-                            if let Some(index) = indexes.get_btree_index(index_name) {
-                                if fully_covered {
-                                    let meta = storage.get_collection_meta(&self.name).ok_or_else(
-                                        || IronBaseError::CollectionNotFound(self.name.clone()),
-                                    )?;
-                                    let mut total_count = 0usize;
-                                    for key in keys {
-                                        total_count += index.count_range_validated(
-                                            key,
-                                            key,
-                                            true,
-                                            true,
-                                            &meta.document_catalog,
-                                        );
-                                    }
-                                    return Ok(total_count as u64);
-                                } else {
-                                    // OOM FIX: Estimate total size via O(1) Count mode, then try_reserve
-                                    let estimated: usize = keys
-                                        .iter()
-                                        .map(|key| {
-                                            index
-                                                .range_query(
-                                                    key,
-                                                    key,
-                                                    true,
-                                                    true,
-                                                    RangeQueryMode::Count,
-                                                )
-                                                .unwrap_count()
-                                        })
-                                        .sum();
-                                    let mut all_doc_ids = Vec::new();
-                                    all_doc_ids.try_reserve(estimated).map_err(|e| {
-                                        IronBaseError::OutOfMemory(format!(
-                                            "Cannot allocate space for {} index entries in MultiValueScan count ({})",
-                                            estimated, e
-                                        ))
-                                    })?;
-                                    for key in keys {
-                                        let mode = RangeQueryMode::Scan {
-                                            skip: 0,
-                                            limit: None,
-                                            order: ScanOrder::Asc,
-                                        };
-                                        let ids = index
-                                            .range_query(key, key, true, true, mode)
-                                            .unwrap_docs();
-                                        all_doc_ids.extend(ids);
-                                    }
-                                    all_doc_ids.sort_unstable();
-                                    all_doc_ids.dedup();
-                                    drop(indexes);
-                                    drop(storage);
-                                    return self.count_index_narrowed(all_doc_ids, query_json, ctx);
-                                }
-                            }
-                        }
-                        QueryPlan::IndexScan {
-                            ref index_name,
-                            ref key,
-                            is_compound,
-                            ..
-                        } => {
-                            if let Some(index) = indexes.get_btree_index(index_name) {
-                                let (start, end) = if *is_compound {
-                                    index.build_prefix_range(key.clone())
-                                } else {
-                                    (key.clone(), key.clone())
-                                };
-
-                                if fully_covered {
-                                    let meta = storage.get_collection_meta(&self.name).ok_or_else(
-                                        || IronBaseError::CollectionNotFound(self.name.clone()),
-                                    )?;
-                                    let count = index.count_range_validated(
-                                        &start,
-                                        &end,
-                                        true,
-                                        true,
-                                        &meta.document_catalog,
-                                    );
-                                    return Ok(count as u64);
-                                } else {
-                                    let mode = RangeQueryMode::Scan {
-                                        skip: 0,
-                                        limit: None,
-                                        order: ScanOrder::Asc,
-                                    };
-                                    let doc_ids = index
-                                        .range_query(&start, &end, true, true, mode)
-                                        .unwrap_docs();
-                                    drop(indexes);
-                                    drop(storage);
-                                    return self.count_index_narrowed(doc_ids, query_json, ctx);
-                                }
-                            }
-                        }
-                        _ => {
-                            // Other plan types: use collect_doc_ids_from_plan as fallback
-                            drop(indexes);
-                            drop(storage);
-                            let parsed_query = Query::from_json(query_json)?;
-                            let cancel_flag = ctx.and_then(|c| c.cancel_flag());
-                            let deadline = ctx.and_then(|c| c.deadline());
-                            let (doc_ids, _) = self.collect_doc_ids_from_plan(
-                                &parsed_query,
-                                plan,
-                                None,
-                                false,
-                                0,
-                                None,
-                                cancel_flag,
-                                deadline,
-                            )?;
-                            return Ok(doc_ids.len() as u64);
                         }
                     }
                 }
@@ -495,327 +338,23 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
             let fully_covered = query_fully_covered_by_plan(query_json, &plan)
                 && !plan_index_is_multikey(&indexes, &plan);
 
-            match &plan {
-                QueryPlan::IndexScan {
-                    ref index_name,
-                    ref key,
-                    is_compound,
-                    ..
-                } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        let (start, end) = if *is_compound {
-                            index.build_prefix_range(key.clone())
-                        } else {
-                            (key.clone(), key.clone())
-                        };
-
-                        if fully_covered {
-                            // Fast path: validate index entries against catalog — O(1) memory
-                            let meta =
-                                storage.get_collection_meta(&self.name).ok_or_else(|| {
-                                    IronBaseError::CollectionNotFound(self.name.clone())
-                                })?;
-                            let count = index.count_range_validated(
-                                &start,
-                                &end,
-                                true,
-                                true,
-                                &meta.document_catalog,
-                            );
-                            return Ok(count as u64);
-                        } else {
-                            // FIX #36: query has extra conditions — narrow via index, then post-filter
-                            let mode = RangeQueryMode::Scan {
-                                skip: 0,
-                                limit: None,
-                                order: ScanOrder::Asc,
-                            };
-                            let doc_ids = index
-                                .range_query(&start, &end, true, true, mode)
-                                .unwrap_docs();
-                            drop(indexes);
-                            drop(storage);
-                            return self.count_index_narrowed(doc_ids, query_json, ctx);
-                        }
-                    }
-                }
-                QueryPlan::IndexRangeScan {
-                    ref index_name,
-                    ref start,
-                    ref end,
-                    inclusive_start,
-                    inclusive_end,
-                    ..
-                } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        // Numeric range: count both Int + Float buckets (D).
-                        let buckets = numeric_range_buckets(
-                            start.as_ref(),
-                            end.as_ref(),
-                            *inclusive_start,
-                            *inclusive_end,
-                        );
-                        let default_start = IndexKey::Null;
-                        let default_end = max_string_key();
-                        let start_key = start.as_ref().unwrap_or(&default_start);
-                        let end_key = end.as_ref().unwrap_or(&default_end);
-
-                        if fully_covered {
-                            // Fast path: validate index entries against catalog — O(1) memory
-                            let meta =
-                                storage.get_collection_meta(&self.name).ok_or_else(|| {
-                                    IronBaseError::CollectionNotFound(self.name.clone())
-                                })?;
-                            let count = match &buckets {
-                                Some(b) => index.count_numeric_buckets(b, &meta.document_catalog),
-                                None => index.count_range_validated(
-                                    start_key,
-                                    end_key,
-                                    *inclusive_start,
-                                    *inclusive_end,
-                                    &meta.document_catalog,
-                                ),
-                            };
-                            return Ok(count as u64);
-                        } else {
-                            // FIX #36: narrow via index, then post-filter
-                            let doc_ids = match &buckets {
-                                Some(b) => index.scan_numeric_buckets(b),
-                                None => {
-                                    let mode = RangeQueryMode::Scan {
-                                        skip: 0,
-                                        limit: None,
-                                        order: ScanOrder::Asc,
-                                    };
-                                    index
-                                        .range_query(
-                                            start_key,
-                                            end_key,
-                                            *inclusive_start,
-                                            *inclusive_end,
-                                            mode,
-                                        )
-                                        .unwrap_docs()
-                                }
-                            };
-                            drop(indexes);
-                            drop(storage);
-                            return self.count_index_narrowed(doc_ids, query_json, ctx);
-                        }
-                    }
-                }
-                QueryPlan::RegexPrefixScan {
-                    ref index_name,
-                    ref prefix,
-                    exact,
-                    case_insensitive,
-                    ..
-                } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        let start = IndexKey::String(prefix.clone());
-                        // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
-                        let end = prefix_scan_upper_bound(prefix);
-
-                        // The O(1) count_range_validated fast path counts the raw key
-                        // range without re-applying the pattern, so it is correct ONLY
-                        // for an exact, case-sensitive prefix. A non-exact regex
-                        // (`^a.*b`) over-counts the range, and a case-insensitive
-                        // `(?i)` regex (whose Unicode case-folding differs from the
-                        // index's to_lowercase keys) mis-counts; both must be
-                        // re-verified per document via the narrowed path (audit
-                        // 2026-06-06 findings F + I). The narrowed path also USES the
-                        // index range for non-exact regexes instead of a full scan.
-                        if *exact && !*case_insensitive && fully_covered {
-                            // Fast path: validate index entries against catalog — O(1) memory
-                            let meta =
-                                storage.get_collection_meta(&self.name).ok_or_else(|| {
-                                    IronBaseError::CollectionNotFound(self.name.clone())
-                                })?;
-                            let count = index.count_range_validated(
-                                &start,
-                                &end,
-                                true,
-                                false,
-                                &meta.document_catalog,
-                            );
-                            return Ok(count as u64);
-                        } else {
-                            // Narrow via index range, then post-filter the full query.
-                            let mode = RangeQueryMode::Scan {
-                                skip: 0,
-                                limit: None,
-                                order: ScanOrder::Asc,
-                            };
-                            let doc_ids = index
-                                .range_query(&start, &end, true, false, mode)
-                                .unwrap_docs();
-                            drop(indexes);
-                            drop(storage);
-                            return self.count_index_narrowed(doc_ids, query_json, ctx);
-                        }
-                    }
-                }
-                QueryPlan::MultiRegexPrefixScan {
-                    ref index_name,
-                    ref prefixes,
-                    ..
-                } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        if fully_covered {
-                            // Fast path: validate index entries against catalog — O(1) memory
-                            let meta =
-                                storage.get_collection_meta(&self.name).ok_or_else(|| {
-                                    IronBaseError::CollectionNotFound(self.name.clone())
-                                })?;
-                            let mut total_count = 0usize;
-                            for prefix in prefixes {
-                                let start = IndexKey::String(prefix.clone());
-                                let end = prefix_scan_upper_bound(prefix);
-                                total_count += index.count_range_validated(
-                                    &start,
-                                    &end,
-                                    true,
-                                    false,
-                                    &meta.document_catalog,
-                                );
-                            }
-                            return Ok(total_count as u64);
-                        } else {
-                            // FIX #36: narrow via index, then post-filter
-                            // OOM FIX: Estimate total size via O(1) Count mode, then try_reserve
-                            let estimated: usize = prefixes
-                                .iter()
-                                .map(|prefix| {
-                                    let start = IndexKey::String(prefix.clone());
-                                    let end = prefix_scan_upper_bound(prefix);
-                                    index
-                                        .range_query(
-                                            &start,
-                                            &end,
-                                            true,
-                                            false,
-                                            RangeQueryMode::Count,
-                                        )
-                                        .unwrap_count()
-                                })
-                                .sum();
-                            let mut all_doc_ids = Vec::new();
-                            all_doc_ids.try_reserve(estimated).map_err(|e| {
-                                IronBaseError::OutOfMemory(format!(
-                                    "Cannot allocate space for {} index entries in MultiRegexPrefixScan count ({})",
-                                    estimated, e
-                                ))
-                            })?;
-                            for prefix in prefixes {
-                                let start = IndexKey::String(prefix.clone());
-                                let end = prefix_scan_upper_bound(prefix);
-                                let mode = RangeQueryMode::Scan {
-                                    skip: 0,
-                                    limit: None,
-                                    order: ScanOrder::Asc,
-                                };
-                                let ids = index
-                                    .range_query(&start, &end, true, false, mode)
-                                    .unwrap_docs();
-                                all_doc_ids.extend(ids);
-                            }
-                            all_doc_ids.sort_unstable();
-                            all_doc_ids.dedup();
-                            drop(indexes);
-                            drop(storage);
-                            return self.count_index_narrowed(all_doc_ids, query_json, ctx);
-                        }
-                    }
-                }
-                QueryPlan::MultiValueScan {
-                    ref index_name,
-                    ref keys,
-                    ..
-                } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        if fully_covered {
-                            // Fast path: validate index entries against catalog — O(1) memory
-                            let meta =
-                                storage.get_collection_meta(&self.name).ok_or_else(|| {
-                                    IronBaseError::CollectionNotFound(self.name.clone())
-                                })?;
-                            let mut total_count = 0usize;
-                            for key in keys {
-                                total_count += index.count_range_validated(
-                                    key,
-                                    key,
-                                    true,
-                                    true,
-                                    &meta.document_catalog,
-                                );
-                            }
-                            return Ok(total_count as u64);
-                        } else {
-                            // FIX #36: narrow via index, then post-filter
-                            // OOM FIX: Estimate total size via O(1) Count mode, then try_reserve
-                            let estimated: usize = keys
-                                .iter()
-                                .map(|key| {
-                                    index
-                                        .range_query(key, key, true, true, RangeQueryMode::Count)
-                                        .unwrap_count()
-                                })
-                                .sum();
-                            let mut all_doc_ids = Vec::new();
-                            all_doc_ids.try_reserve(estimated).map_err(|e| {
-                                IronBaseError::OutOfMemory(format!(
-                                    "Cannot allocate space for {} index entries in MultiValueScan count ({})",
-                                    estimated, e
-                                ))
-                            })?;
-                            for key in keys {
-                                let mode = RangeQueryMode::Scan {
-                                    skip: 0,
-                                    limit: None,
-                                    order: ScanOrder::Asc,
-                                };
-                                let ids =
-                                    index.range_query(key, key, true, true, mode).unwrap_docs();
-                                all_doc_ids.extend(ids);
-                            }
-                            all_doc_ids.sort_unstable();
-                            all_doc_ids.dedup();
-                            drop(indexes);
-                            drop(storage);
-                            return self.count_index_narrowed(all_doc_ids, query_json, ctx);
-                        }
-                    }
-                }
-                QueryPlan::SparseIndexScan { ref index_name, .. } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        if fully_covered {
-                            // Fast path: validate index entries against catalog — O(1) memory
-                            let meta =
-                                storage.get_collection_meta(&self.name).ok_or_else(|| {
-                                    IronBaseError::CollectionNotFound(self.name.clone())
-                                })?;
-                            let count = index.count_range_validated(
-                                &IndexKey::Null,
-                                &IndexKey::MaxKey,
-                                true,
-                                true,
-                                &meta.document_catalog,
-                            );
-                            return Ok(count as u64);
-                        } else {
-                            // FIX #35/#36: query has extra conditions beyond $exists
-                            let mode = RangeQueryMode::Scan {
-                                skip: 0,
-                                limit: None,
-                                order: ScanOrder::Asc,
-                            };
-                            let doc_ids = index
-                                .range_query(&IndexKey::Null, &IndexKey::MaxKey, true, true, mode)
-                                .unwrap_docs();
-                            drop(indexes);
-                            drop(storage);
-                            return self.count_index_narrowed(doc_ids, query_json, ctx);
-                        }
+            // Single shared derivation (audit finding #8). The plan references an
+            // index present in this same locked `indexes`, so get_btree_index
+            // always succeeds; count_for_plan resolves every variant uniformly
+            // (the regex `exact && !case_insensitive` rule lives in PlanRanges).
+            if let Some(index) = indexes.get_btree_index(plan.index_name()) {
+                let outcome = {
+                    let meta = storage
+                        .get_collection_meta(&self.name)
+                        .ok_or_else(|| IronBaseError::CollectionNotFound(self.name.clone()))?;
+                    count_for_plan(index, &plan, &meta.document_catalog, fully_covered)?
+                };
+                match outcome {
+                    CountOutcome::Exact(n) => return Ok(n),
+                    CountOutcome::Narrow(doc_ids) => {
+                        drop(indexes);
+                        drop(storage);
+                        return self.count_index_narrowed(doc_ids, query_json, ctx);
                     }
                 }
             }

--- a/ironbase-core/src/collection_core/cursor.rs
+++ b/ironbase-core/src/collection_core/cursor.rs
@@ -5,7 +5,8 @@ use std::collections::HashSet;
 
 use crate::document::{Document, DocumentId};
 use crate::error::{IronBaseError, Result};
-use crate::index::{numeric_range_buckets, prefix_scan_upper_bound, IndexKey, ScanOrder};
+use crate::index::plan_ranges::PlanRanges;
+use crate::index::{IndexKey, ScanOrder};
 use crate::query::Query;
 use crate::query_planner::QueryPlan;
 use crate::storage::{RawStorage, Storage, HEADER_SIZE};
@@ -215,87 +216,48 @@ impl<'a, S: Storage + RawStorage> FindCursor<'a, S> {
         query_json: &Value,
         plan: QueryPlan,
     ) -> Result<Option<Self>> {
-        match plan {
-            QueryPlan::IndexScan {
-                index_name,
-                key,
-                is_compound,
-                ..
-            } => {
-                let (start, end) = if is_compound {
-                    let indexes = collection.indexes.read();
-                    let Some(index) = indexes.get_btree_index(&index_name) else {
-                        return Ok(None);
-                    };
-                    index.build_prefix_range(key.clone())
-                } else {
-                    (key.clone(), key.clone())
-                };
-                Ok(Some(FindCursor::new_index_scan(
-                    collection, query_json, index_name, start, end, true, true,
-                )?))
-            }
-            QueryPlan::IndexRangeScan {
-                index_name,
-                start,
-                end,
-                inclusive_start,
-                inclusive_end,
-                ..
-            } => {
-                // A numeric range spans two disjoint key buckets (all Int sort
-                // below all Float), which a single contiguous streaming cursor
-                // range cannot cover. Fall back to the non-streaming
-                // collect_doc_ids_from_plan path, which scans BOTH buckets via
-                // scan_numeric_buckets — otherwise the streaming path (and
-                // aggregation $match) silently drops Float-keyed docs (finding D).
-                if numeric_range_buckets(
-                    start.as_ref(),
-                    end.as_ref(),
-                    inclusive_start,
-                    inclusive_end,
-                )
-                .is_some()
-                {
-                    return Ok(None);
-                }
-                let default_start = IndexKey::Null;
-                let default_end = IndexKey::MaxKey;
-                let start_key = start.unwrap_or(default_start);
-                let end_key = end.unwrap_or(default_end);
-                Ok(Some(FindCursor::new_index_scan(
-                    collection,
-                    query_json,
-                    index_name,
-                    start_key,
-                    end_key,
-                    inclusive_start,
-                    inclusive_end,
-                )?))
-            }
-            QueryPlan::RegexPrefixScan {
-                index_name, prefix, ..
-            } => {
-                let start = IndexKey::String(prefix.clone());
-                // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
-                let end = prefix_scan_upper_bound(&prefix);
-                Ok(Some(FindCursor::new_index_scan(
-                    collection, query_json, index_name, start, end, true, false,
-                )?))
-            }
-            QueryPlan::SparseIndexScan { index_name, .. } => Ok(Some(FindCursor::new_index_scan(
-                collection,
-                query_json,
-                index_name,
-                IndexKey::Null,
-                IndexKey::MaxKey,
-                true,
-                true,
-            )?)),
-            QueryPlan::MultiRegexPrefixScan { .. } => Ok(None),
-            // MultiValueScan is handled by collect_doc_ids_from_plan, not cursor
-            QueryPlan::MultiValueScan { .. } => Ok(None),
+        // Derive the plan's key-ranges from the shared chokepoint (the single
+        // source of truth count/find/cursor all use — audit finding #8). The
+        // index lock is held only long enough to read the index, because a
+        // compound IndexScan needs its arity for build_prefix_range; drop it
+        // before new_index_scan, which re-acquires indexes.read() (parking_lot
+        // read locks are not recursive).
+        let ranges = {
+            let indexes = collection.indexes.read();
+            let Some(index) = indexes.get_btree_index(plan.index_name()) else {
+                return Ok(None);
+            };
+            PlanRanges::from_plan(&plan, index)
+        };
+
+        // Only a single contiguous interval is streamable. A numeric range's
+        // disjoint Int/Float buckets, an `$in` union and a multi-regex union all
+        // span multiple ranges — defer to the materialized
+        // collect_doc_ids_from_plan path, which scans EVERY sub-range. Streaming
+        // only the first would silently drop the rest (e.g. the Float-keyed docs
+        // of a numeric range — finding D).
+        if !ranges.single_contiguous() {
+            return Ok(None);
         }
+
+        let PlanRanges {
+            index_name,
+            sub_ranges,
+            ..
+        } = ranges;
+        let sr = sub_ranges
+            .into_iter()
+            .next()
+            .expect("single_contiguous ⇒ exactly one sub-range");
+        Ok(Some(FindCursor::new_index_scan(
+            collection,
+            query_json,
+            index_name,
+            sr.start,
+            sr.end,
+            sr.inclusive_start,
+            sr.inclusive_end,
+        )?))
     }
 
     /// Set the default batch size for chunk operations

--- a/ironbase-core/src/collection_core/mod.rs
+++ b/ironbase-core/src/collection_core/mod.rs
@@ -190,10 +190,8 @@ use std::collections::{HashMap, HashSet};
 use crate::document::{Document, DocumentId};
 use crate::error::{IronBaseError, Result};
 use crate::execution::ExecutionContext;
-use crate::index::{
-    numeric_range_buckets, prefix_scan_upper_bound, IndexKey, IndexManager, RangeQueryMode,
-    ScanOrder,
-};
+use crate::index::plan_ranges::PlanRanges;
+use crate::index::{IndexKey, IndexManager, RangeQueryMode, ScanOrder};
 use crate::query::Query;
 use crate::query_cache::{QueryCache, QueryHash};
 use crate::query_planner::{LogicalOperator, QueryPlan, QueryPlanner};
@@ -2802,199 +2800,86 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
             }
         }
         let mut index_limit_applied = false;
+        // Whether the returned doc_ids come out in index-key (= sort-field) order.
+        // Only a single contiguous range scan is index-ordered; a multi-range scan
+        // (numeric Int/Float buckets, `$in`, multi-regex) is concatenated and
+        // sorted by DocumentId in `scan_ranges`, so it is NOT in sort-field order
+        // and must be re-sorted in memory (finding #2, 2026-06-08).
+        let mut scan_index_ordered = false;
         let mut doc_ids = {
             let indexes = self.indexes.read();
-            match plan {
-                QueryPlan::IndexScan {
-                    ref index_name,
-                    ref key,
-                    is_compound,
-                    ..
-                } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        let mode = RangeQueryMode::Scan {
-                            skip: 0,
-                            limit: None,
-                            order: ScanOrder::Asc,
-                        };
-                        if is_compound {
-                            // Compound index prefix query: use range scan with compound bounds
-                            let (start, end) = index.build_prefix_range(key.clone());
-                            index
-                                .range_query(&start, &end, true, true, mode)
-                                .unwrap_docs()
-                        } else {
-                            // Single-field index: point lookup
-                            index.range_query(key, key, true, true, mode).unwrap_docs()
-                        }
-                    } else {
-                        vec![]
-                    }
-                }
-                QueryPlan::IndexRangeScan {
-                    ref index_name,
-                    ref start,
-                    ref end,
-                    inclusive_start,
-                    inclusive_end,
-                    ..
-                } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        if let Some(buckets) = numeric_range_buckets(
-                            start.as_ref(),
-                            end.as_ref(),
-                            inclusive_start,
-                            inclusive_end,
-                        ) {
-                            // Numeric range: scan BOTH the Int and Float key
-                            // buckets so float-valued docs are not missed (D).
-                            // The post-filter (parsed_query.matches) below makes
-                            // the final set exact.
-                            index.scan_numeric_buckets(&buckets)
-                        } else {
-                            let default_start = IndexKey::Null;
-                            let default_end = IndexKey::String("\u{10ffff}".repeat(100));
+            match indexes.get_btree_index(plan.index_name()) {
+                // Index dropped concurrently with planning → no candidates.
+                None => Vec::new(),
+                Some(index) => {
+                    // Derive the key-ranges once via the shared chokepoint (audit
+                    // finding #8); every variant — point lookup, compound prefix,
+                    // numeric Int/Float buckets, regex prefix, sparse, `$in`/multi-
+                    // regex unions — is encoded as one or more sub-ranges.
+                    let ranges = PlanRanges::from_plan(&plan, index);
+                    scan_index_ordered = ranges.single_contiguous();
 
-                            let start_key = start.as_ref().unwrap_or(&default_start);
-                            let end_key = end.as_ref().unwrap_or(&default_end);
-                            let mode = RangeQueryMode::Scan {
-                                skip: 0,
-                                limit: None,
-                                order: ScanOrder::Asc,
-                            };
-                            index
-                                .range_query(
-                                    start_key,
-                                    end_key,
-                                    inclusive_start,
-                                    inclusive_end,
-                                    mode,
-                                )
-                                .unwrap_docs()
+                    // Regex limit-pushdown (preserved from the pre-#8 path): a
+                    // simple (no other conditions), exact, case-sensitive prefix on
+                    // a non-multikey index has no post-filter rejection, so skip/
+                    // limit can be pushed straight into the single index range —
+                    // O(limit) instead of materializing the whole prefix.
+                    let regex_pushdown = match &plan {
+                        QueryPlan::RegexPrefixScan {
+                            exact: true, field, ..
+                        } => {
+                            !index.metadata.multikey
+                                && Self::is_simple_regex_query(parsed_query.to_json(), field)
                         }
-                    } else {
-                        vec![]
-                    }
-                }
-                QueryPlan::RegexPrefixScan {
-                    ref index_name,
-                    ref prefix,
-                    exact,
-                    ref field,
-                    ..
-                } => {
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        let can_apply_limit = exact
-                            && !index.metadata.multikey
-                            && Self::is_simple_regex_query(parsed_query.to_json(), field);
-                        let (scan_skip, scan_limit) = if can_apply_limit {
-                            index_limit_applied = true;
-                            (skip, limit)
-                        } else {
-                            (0, None)
-                        };
-                        let start = IndexKey::String(prefix.clone());
-                        // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
-                        let end = prefix_scan_upper_bound(prefix);
+                        _ => false,
+                    };
+
+                    // The pushdown reads only sub_ranges[0]; gate it on
+                    // single_contiguous so that if a future planner ever splits a
+                    // regex prefix into multiple sub-ranges (as numeric ranges
+                    // split into Int/Float buckets) we fall back to scan_ranges —
+                    // which covers EVERY sub-range — instead of silently dropping
+                    // the rest (the exact shape of the original cursor bug).
+                    if regex_pushdown && ranges.single_contiguous() {
+                        index_limit_applied = true;
+                        let sr = &ranges.sub_ranges[0];
                         let mode = RangeQueryMode::Scan {
-                            skip: scan_skip,
-                            limit: scan_limit,
+                            skip,
+                            limit,
                             order: ScanOrder::Asc,
                         };
                         index
-                            .range_query(&start, &end, true, false, mode)
+                            .range_query(
+                                &sr.start,
+                                &sr.end,
+                                sr.inclusive_start,
+                                sr.inclusive_end,
+                                mode,
+                            )
                             .unwrap_docs()
                     } else {
-                        vec![]
-                    }
-                }
-                QueryPlan::SparseIndexScan { ref index_name, .. } => {
-                    // Sparse index scan: return ALL doc_ids in the index
-                    // Since sparse indexes only contain documents where the field exists,
-                    // this effectively returns all documents matching $exists: true
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        // Full range scan from minimum to maximum key
-                        let start = IndexKey::Null;
-                        let end = IndexKey::MaxKey;
-                        let mode = RangeQueryMode::Scan {
-                            skip: 0,
-                            limit: None,
-                            order: ScanOrder::Asc,
-                        };
-                        index
-                            .range_query(&start, &end, true, true, mode)
-                            .unwrap_docs()
-                    } else {
-                        vec![]
-                    }
-                }
-                QueryPlan::MultiRegexPrefixScan {
-                    ref index_name,
-                    ref prefixes,
-                    ..
-                } => {
-                    // Multi-regex prefix scan: union of multiple prefix range scans
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        let mut all_doc_ids = Vec::new();
-                        for prefix in prefixes {
-                            let start = IndexKey::String(prefix.clone());
-                            // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
-                            let end = prefix_scan_upper_bound(prefix);
-                            let mode = RangeQueryMode::Scan {
-                                skip: 0,
-                                limit: None,
-                                order: ScanOrder::Asc,
-                            };
-                            let ids = index
-                                .range_query(&start, &end, true, false, mode)
-                                .unwrap_docs();
-                            all_doc_ids.extend(ids);
-                        }
-                        // Sort and dedup to remove duplicates from overlapping ranges
-                        all_doc_ids.sort_unstable();
-                        all_doc_ids.dedup();
-                        all_doc_ids
-                    } else {
-                        vec![]
-                    }
-                }
-                QueryPlan::MultiValueScan {
-                    ref index_name,
-                    ref keys,
-                    ..
-                } => {
-                    // Multi-value scan: O(k) index lookups for $in queries
-                    // Much faster than collection scan O(n) when k << n
-                    if let Some(index) = indexes.get_btree_index(index_name) {
-                        let mut all_doc_ids = Vec::new();
-                        for key in keys {
-                            let mode = RangeQueryMode::Scan {
-                                skip: 0,
-                                limit: None,
-                                order: ScanOrder::Asc,
-                            };
-                            // Point lookup for each key
-                            let ids = index.range_query(key, key, true, true, mode).unwrap_docs();
-                            all_doc_ids.extend(ids);
-                        }
-                        // Sort and dedup (in case of duplicates from multikey index)
-                        all_doc_ids.sort_unstable();
-                        all_doc_ids.dedup();
-                        all_doc_ids
-                    } else {
-                        vec![]
+                        index.scan_ranges(&ranges)?
                     }
                 }
             }
         };
 
-        let uses_index_sort = match (&plan, sort_field) {
-            (QueryPlan::IndexScan { ref field, .. }, Some(sf)) if field == sf => true,
-            (QueryPlan::IndexRangeScan { ref field, .. }, Some(sf)) if field == sf => true,
-            (QueryPlan::RegexPrefixScan { ref field, .. }, Some(sf)) if field == sf => true,
-            (QueryPlan::MultiRegexPrefixScan { ref field, .. }, Some(sf)) if field == sf => true,
-            _ => false,
-        };
+        // The doc_ids are already in sort order only when BOTH the scan came out
+        // in index-key order (scan_index_ordered — a single contiguous range) AND
+        // the index field is the sort field. A numeric IndexRangeScan or a
+        // multi-regex union scans multiple sub-ranges → DocumentId-sorted, so it
+        // must fall through to a memory sort even though its field matches
+        // (finding #2, 2026-06-08).
+        let uses_index_sort = scan_index_ordered
+            && match (&plan, sort_field) {
+                (QueryPlan::IndexScan { ref field, .. }, Some(sf)) if field == sf => true,
+                (QueryPlan::IndexRangeScan { ref field, .. }, Some(sf)) if field == sf => true,
+                (QueryPlan::RegexPrefixScan { ref field, .. }, Some(sf)) if field == sf => true,
+                (QueryPlan::MultiRegexPrefixScan { ref field, .. }, Some(sf)) if field == sf => {
+                    true
+                }
+                _ => false,
+            };
 
         if uses_index_sort && sort_desc {
             doc_ids.reverse();

--- a/ironbase-core/src/index/btree.rs
+++ b/ironbase-core/src/index/btree.rs
@@ -2402,51 +2402,6 @@ impl BPlusTree {
         results
     }
 
-    /// Count documents matching a NUMERIC range across BOTH the Int and Float
-    /// key buckets. Numbers split across two disjoint key ranges (all Int sort
-    /// below all Float), but a numeric range matches only numbers, so summing
-    /// the two bucket counts is exact. O(1) memory; validates against `catalog`.
-    /// See [`super::key::numeric_range_buckets`] (audit 2026-06-06 finding D).
-    pub(crate) fn count_numeric_buckets(
-        &self,
-        buckets: &super::key::NumericBucketRanges,
-        catalog: &std::collections::HashMap<DocumentId, u64>,
-    ) -> usize {
-        let mut total = 0;
-        if let Some((s, e, is, ie)) = &buckets.int_range {
-            total += self.count_range_validated(s, e, *is, *ie, catalog);
-        }
-        let (fs, fe, fis, fie) = &buckets.float_range;
-        total += self.count_range_validated(fs, fe, *fis, *fie, catalog);
-        total
-    }
-
-    /// Scan document ids matching a NUMERIC range across BOTH the Int and Float
-    /// key buckets (see [`Self::count_numeric_buckets`] / finding D).
-    pub(crate) fn scan_numeric_buckets(
-        &self,
-        buckets: &super::key::NumericBucketRanges,
-    ) -> Vec<DocumentId> {
-        let mut ids = Vec::new();
-        let mode = || RangeQueryMode::Scan {
-            skip: 0,
-            limit: None,
-            order: ScanOrder::Asc,
-        };
-        if let Some((s, e, is, ie)) = &buckets.int_range {
-            ids.extend(self.range_query(s, e, *is, *ie, mode()).unwrap_docs());
-        }
-        let (fs, fe, fis, fie) = &buckets.float_range;
-        ids.extend(self.range_query(fs, fe, *fis, *fie, mode()).unwrap_docs());
-        // Dedup across the two buckets: a multikey doc with elements in BOTH the
-        // Int and Float bucket would otherwise appear twice and double-count on
-        // the index-narrowed count path (siblings MultiValueScan/MultiRegex dedup
-        // likewise). find() dedups again downstream, which is harmless.
-        ids.sort_unstable();
-        ids.dedup();
-        ids
-    }
-
     /// Range scan that returns (key, doc_id) pairs for resumable streaming.
     pub fn range_query_pairs(
         &self,

--- a/ironbase-core/src/index/mod.rs
+++ b/ironbase-core/src/index/mod.rs
@@ -62,6 +62,9 @@ pub mod fuzzy;
 pub mod key;
 pub mod legacy;
 pub mod manager;
+// Crate-internal: single source of truth for QueryPlan → index key-ranges
+// (audit 2026-06-06 finding #8). NOT part of the public crate API.
+pub(crate) mod plan_ranges;
 pub mod traits;
 
 // Re-export main types for convenience
@@ -73,10 +76,9 @@ pub use fuzzy::{
     FuzzyAlgorithm, FuzzyIndex, FuzzyIndexMetadata, FuzzySearchOptions, FuzzySearchResult,
 };
 pub use key::{IndexKey, IndexPrefixInfo, OrderedFloat};
-// Crate-internal query-planner helpers (audit 2026-06-06 fixes) — NOT part of
-// the public crate API. NumericBucketRanges is referenced directly via
-// super::key in btree.rs, so it is not re-exported here.
-pub(crate) use key::{numeric_range_buckets, prefix_scan_upper_bound};
+// numeric_range_buckets / prefix_scan_upper_bound (audit 2026-06-06 fixes) are
+// consumed only inside the index layer (plan_ranges::from_plan, via super::key),
+// so they are not re-exported from this module.
 pub use legacy::{Index, IndexDefinition, IndexType};
 pub use manager::IndexManager;
 pub use traits::{calculate_lazy_threshold, IndexTrait, LazyLoadable};

--- a/ironbase-core/src/index/plan_ranges.rs
+++ b/ironbase-core/src/index/plan_ranges.rs
@@ -1,0 +1,622 @@
+//! Single source of truth for translating a [`QueryPlan`] into the index
+//! key-ranges that `count`, `find` and the streaming cursor all scan.
+//!
+//! Audit 2026-06-06 finding #8: one `QueryPlan` was interpreted by **four**
+//! separate executors (the two `count_with_plan` blocks, `collect_doc_ids_from_plan`
+//! and `FindCursor::new_index_scan_from_plan`) that had to be hand-kept in
+//! lockstep. A numeric Int/Float two-bucket fix once landed in three of them and
+//! missed the cursor, shipping a bug where `find_streaming` silently dropped
+//! Float-keyed docs. This module derives the ranges **once** so a fix lands once.
+//!
+//! [`PlanRanges::from_plan`] is pure `IndexKey`/`BPlusTree` math — it borrows a
+//! `&BPlusTree` only to read a compound index's arity (`build_prefix_range`) and
+//! touches no storage, catalog or lock. That keeps it safe to call while holding
+//! any lock order (issue #75).
+//!
+//! Consumers differ only in *how* they read the ranges:
+//! - count-exact: [`BPlusTree::count_exact`] — O(1) memory, no post-filter
+//!   (caller must guarantee [`PlanRanges::exact`] and a non-multikey index);
+//! - materialized find: [`BPlusTree::scan_ranges`] — caller post-filters;
+//! - streaming cursor: a single contiguous range (see
+//!   [`PlanRanges::single_contiguous`]).
+
+use super::btree::{BPlusTree, RangeQueryMode, ScanOrder};
+use super::key::{numeric_range_buckets, prefix_scan_upper_bound};
+use super::IndexKey;
+use crate::document::DocumentId;
+use crate::error::{IronBaseError, Result};
+use crate::query_planner::{QueryPlan, QueryPlanner};
+use std::collections::HashMap;
+
+/// One contiguous B+ tree key interval to scan.
+#[derive(Debug, Clone)]
+pub(crate) struct SubRange {
+    pub start: IndexKey,
+    pub end: IndexKey,
+    pub inclusive_start: bool,
+    pub inclusive_end: bool,
+}
+
+/// The index key-ranges derived from a [`QueryPlan`], plus whether the raw range
+/// answer is exact for the count fast path.
+#[derive(Debug, Clone)]
+pub(crate) struct PlanRanges {
+    /// Index the plan scans (every `QueryPlan` variant names one).
+    pub index_name: String,
+    /// 1 range (`IndexScan` / single-regex / sparse / single non-numeric range),
+    /// 2 (numeric Int+Float buckets), or N (`$in` / multi-regex).
+    pub sub_ranges: Vec<SubRange>,
+    /// Whether `count` may sum the raw validated range counts WITHOUT a
+    /// post-filter. This carries only the per-plan part of that decision —
+    /// chiefly the `RegexPrefixScan` `exact && !case_insensitive` rule (count.rs,
+    /// audit findings F + I) and the non-numeric range type-homogeneity rule
+    /// (finding #1, 2026-06-08: a single-sided range whose defaulted open end
+    /// crosses other key-type buckets, e.g. `{f: {$lt: "z"}}` → `[Null, "z"]`, is
+    /// NOT exact — `count_exact` would count the Int/Float/Bool keys the operator
+    /// can never match). The caller still ANDs `exact` with its own coverage +
+    /// non-multikey gates; a non-exact plan routes count through the index-narrowed
+    /// post-filter, matching find.
+    pub exact: bool,
+}
+
+impl PlanRanges {
+    /// Whether the ranges form a single contiguous interval — the streaming
+    /// cursor's precondition (it cannot span the disjoint numeric Int/Float
+    /// buckets or a `$in`/multi-regex union). Derived, never stored, so it can
+    /// never desync from `sub_ranges`.
+    pub(crate) fn single_contiguous(&self) -> bool {
+        self.sub_ranges.len() == 1
+    }
+
+    fn single(
+        index_name: String,
+        start: IndexKey,
+        end: IndexKey,
+        inclusive_start: bool,
+        inclusive_end: bool,
+        exact: bool,
+    ) -> Self {
+        PlanRanges {
+            index_name,
+            sub_ranges: vec![SubRange {
+                start,
+                end,
+                inclusive_start,
+                inclusive_end,
+            }],
+            exact,
+        }
+    }
+
+    fn multi(index_name: String, sub_ranges: Vec<SubRange>, exact: bool) -> Self {
+        PlanRanges {
+            index_name,
+            sub_ranges,
+            exact,
+        }
+    }
+
+    /// Derive the index key-ranges a plan scans. Mirrors exactly what
+    /// `collect_doc_ids_from_plan` (find) derives today, so the consumers below
+    /// produce identical results.
+    ///
+    /// `index` is borrowed only for a compound `IndexScan`'s `build_prefix_range`
+    /// (arity); no storage/catalog/lock is touched.
+    pub(crate) fn from_plan(plan: &QueryPlan, index: &BPlusTree) -> Self {
+        let index_name = plan.index_name().to_string();
+        match plan {
+            QueryPlan::IndexScan {
+                key, is_compound, ..
+            } => {
+                let (start, end) = if *is_compound {
+                    // Compound prefix: [prefix..Null, prefix..MaxKey].
+                    index.build_prefix_range(key.clone())
+                } else {
+                    // Single-field equality point lookup.
+                    (key.clone(), key.clone())
+                };
+                PlanRanges::single(index_name, start, end, true, true, true)
+            }
+
+            QueryPlan::IndexRangeScan {
+                start,
+                end,
+                inclusive_start,
+                inclusive_end,
+                ..
+            } => {
+                if let Some(buckets) = numeric_range_buckets(
+                    start.as_ref(),
+                    end.as_ref(),
+                    *inclusive_start,
+                    *inclusive_end,
+                ) {
+                    // Numeric range spans two disjoint key buckets (all Int sort
+                    // below all Float) — scan/count both so Float-keyed docs are
+                    // not missed (finding D). One bucket may be absent.
+                    let mut sub_ranges = Vec::with_capacity(2);
+                    if let Some((s, e, is, ie)) = buckets.int_range {
+                        sub_ranges.push(SubRange {
+                            start: s,
+                            end: e,
+                            inclusive_start: is,
+                            inclusive_end: ie,
+                        });
+                    }
+                    let (fs, fe, fis, fie) = buckets.float_range;
+                    sub_ranges.push(SubRange {
+                        start: fs,
+                        end: fe,
+                        inclusive_start: fis,
+                        inclusive_end: fie,
+                    });
+                    PlanRanges::multi(index_name, sub_ranges, true)
+                } else {
+                    // Non-numeric (string/bool) range. An absent bound becomes the
+                    // open end of the key space (Null below, MaxKey above). All
+                    // three executors agree on this single bound; find/cursor make
+                    // it exact via their post-filter.
+                    //
+                    // COUNT has no post-filter (count_exact), so the raw range is
+                    // an exact answer ONLY when it is type-homogeneous — it must
+                    // not pull in index keys of a type the operator can never match
+                    // (finding #1, 2026-06-08, e.g. `{f: {$lt: "z"}}` →
+                    // `[Null, "z"]` counting Int/Float/Bool keys):
+                    //  - a defaulted LOWER (Null) pulls in every bucket below the
+                    //    upper bound → never exact;
+                    //  - a defaulted UPPER (MaxKey) pulls in every bucket above the
+                    //    lower bound → exact only when the lower bound is a String,
+                    //    the top scalar bucket on a single-field index (above it
+                    //    only the never-present Compound keys sort);
+                    //  - a fully-bounded range is exact iff both bounds share a
+                    //    type bucket (the planner already rejects mixed-type
+                    //    two-sided ranges; re-checked here for safety).
+                    // Non-exact ⇒ count takes the index-narrowed post-filter path,
+                    // matching find's correct result.
+                    let exact = match (start.as_ref(), end.as_ref()) {
+                        (Some(s), Some(e)) => {
+                            QueryPlanner::index_key_type_bucket(s)
+                                == QueryPlanner::index_key_type_bucket(e)
+                        }
+                        (Some(IndexKey::String(_)), None) => true,
+                        (Some(_), None) => false,
+                        (None, _) => false,
+                    };
+                    let start = start.clone().unwrap_or(IndexKey::Null);
+                    let end = end.clone().unwrap_or(IndexKey::MaxKey);
+                    PlanRanges::single(
+                        index_name,
+                        start,
+                        end,
+                        *inclusive_start,
+                        *inclusive_end,
+                        exact,
+                    )
+                }
+            }
+
+            QueryPlan::RegexPrefixScan {
+                prefix,
+                exact,
+                case_insensitive,
+                ..
+            } => {
+                let start = IndexKey::String(prefix.clone());
+                // Half-open [prefix, upper) — see prefix_scan_upper_bound (H).
+                let end = prefix_scan_upper_bound(prefix);
+                // O(1) count over the raw range is correct only for an exact,
+                // case-sensitive prefix: a non-exact regex (`^a.*b`) over-counts
+                // the range, and a `(?i)` regex's Unicode case-folding differs
+                // from the index's to_lowercase keys (findings F + I). Otherwise
+                // the count must post-filter (exact = false).
+                let exact = *exact && !*case_insensitive;
+                PlanRanges::single(index_name, start, end, true, false, exact)
+            }
+
+            QueryPlan::SparseIndexScan { .. } => {
+                // Sparse index holds only docs where the field exists → the whole
+                // key space answers `$exists: true` exactly.
+                PlanRanges::single(
+                    index_name,
+                    IndexKey::Null,
+                    IndexKey::MaxKey,
+                    true,
+                    true,
+                    true,
+                )
+            }
+
+            QueryPlan::MultiRegexPrefixScan { prefixes, .. } => {
+                let sub_ranges = prefixes
+                    .iter()
+                    .map(|p| SubRange {
+                        start: IndexKey::String(p.clone()),
+                        end: prefix_scan_upper_bound(p),
+                        inclusive_start: true,
+                        inclusive_end: false,
+                    })
+                    .collect();
+                PlanRanges::multi(index_name, sub_ranges, true)
+            }
+
+            QueryPlan::MultiValueScan { keys, .. } => {
+                // O(k) point lookups for `$in`. The planner dedups the keys, so
+                // disjoint point ranges sum without double-counting (the multikey
+                // gate handles array-valued docs separately).
+                let sub_ranges = keys
+                    .iter()
+                    .map(|k| SubRange {
+                        start: k.clone(),
+                        end: k.clone(),
+                        inclusive_start: true,
+                        inclusive_end: true,
+                    })
+                    .collect();
+                PlanRanges::multi(index_name, sub_ranges, true)
+            }
+        }
+    }
+}
+
+impl BPlusTree {
+    /// Exact count of catalog-validated documents across all of a plan's
+    /// sub-ranges. O(1) memory; no post-filter.
+    ///
+    /// The caller MUST guarantee [`PlanRanges::exact`] and a non-multikey index
+    /// (otherwise summing raw range counts diverges from the query result — use
+    /// [`Self::scan_ranges`] + an index-narrowed post-filter instead).
+    ///
+    /// Subsumes the former `count_numeric_buckets` (the numeric case is just a
+    /// two-sub-range `PlanRanges`).
+    pub(crate) fn count_exact(
+        &self,
+        ranges: &PlanRanges,
+        catalog: &HashMap<DocumentId, u64>,
+    ) -> usize {
+        ranges
+            .sub_ranges
+            .iter()
+            .map(|r| {
+                self.count_range_validated(
+                    &r.start,
+                    &r.end,
+                    r.inclusive_start,
+                    r.inclusive_end,
+                    catalog,
+                )
+            })
+            .sum()
+    }
+
+    /// Union of document ids across all of a plan's sub-ranges, in scan order.
+    ///
+    /// A single range is returned verbatim so the caller's own index-sort order
+    /// and `HashSet::retain` dedup are preserved (find relies on this). Multiple
+    /// ranges (numeric buckets, `$in`, multi-regex) are concatenated then sorted
+    /// and de-duplicated — matching the former `scan_numeric_buckets`/`$in` loops —
+    /// because a doc may appear in more than one sub-range.
+    ///
+    /// OOM-safe: each sub-range's docs are `try_reserve`d before being appended,
+    /// so a runaway union returns an error instead of aborting. This avoids the
+    /// separate O(range) Count-mode pass the unified path would otherwise add —
+    /// the old numeric scan did a single descent per bucket, and a doubled descent
+    /// (Count then Scan) is wasted work on the hot numeric-range find/`$match` path.
+    ///
+    /// Subsumes the former `scan_numeric_buckets`.
+    pub(crate) fn scan_ranges(&self, ranges: &PlanRanges) -> Result<Vec<DocumentId>> {
+        let scan_mode = || RangeQueryMode::Scan {
+            skip: 0,
+            limit: None,
+            order: ScanOrder::Asc,
+        };
+
+        if ranges.sub_ranges.len() == 1 {
+            let r = &ranges.sub_ranges[0];
+            return Ok(self
+                .range_query(
+                    &r.start,
+                    &r.end,
+                    r.inclusive_start,
+                    r.inclusive_end,
+                    scan_mode(),
+                )
+                .unwrap_docs());
+        }
+
+        let mut ids: Vec<DocumentId> = Vec::new();
+        for r in &ranges.sub_ranges {
+            let chunk = self
+                .range_query(
+                    &r.start,
+                    &r.end,
+                    r.inclusive_start,
+                    r.inclusive_end,
+                    scan_mode(),
+                )
+                .unwrap_docs();
+            ids.try_reserve(chunk.len()).map_err(|e| {
+                IronBaseError::OutOfMemory(format!(
+                    "Cannot allocate {} index entries in scan_ranges ({e})",
+                    chunk.len()
+                ))
+            })?;
+            ids.extend(chunk);
+        }
+        // Dedup across overlapping/duplicate-doc sub-ranges (a multikey doc may
+        // land in both the Int and Float bucket; find dedups again, harmlessly).
+        ids.sort_unstable();
+        ids.dedup();
+        Ok(ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::key::OrderedFloat;
+
+    fn tree() -> BPlusTree {
+        BPlusTree::new("idx".to_string(), "f".to_string(), false, false)
+    }
+
+    fn range_scan(start: Option<IndexKey>, end: Option<IndexKey>, is: bool, ie: bool) -> QueryPlan {
+        QueryPlan::IndexRangeScan {
+            index_name: "idx".to_string(),
+            field: "f".to_string(),
+            start,
+            end,
+            inclusive_start: is,
+            inclusive_end: ie,
+        }
+    }
+
+    #[test]
+    fn index_scan_single_point_exact_contiguous() {
+        let plan = QueryPlan::IndexScan {
+            index_name: "idx".to_string(),
+            field: "f".to_string(),
+            key: IndexKey::Int(7),
+            is_compound: false,
+        };
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.index_name, "idx");
+        assert_eq!(r.sub_ranges.len(), 1);
+        assert!(r.exact);
+        assert!(r.single_contiguous());
+        let sr = &r.sub_ranges[0];
+        assert_eq!(sr.start, IndexKey::Int(7));
+        assert_eq!(sr.end, IndexKey::Int(7));
+        assert!(sr.inclusive_start && sr.inclusive_end);
+    }
+
+    #[test]
+    fn compound_index_scan_uses_prefix_range() {
+        let mut compound =
+            BPlusTree::new_compound("c".to_string(), vec!["a".into(), "b".into()], false, false);
+        compound
+            .insert(
+                IndexKey::Compound(vec![IndexKey::Int(1), IndexKey::Int(2)]),
+                DocumentId::Int(1),
+            )
+            .unwrap();
+        let plan = QueryPlan::IndexScan {
+            index_name: "c".to_string(),
+            field: "a".to_string(),
+            key: IndexKey::Int(1),
+            is_compound: true,
+        };
+        let r = PlanRanges::from_plan(&plan, &compound);
+        assert_eq!(r.sub_ranges.len(), 1);
+        assert!(r.single_contiguous() && r.exact);
+        // build_prefix_range wraps the key in a Compound with Null/MaxKey tail.
+        let sr = &r.sub_ranges[0];
+        assert!(matches!(sr.start, IndexKey::Compound(_)));
+        assert!(matches!(sr.end, IndexKey::Compound(_)));
+    }
+
+    #[test]
+    fn numeric_range_splits_into_two_buckets() {
+        // {f: {$gte: 18, $lt: 65}} → Int bucket + Float bucket.
+        let plan = range_scan(
+            Some(IndexKey::Int(18)),
+            Some(IndexKey::Int(65)),
+            true,
+            false,
+        );
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 2, "numeric range = Int + Float buckets");
+        assert!(!r.single_contiguous(), "two buckets are not streamable");
+        assert!(r.exact);
+        // First sub-range is the Int bucket, second the Float bucket.
+        assert!(matches!(r.sub_ranges[0].start, IndexKey::Int(_)));
+        assert!(matches!(r.sub_ranges[1].start, IndexKey::Float(_)));
+    }
+
+    #[test]
+    fn float_only_numeric_range_still_two_buckets() {
+        let plan = range_scan(
+            Some(IndexKey::Float(OrderedFloat(1.5))),
+            Some(IndexKey::Float(OrderedFloat(9.5))),
+            true,
+            true,
+        );
+        let r = PlanRanges::from_plan(&plan, &tree());
+        // No integer falls outside (1.5, 9.5) boundaries but some do inside, so
+        // the Int bucket is present; the Float bucket always is.
+        assert!(r.sub_ranges.len() == 2 || r.sub_ranges.len() == 1);
+        assert!(r.exact);
+    }
+
+    #[test]
+    fn string_range_is_single_contiguous() {
+        let plan = range_scan(
+            Some(IndexKey::String("a".into())),
+            Some(IndexKey::String("z".into())),
+            true,
+            true,
+        );
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 1);
+        assert!(r.single_contiguous() && r.exact);
+    }
+
+    #[test]
+    fn unbounded_string_upper_defaults_to_maxkey() {
+        // {f: {$gte: "abc"}} → [String("abc"), MaxKey].
+        let plan = range_scan(Some(IndexKey::String("abc".into())), None, true, true);
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 1);
+        assert!(r.single_contiguous());
+        assert_eq!(r.sub_ranges[0].start, IndexKey::String("abc".into()));
+        assert_eq!(r.sub_ranges[0].end, IndexKey::MaxKey);
+    }
+
+    #[test]
+    fn regex_exact_cs_is_exact() {
+        let plan = QueryPlan::RegexPrefixScan {
+            index_name: "idx".to_string(),
+            field: "f".to_string(),
+            prefix: "Al".to_string(),
+            exact: true,
+            case_insensitive: false,
+        };
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 1);
+        assert!(r.single_contiguous());
+        assert!(r.exact, "exact && !ci ⇒ exact");
+        let sr = &r.sub_ranges[0];
+        assert_eq!(sr.start, IndexKey::String("Al".into()));
+        assert!(
+            sr.inclusive_start && !sr.inclusive_end,
+            "half-open [prefix, upper)"
+        );
+    }
+
+    #[test]
+    fn regex_nonexact_or_ci_is_not_exact() {
+        for (exact, ci) in [(false, false), (true, true), (false, true)] {
+            let plan = QueryPlan::RegexPrefixScan {
+                index_name: "idx".to_string(),
+                field: "f".to_string(),
+                prefix: "al".to_string(),
+                exact,
+                case_insensitive: ci,
+            };
+            let r = PlanRanges::from_plan(&plan, &tree());
+            assert!(!r.exact, "non-exact OR ci ⇒ post-filter (exact=false)");
+            assert!(r.single_contiguous(), "regex is still a single range");
+        }
+    }
+
+    #[test]
+    fn sparse_scan_covers_whole_keyspace() {
+        let plan = QueryPlan::SparseIndexScan {
+            index_name: "idx".to_string(),
+            field: "f".to_string(),
+        };
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 1);
+        assert!(r.single_contiguous() && r.exact);
+        assert_eq!(r.sub_ranges[0].start, IndexKey::Null);
+        assert_eq!(r.sub_ranges[0].end, IndexKey::MaxKey);
+    }
+
+    #[test]
+    fn multi_value_scan_is_multi_range_not_contiguous() {
+        let plan = QueryPlan::MultiValueScan {
+            index_name: "idx".to_string(),
+            field: "f".to_string(),
+            keys: vec![IndexKey::Int(1), IndexKey::Int(2), IndexKey::Int(3)],
+        };
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 3);
+        assert!(!r.single_contiguous(), "$in union is not streamable");
+        assert!(r.exact);
+        for sr in &r.sub_ranges {
+            assert_eq!(sr.start, sr.end, "each $in key is a point lookup");
+        }
+    }
+
+    #[test]
+    fn single_key_in_is_contiguous() {
+        // A one-element $in collapses to a single point range — streamable.
+        let plan = QueryPlan::MultiValueScan {
+            index_name: "idx".to_string(),
+            field: "f".to_string(),
+            keys: vec![IndexKey::Int(42)],
+        };
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 1);
+        assert!(r.single_contiguous());
+    }
+
+    #[test]
+    fn multi_regex_is_multi_range() {
+        let plan = QueryPlan::MultiRegexPrefixScan {
+            index_name: "idx".to_string(),
+            field: "f".to_string(),
+            prefixes: vec!["A".into(), "B".into()],
+        };
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 2);
+        assert!(!r.single_contiguous());
+        for sr in &r.sub_ranges {
+            assert!(sr.inclusive_start && !sr.inclusive_end);
+        }
+    }
+
+    // ---- consumer smoke tests (count_exact / scan_ranges wire-up) ----
+
+    fn catalog_of(ids: &[DocumentId]) -> HashMap<DocumentId, u64> {
+        ids.iter().map(|d| (d.clone(), 0u64)).collect()
+    }
+
+    #[test]
+    fn scan_and_count_single_range() {
+        let mut t = tree();
+        for i in 1..=5 {
+            t.insert(IndexKey::Int(i), DocumentId::Int(i as i64))
+                .unwrap();
+        }
+        let cat = catalog_of(&(1..=5).map(DocumentId::Int).collect::<Vec<_>>());
+        // {f: {$gte: 2, $lte: 4}} (numeric → two buckets, Int bucket carries all).
+        let plan = range_scan(Some(IndexKey::Int(2)), Some(IndexKey::Int(4)), true, true);
+        let r = PlanRanges::from_plan(&plan, &t);
+        let docs = t.scan_ranges(&r).unwrap();
+        assert_eq!(docs.len(), 3, "ids 2,3,4");
+        assert_eq!(t.count_exact(&r, &cat), 3);
+    }
+
+    #[test]
+    fn scan_ranges_dedups_multikey_across_buckets() {
+        // One doc indexed under both an Int and a Float key inside the range must
+        // appear once after scan_ranges' multi-range dedup.
+        let mut t = tree();
+        t.insert(IndexKey::Int(3), DocumentId::Int(1)).unwrap();
+        t.insert(IndexKey::Float(OrderedFloat(3.5)), DocumentId::Int(1))
+            .unwrap();
+        let plan = range_scan(Some(IndexKey::Int(2)), Some(IndexKey::Int(4)), true, true);
+        let r = PlanRanges::from_plan(&plan, &t);
+        assert_eq!(r.sub_ranges.len(), 2);
+        let docs = t.scan_ranges(&r).unwrap();
+        assert_eq!(docs, vec![DocumentId::Int(1)], "deduped across buckets");
+    }
+
+    #[test]
+    fn count_exact_sums_in_keys() {
+        let mut t = tree();
+        for i in 1..=4 {
+            t.insert(IndexKey::Int(i), DocumentId::Int(i as i64))
+                .unwrap();
+        }
+        let cat = catalog_of(&(1..=4).map(DocumentId::Int).collect::<Vec<_>>());
+        let plan = QueryPlan::MultiValueScan {
+            index_name: "idx".to_string(),
+            field: "f".to_string(),
+            keys: vec![IndexKey::Int(1), IndexKey::Int(3)],
+        };
+        let r = PlanRanges::from_plan(&plan, &t);
+        assert_eq!(t.count_exact(&r, &cat), 2);
+        assert_eq!(t.scan_ranges(&r).unwrap().len(), 2);
+    }
+}

--- a/ironbase-core/src/index/plan_ranges.rs
+++ b/ironbase-core/src/index/plan_ranges.rs
@@ -49,13 +49,16 @@ pub(crate) struct PlanRanges {
     /// Whether `count` may sum the raw validated range counts WITHOUT a
     /// post-filter. This carries only the per-plan part of that decision —
     /// chiefly the `RegexPrefixScan` `exact && !case_insensitive` rule (count.rs,
-    /// audit findings F + I) and the non-numeric range type-homogeneity rule
-    /// (finding #1, 2026-06-08: a single-sided range whose defaulted open end
-    /// crosses other key-type buckets, e.g. `{f: {$lt: "z"}}` → `[Null, "z"]`, is
-    /// NOT exact — `count_exact` would count the Int/Float/Bool keys the operator
-    /// can never match). The caller still ANDs `exact` with its own coverage +
-    /// non-multikey gates; a non-exact plan routes count through the index-narrowed
-    /// post-filter, matching find.
+    /// audit findings F + I). For a non-numeric range, `from_plan` builds a
+    /// TYPE-TIGHT range (an absent bound is filled with the present bound's type
+    /// min/max), so the range holds only the operator's type and stays exact —
+    /// `{f: {$lt: "z"}}` scans `[String(""), "z")`, not `[Null, "z"]`, keeping the
+    /// O(1) count fast path while excluding the Int/Float/Bool keys the operator
+    /// can never match (finding #1 + perf follow-up, 2026-06-08). `exact` is false
+    /// only for shapes a single range cannot tighten (a bound type with no scalar
+    /// min/max sentinel, or a fully-unbounded range). The caller still ANDs `exact`
+    /// with its own coverage + non-multikey gates; a non-exact plan routes count
+    /// through the index-narrowed post-filter, matching find.
     pub exact: bool,
 }
 
@@ -152,46 +155,69 @@ impl PlanRanges {
                     });
                     PlanRanges::multi(index_name, sub_ranges, true)
                 } else {
-                    // Non-numeric (string/bool) range. An absent bound becomes the
-                    // open end of the key space (Null below, MaxKey above). All
-                    // three executors agree on this single bound; find/cursor make
-                    // it exact via their post-filter.
+                    // Non-numeric (string/bool) range. Make the scanned range
+                    // TYPE-TIGHT: an absent bound is filled with the PRESENT bound's
+                    // type min/max, so the range holds ONLY keys of that type. This
+                    // keeps count's O(1) `count_exact` path valid (no cross-bucket
+                    // keys to over-count) AND tightens the find/cursor scan — rather
+                    // than widening to `[Null, hi]` / `[lo, MaxKey]` and leaning on a
+                    // post-filter, which over-counted on the count fast path AND
+                    // dropped count from O(1) to O(matches) even on a type-
+                    // homogeneous field (finding #1 + perf follow-up, 2026-06-08).
                     //
-                    // COUNT has no post-filter (count_exact), so the raw range is
-                    // an exact answer ONLY when it is type-homogeneous — it must
-                    // not pull in index keys of a type the operator can never match
-                    // (finding #1, 2026-06-08, e.g. `{f: {$lt: "z"}}` →
-                    // `[Null, "z"]` counting Int/Float/Bool keys):
-                    //  - a defaulted LOWER (Null) pulls in every bucket below the
-                    //    upper bound → never exact;
-                    //  - a defaulted UPPER (MaxKey) pulls in every bucket above the
-                    //    lower bound → exact only when the lower bound is a String,
-                    //    the top scalar bucket on a single-field index (above it
-                    //    only the never-present Compound keys sort);
-                    //  - a fully-bounded range is exact iff both bounds share a
-                    //    type bucket (the planner already rejects mixed-type
-                    //    two-sided ranges; re-checked here for safety).
-                    // Non-exact ⇒ count takes the index-narrowed post-filter path,
-                    // matching find's correct result.
-                    let exact = match (start.as_ref(), end.as_ref()) {
-                        (Some(s), Some(e)) => {
-                            QueryPlanner::index_key_type_bucket(s)
-                                == QueryPlanner::index_key_type_bucket(e)
+                    // Bounds here are non-numeric (numeric goes through the bucket
+                    // path) — String in practice, occasionally Bool. The planner
+                    // already rejects mixed-type two-sided ranges, so a two-sided
+                    // range shares one bucket. A FILLED bound is INCLUSIVE of the
+                    // type boundary; the PRESENT bound keeps the plan's inclusivity.
+                    // IndexKey order: Null < Bool < Int < Float < String < Compound
+                    // < MaxKey. `String("")` is the lexicographically smallest string
+                    // (so `[String(""), hi)` excludes every Bool/Int/Float/Null key);
+                    // a single-field index stores no Compound keys, so `[lo, MaxKey]`
+                    // with a String `lo` is already string-only (String is the top
+                    // scalar bucket).
+                    let (lo, lo_incl, hi, hi_incl, exact) = match (start.as_ref(), end.as_ref()) {
+                        // Two-sided, same bucket → already type-tight.
+                        (Some(s), Some(e))
+                            if QueryPlanner::index_key_type_bucket(s)
+                                == QueryPlanner::index_key_type_bucket(e) =>
+                        {
+                            (s.clone(), *inclusive_start, e.clone(), *inclusive_end, true)
                         }
-                        (Some(IndexKey::String(_)), None) => true,
-                        (Some(_), None) => false,
-                        (None, _) => false,
+                        // Open lower → the upper bound's type-minimum.
+                        (None, Some(e @ IndexKey::String(_))) => (
+                            IndexKey::String(String::new()),
+                            true,
+                            e.clone(),
+                            *inclusive_end,
+                            true,
+                        ),
+                        (None, Some(e @ IndexKey::Bool(_))) => {
+                            (IndexKey::Bool(false), true, e.clone(), *inclusive_end, true)
+                        }
+                        // Open upper → the lower bound's type-maximum (MaxKey for a
+                        // String lower — the top scalar bucket; Bool(true) for Bool).
+                        (Some(s @ IndexKey::String(_)), None) => {
+                            (s.clone(), *inclusive_start, IndexKey::MaxKey, true, true)
+                        }
+                        (Some(s @ IndexKey::Bool(_)), None) => (
+                            s.clone(),
+                            *inclusive_start,
+                            IndexKey::Bool(true),
+                            true,
+                            true,
+                        ),
+                        // Unhandled bound type, both-absent, or (defensively) a
+                        // two-sided cross-bucket range → widest range + post-filter.
+                        _ => (
+                            start.clone().unwrap_or(IndexKey::Null),
+                            *inclusive_start,
+                            end.clone().unwrap_or(IndexKey::MaxKey),
+                            *inclusive_end,
+                            false,
+                        ),
                     };
-                    let start = start.clone().unwrap_or(IndexKey::Null);
-                    let end = end.clone().unwrap_or(IndexKey::MaxKey);
-                    PlanRanges::single(
-                        index_name,
-                        start,
-                        end,
-                        *inclusive_start,
-                        *inclusive_end,
-                        exact,
-                    )
+                    PlanRanges::single(index_name, lo, hi, lo_incl, hi_incl, exact)
                 }
             }
 
@@ -487,13 +513,57 @@ mod tests {
 
     #[test]
     fn unbounded_string_upper_defaults_to_maxkey() {
-        // {f: {$gte: "abc"}} → [String("abc"), MaxKey].
+        // {f: {$gte: "abc"}} → [String("abc"), MaxKey]; String is the top scalar
+        // bucket on a single-field index, so this is exact (O(1) count).
         let plan = range_scan(Some(IndexKey::String("abc".into())), None, true, true);
         let r = PlanRanges::from_plan(&plan, &tree());
         assert_eq!(r.sub_ranges.len(), 1);
         assert!(r.single_contiguous());
         assert_eq!(r.sub_ranges[0].start, IndexKey::String("abc".into()));
         assert_eq!(r.sub_ranges[0].end, IndexKey::MaxKey);
+        assert!(r.exact, "open-upper string range is type-tight → exact");
+    }
+
+    #[test]
+    fn unbounded_string_lower_is_type_tight_and_exact() {
+        // {f: {$lt: "z"}} → open lower filled with String("") (the lex-min string),
+        // NOT Null — so the range is string-only and EXACT (keeps the O(1) count
+        // fast path; the perf regression of routing it to the narrow path is gone).
+        let plan = range_scan(None, Some(IndexKey::String("z".into())), true, false);
+        let r = PlanRanges::from_plan(&plan, &tree());
+        assert_eq!(r.sub_ranges.len(), 1);
+        assert!(r.single_contiguous());
+        let sr = &r.sub_ranges[0];
+        assert_eq!(
+            sr.start,
+            IndexKey::String(String::new()),
+            "lower = String(\"\"), not Null"
+        );
+        assert!(sr.inclusive_start, "filled lower bound is inclusive");
+        assert_eq!(sr.end, IndexKey::String("z".into()));
+        assert!(!sr.inclusive_end, "$lt → exclusive upper preserved");
+        assert!(r.exact, "type-tight string range is exact");
+    }
+
+    #[test]
+    fn unbounded_bool_bounds_are_type_tight() {
+        // {f: {$gte: true}} → [Bool(true), Bool(true)] (open upper filled with the
+        // Bool max, not MaxKey), exact and bool-only.
+        let gte = range_scan(Some(IndexKey::Bool(true)), None, true, true);
+        let r = PlanRanges::from_plan(&gte, &tree());
+        assert_eq!(r.sub_ranges[0].start, IndexKey::Bool(true));
+        assert_eq!(r.sub_ranges[0].end, IndexKey::Bool(true));
+        assert!(r.exact, "bool open-upper is type-tight → exact");
+
+        // {f: {$lt: true}} → [Bool(false), Bool(true)) (open lower filled with the
+        // Bool min), exact.
+        let lt = range_scan(None, Some(IndexKey::Bool(true)), true, false);
+        let r = PlanRanges::from_plan(&lt, &tree());
+        assert_eq!(r.sub_ranges[0].start, IndexKey::Bool(false));
+        assert!(r.sub_ranges[0].inclusive_start);
+        assert_eq!(r.sub_ranges[0].end, IndexKey::Bool(true));
+        assert!(!r.sub_ranges[0].inclusive_end);
+        assert!(r.exact, "bool open-lower is type-tight → exact");
     }
 
     #[test]

--- a/ironbase-core/src/index/plan_ranges.rs
+++ b/ironbase-core/src/index/plan_ranges.rs
@@ -296,11 +296,15 @@ impl BPlusTree {
     /// and de-duplicated — matching the former `scan_numeric_buckets`/`$in` loops —
     /// because a doc may appear in more than one sub-range.
     ///
-    /// OOM-safe: each sub-range's docs are `try_reserve`d before being appended,
-    /// so a runaway union returns an error instead of aborting. This avoids the
-    /// separate O(range) Count-mode pass the unified path would otherwise add —
-    /// the old numeric scan did a single descent per bucket, and a doubled descent
-    /// (Count then Scan) is wasted work on the hot numeric-range find/`$match` path.
+    /// OOM-safe at the UNION level: each sub-range's docs are `try_reserve`d
+    /// before being appended, so accumulating across many sub-ranges
+    /// (`$in`/multi-regex) returns an error instead of aborting. A single
+    /// sub-range whose own `range_query` materializes more docs than fit in RAM
+    /// still aborts inside `range_query` (the unbounded inner `Vec`) — the same
+    /// exposure as the single-range path and the former `scan_numeric_buckets`,
+    /// not made worse here. This avoids the separate O(range) Count-mode pass the
+    /// unified path would otherwise add — a doubled descent (Count then Scan) is
+    /// wasted work on the hot numeric-range find/`$match` path.
     ///
     /// Subsumes the former `scan_numeric_buckets`.
     pub(crate) fn scan_ranges(&self, ranges: &PlanRanges) -> Result<Vec<DocumentId>> {
@@ -433,17 +437,38 @@ mod tests {
     }
 
     #[test]
-    fn float_only_numeric_range_still_two_buckets() {
-        let plan = range_scan(
+    fn float_only_numeric_range_buckets() {
+        // Float bounds that CONTAIN integers (2..=9) → Int bucket present → two
+        // sub-ranges (Int then Float). This pins the finding-D regression guard.
+        let with_ints = range_scan(
             Some(IndexKey::Float(OrderedFloat(1.5))),
             Some(IndexKey::Float(OrderedFloat(9.5))),
             true,
             true,
         );
-        let r = PlanRanges::from_plan(&plan, &tree());
-        // No integer falls outside (1.5, 9.5) boundaries but some do inside, so
-        // the Int bucket is present; the Float bucket always is.
-        assert!(r.sub_ranges.len() == 2 || r.sub_ranges.len() == 1);
+        let r = PlanRanges::from_plan(&with_ints, &tree());
+        assert_eq!(r.sub_ranges.len(), 2, "Int bucket (2..=9) + Float bucket");
+        assert!(matches!(r.sub_ranges[0].start, IndexKey::Int(_)));
+        assert!(matches!(r.sub_ranges[1].start, IndexKey::Float(_)));
+        assert!(!r.single_contiguous());
+        assert!(r.exact);
+
+        // Float bounds with NO integer between them (ceil 1.2 = 2 > floor 1.8 = 1)
+        // → Int bucket absent → a single Float sub-range, which IS streamable.
+        let no_ints = range_scan(
+            Some(IndexKey::Float(OrderedFloat(1.2))),
+            Some(IndexKey::Float(OrderedFloat(1.8))),
+            true,
+            true,
+        );
+        let r = PlanRanges::from_plan(&no_ints, &tree());
+        assert_eq!(
+            r.sub_ranges.len(),
+            1,
+            "no integer in (1.2, 1.8) → Float bucket only"
+        );
+        assert!(r.single_contiguous());
+        assert!(matches!(r.sub_ranges[0].start, IndexKey::Float(_)));
         assert!(r.exact);
     }
 

--- a/ironbase-core/src/query_planner.rs
+++ b/ironbase-core/src/query_planner.rs
@@ -263,6 +263,21 @@ pub enum QueryPlan {
     },
 }
 
+impl QueryPlan {
+    /// Name of the index this plan scans. Every variant carries one, so this
+    /// replaces the 6-arm `match` previously hand-duplicated at each call site.
+    pub fn index_name(&self) -> &str {
+        match self {
+            QueryPlan::IndexScan { index_name, .. }
+            | QueryPlan::IndexRangeScan { index_name, .. }
+            | QueryPlan::RegexPrefixScan { index_name, .. }
+            | QueryPlan::MultiRegexPrefixScan { index_name, .. }
+            | QueryPlan::MultiValueScan { index_name, .. }
+            | QueryPlan::SparseIndexScan { index_name, .. } => index_name,
+        }
+    }
+}
+
 /// Query planner - analyzes queries and selects optimal execution plan
 pub struct QueryPlanner;
 
@@ -632,7 +647,10 @@ impl QueryPlanner {
     /// can never overlap into a valid range, so a mixed-type range (e.g.
     /// `{$gte: 5, $lte: "z"}`) matches nothing — the `IndexKey` equivalent of
     /// `value_type_rank` (audit 2026-06-06 finding: mixed-type range over-count).
-    fn index_key_type_bucket(k: &IndexKey) -> u8 {
+    /// `pub(crate)` so `PlanRanges::from_plan` can reuse it to decide range
+    /// exactness for count (a single-sided range whose open end crosses buckets
+    /// is NOT exact — finding #1, 2026-06-08).
+    pub(crate) fn index_key_type_bucket(k: &IndexKey) -> u8 {
         match k {
             IndexKey::Null => 0,
             IndexKey::Bool(_) => 1,

--- a/ironbase-core/tests/common/mod.rs
+++ b/ironbase-core/tests/common/mod.rs
@@ -8,9 +8,10 @@
 #![allow(dead_code)]
 
 use ironbase_core::storage::MemoryStorage;
-use ironbase_core::DatabaseCore;
+use ironbase_core::{DatabaseCore, StorageEngine};
 use serde_json::Value;
 use std::collections::HashMap;
+use tempfile::TempDir;
 
 pub fn doc(v: &Value) -> HashMap<String, Value> {
     v.as_object()
@@ -31,7 +32,10 @@ fn build(docs: &[Value]) -> DatabaseCore<MemoryStorage> {
     db
 }
 
-fn compare(db: &DatabaseCore<MemoryStorage>, query: &Value) {
+/// Compares indexed `count`/`find` against the ground-truth collection scan.
+/// Returns the ground-truth row count so the caller can also assert the
+/// file-backed streaming cursor (see `assert_cursor_matches_scan`).
+fn compare(db: &DatabaseCore<MemoryStorage>, query: &Value) -> u64 {
     let cidx = db.get_collection("idx").unwrap();
     let cno = db.get_collection("noidx").unwrap();
 
@@ -53,6 +57,50 @@ fn compare(db: &DatabaseCore<MemoryStorage>, query: &Value) {
         find_idx, find_scan,
         "indexed find diverges from collection scan for {query}: {find_idx} != {find_scan}"
     );
+    count_scan
+}
+
+/// Third leg of the parity oracle: drain `find_streaming` on a **file-backed**
+/// collection and assert the cursor row count matches the ground-truth scan.
+///
+/// MemoryStorage early-returns `find_streaming` to the materialized
+/// `collect_doc_ids_from_plan` path, so the streaming cursor
+/// (`FindCursor::*_from_plan`) is only ever exercised on a real `.mlite` file.
+/// Without this leg a cursor-only divergence (e.g. the numeric Int/Float
+/// two-bucket split that originally missed the cursor) is invisible to the
+/// MemoryStorage `count == find == scan` checks above.
+fn assert_cursor_matches_scan(
+    docs: &[Value],
+    index_field: &str,
+    query: &Value,
+    ci: bool,
+    scan: u64,
+) {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("parity.mlite");
+    let db = DatabaseCore::<StorageEngine>::open(&path).unwrap();
+    db.collection("idx").unwrap();
+    for d in docs {
+        db.insert_one("idx", doc(d)).unwrap();
+    }
+    let cidx = db.get_collection("idx").unwrap();
+    if ci {
+        cidx.create_ci_index(index_field.to_string(), false)
+            .unwrap();
+    } else {
+        cidx.create_index(index_field.to_string(), false, false)
+            .unwrap();
+    }
+
+    let mut cursor = cidx.find_streaming(query).unwrap();
+    let mut cursor_n = 0u64;
+    while cursor.next().unwrap().is_some() {
+        cursor_n += 1;
+    }
+    assert_eq!(
+        cursor_n, scan,
+        "file-backed streaming cursor diverges from collection scan for {query}: {cursor_n} != {scan}"
+    );
 }
 
 /// Single-field B+ tree index (non-unique, non-sparse) on `index_field`.
@@ -62,7 +110,8 @@ pub fn assert_index_matches_scan(docs: &[Value], index_field: &str, query: &Valu
         .unwrap()
         .create_index(index_field.to_string(), false, false)
         .unwrap();
-    compare(&db, query);
+    let scan = compare(&db, query);
+    assert_cursor_matches_scan(docs, index_field, query, false, scan);
 }
 
 /// Case-insensitive B+ tree index (non-unique) on `index_field`.
@@ -72,5 +121,6 @@ pub fn assert_ci_index_matches_scan(docs: &[Value], index_field: &str, query: &V
         .unwrap()
         .create_ci_index(index_field.to_string(), false)
         .unwrap();
-    compare(&db, query);
+    let scan = compare(&db, query);
+    assert_cursor_matches_scan(docs, index_field, query, true, scan);
 }

--- a/ironbase-core/tests/qp_review_followup_test.rs
+++ b/ironbase-core/tests/qp_review_followup_test.rs
@@ -1,0 +1,202 @@
+//! Regression tests for the two pre-existing count/find divergences surfaced by
+//! the #8 (QueryPlan executor unification) code review, 2026-06-08:
+//!
+//! 1. A single-sided non-numeric `IndexRangeScan` whose defaulted open end
+//!    crosses other key-type buckets was counted EXACT (no post-filter), so
+//!    `count_documents` summed index keys the operator can never match — e.g.
+//!    `{f: {$lt: "z"}}` over mixed-type data returned 6 vs the correct 1.
+//!    Fixed: `PlanRanges::from_plan` marks such a range non-exact, routing count
+//!    through the index-narrowed post-filter (matching find).
+//!
+//! 2. A numeric `IndexRangeScan` (Int/Float two-bucket scan) returns its doc_ids
+//!    DocumentId-sorted, not in index-key order, yet `collect_doc_ids_from_plan`
+//!    reported `uses_index_sort = true` for it — so `find(...).sort({f: 1})`
+//!    skipped the memory sort and returned DocumentId order. Fixed: index-sort is
+//!    claimed only for a single contiguous (index-ordered) scan.
+
+mod common;
+
+use common::assert_index_matches_scan;
+use ironbase_core::storage::MemoryStorage;
+use ironbase_core::{DatabaseCore, FindOptions};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+fn doc(v: &Value) -> HashMap<String, Value> {
+    v.as_object()
+        .unwrap()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+// ----------------------------------------------------------------------------
+// Finding #1 — cross-type single-sided range count must equal find/scan.
+// assert_index_matches_scan checks count == find == collection-scan AND drains a
+// file-backed streaming cursor, across every bound shape.
+// ----------------------------------------------------------------------------
+
+fn mixed_type_docs() -> Vec<Value> {
+    vec![
+        json!({"f": 5}),
+        json!({"f": 7}),
+        json!({"f": 1.5}),
+        json!({"f": true}),
+        json!({"f": false}),
+        json!({"f": "apple"}),
+        json!({"f": "zebra"}),
+        json!({"f": null}),
+    ]
+}
+
+#[test]
+fn cross_type_lt_string_upper_open_lower() {
+    // [Null, "z") spans Int/Float/Bool/Null — only "apple" matches.
+    assert_index_matches_scan(&mixed_type_docs(), "f", &json!({"f": {"$lt": "z"}}));
+}
+
+#[test]
+fn cross_type_lte_string_upper_open_lower() {
+    assert_index_matches_scan(&mixed_type_docs(), "f", &json!({"f": {"$lte": "m"}}));
+}
+
+#[test]
+fn cross_type_gte_string_lower_open_upper() {
+    // [String("a"), MaxKey] is type-homogeneous on a single-field index → stays
+    // exact AND correct (only strings >= "a").
+    assert_index_matches_scan(&mixed_type_docs(), "f", &json!({"f": {"$gte": "a"}}));
+}
+
+#[test]
+fn cross_type_gt_string_lower_open_upper() {
+    assert_index_matches_scan(&mixed_type_docs(), "f", &json!({"f": {"$gt": "apple"}}));
+}
+
+#[test]
+fn cross_type_bounded_string_range() {
+    // Fully-bounded same-bucket range — exact and correct.
+    assert_index_matches_scan(
+        &mixed_type_docs(),
+        "f",
+        &json!({"f": {"$gte": "a", "$lte": "z"}}),
+    );
+}
+
+#[test]
+fn cross_type_gte_bool_lower_open_upper() {
+    // [Bool(true), MaxKey] crosses Int/Float/String → must NOT be exact.
+    assert_index_matches_scan(&mixed_type_docs(), "f", &json!({"f": {"$gte": true}}));
+}
+
+#[test]
+fn cross_type_numeric_range_unaffected() {
+    // Control: a numeric range still counts both Int+Float buckets exactly.
+    assert_index_matches_scan(
+        &mixed_type_docs(),
+        "f",
+        &json!({"f": {"$gte": 0, "$lt": 100}}),
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Finding #2 — find(...).sort({field}) order must match the collection scan,
+// including for numeric (Int/Float two-bucket) ranges.
+// ----------------------------------------------------------------------------
+
+/// Build an indexed + a non-indexed collection with the same docs (insertion
+/// order deliberately != sorted order), then assert that for every (query, sort)
+/// the indexed `find_with_options` returns rows in the SAME order as the
+/// ground-truth collection scan.
+fn assert_sort_order_matches_scan(docs: &[Value], field: &str, query: &Value, sort_field: &str) {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("idx").unwrap();
+    db.collection("noidx").unwrap();
+    for d in docs {
+        db.insert_one("idx", doc(d)).unwrap();
+        db.insert_one("noidx", doc(d)).unwrap();
+    }
+    db.get_collection("idx")
+        .unwrap()
+        .create_index(field.to_string(), false, false)
+        .unwrap();
+
+    for dir in [1, -1] {
+        let opts = FindOptions::new().with_sort(vec![(sort_field.to_string(), dir)]);
+        let got: Vec<Value> = db
+            .get_collection("idx")
+            .unwrap()
+            .find_with_options(query, opts.clone())
+            .unwrap()
+            .iter()
+            .map(|d| d[sort_field].clone())
+            .collect();
+        let want: Vec<Value> = db
+            .get_collection("noidx")
+            .unwrap()
+            .find_with_options(query, opts)
+            .unwrap()
+            .iter()
+            .map(|d| d[sort_field].clone())
+            .collect();
+        assert_eq!(
+            got, want,
+            "indexed sort order diverges from scan for {query} sort {sort_field}:{dir}"
+        );
+    }
+}
+
+fn unsorted_numeric_docs() -> Vec<Value> {
+    // insertion order (= DocumentId order) is NOT the sorted order; mixed Int/Float
+    vec![
+        json!({"f": 40}),
+        json!({"f": 30.5}),
+        json!({"f": 20}),
+        json!({"f": 50.0}),
+        json!({"f": 10}),
+    ]
+}
+
+#[test]
+fn numeric_range_sort_order() {
+    // The two-bucket numeric scan is DocumentId-sorted; sort must re-order it.
+    assert_sort_order_matches_scan(
+        &unsorted_numeric_docs(),
+        "f",
+        &json!({"f": {"$gte": 0, "$lt": 100}}),
+        "f",
+    );
+}
+
+#[test]
+fn numeric_half_bounded_sort_order() {
+    assert_sort_order_matches_scan(
+        &unsorted_numeric_docs(),
+        "f",
+        &json!({"f": {"$gte": 0}}),
+        "f",
+    );
+}
+
+#[test]
+fn string_range_sort_order_unaffected() {
+    // Control: a single contiguous (index-ordered) string range still gets the
+    // index-sort fast path and stays correctly ordered.
+    let docs = vec![
+        json!({"f": "delta"}),
+        json!({"f": "alpha"}),
+        json!({"f": "charlie"}),
+        json!({"f": "bravo"}),
+    ];
+    assert_sort_order_matches_scan(&docs, "f", &json!({"f": {"$gte": "a", "$lte": "z"}}), "f");
+}
+
+#[test]
+fn in_query_sort_order() {
+    // $in is a multi-value (non-contiguous) scan → must also re-sort.
+    assert_sort_order_matches_scan(
+        &unsorted_numeric_docs(),
+        "f",
+        &json!({"f": {"$in": [10, 20, 30.5, 40, 50.0]}}),
+        "f",
+    );
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.527"
+version = "1.0.528"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Audit finding #8 — QueryPlan executor unification

A single `QueryPlan` was interpreted by **four** hand-synced executors — the two `count_with_plan` blocks (`count.rs`), `collect_doc_ids_from_plan` (`mod.rs`), and `FindCursor::new_index_scan_from_plan` (`cursor.rs`). Every plan→index-range fix had to be mirrored 2–4×, and the numeric Int/Float two-bucket fix once missed the cursor, shipping a bug where `find_streaming` silently dropped Float-keyed docs.

The derivation now lives **once** in `ironbase-core/src/index/plan_ranges.rs` (`PlanRanges::from_plan` + `BPlusTree::count_exact`/`scan_ranges`), read by three thin modes: count-exact (O(1), no post-filter), materialized find, and the streaming cursor (single contiguous range only). `count_numeric_buckets`/`scan_numeric_buckets`/`max_string_key` are subsumed and removed. Net ~−600 lines of duplicated derivation. Behavior-preserving; the unbounded-end non-numeric range now uses `IndexKey::MaxKey` consistently across all three executors.

A new 3-way `count == find == cursor == scan` parity oracle (file-backed streaming, `tests/common/mod.rs`) guards the cursor path the suite never exercised before.

### Migration (6 staged steps, stopped at the planned boundary)
1. 3-way parity oracle (the net that would have caught the prod cursor bug)
2. `QueryPlan::index_name()` accessor
3. `PlanRanges` + `from_plan` + `count_exact`/`scan_ranges` (+ 15 unit tests)
4. cursor → `from_plan` + `single_contiguous`
5. find → `scan_ranges`
6. count → `count_for_plan` + `CountOutcome` (preserves #75 lock order)

## Also fixes two PRE-EXISTING count/find divergences

Surfaced by an xhigh `/code-review` of this branch; both reproduced on `master` (not introduced here):

- **Single-sided non-numeric range over-counted on `count`** — a typed range with a defaulted open end crossing key-type buckets (e.g. `{f:{$lt:"z"}}` → `[Null,"z"]`) was treated as exact, so `count_documents` summed Int/Float/Bool keys the operator can never match (`count=6` vs `find=1` on mixed-type data). `from_plan` now marks such a range non-exact via a type-homogeneity check, routing count through the post-filter.
- **Numeric range `find(...).sort({field})` returned DocumentId order** — a numeric two-bucket scan yields DocumentId-sorted ids, but `uses_index_sort` was reported `true`, skipping the in-memory sort. Index-sort is now claimed only for a single contiguous (index-ordered) scan.

The `/code-review` also applied 4 quality fixes to the new code (incremental `try_reserve` in `scan_ranges`, regex-pushdown `single_contiguous` guard, `single_contiguous` as a derived method, doc accuracy).

## Verification
- `cargo test -p ironbase-core --no-fail-fast` → **1921 passed / 0 failed** (79 binaries)
- 15 `plan_ranges` unit tests + 11 new regression tests (`qp_review_followup_test`)
- `cargo clippy -p ironbase-core --tests`, `cargo fmt --check`, `cargo check --workspace` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

A `QueryPlan` végrehajtás egységesítése a `count`, `find` és kurzor útvonalak között egy közös, tervből index-tartományt származtató réteg bevezetésével, amely javítja a korábbi `count`/`find` eltéréseket, és regressziós lefedettséget ad hozzá.

Bug Fixes:
- Biztosítja, hogy az egyoldalú, nem numerikus `IndexRangeScan` számlálások tiszteletben tartsák a típusböngyöket, azáltal, hogy a nem pontos tartományokat utószűrt, index-szűkített útvonalakon vezeti át, hogy illeszkedjenek a `find` eredményekhez.
- Kijavítja a numerikus tartományokra vonatkozó `find(...).sort({field})` viselkedését azzal, hogy csak akkor kezeli a szkennelést index-rendezettnek, ha az egyetlen, összefüggő tartomány; így a több bucketet és több tartományt érintő szkennelések megfelelően újrarendezésre kerülnek memóriában.
- Igazítja a nem numerikus tartományok korlátlan végeit az `IndexKey::MaxKey` értékre az egyes végrehajtók között, elkerülve a végrehajtó-specifikus eltéréseket.

Enhancements:
- Bevezeti a `PlanRanges` struktúrát, mint egyetlen hiteles forrást a `QueryPlan` variánsok index kulcstartományokká fordításához, amelyet a `count`, `find` és a streaming kurzor útvonalak fogyasztanak.
- Refaktorálja a `count_with_plan` és `collect_doc_ids_from_plan` függvényeket úgy, hogy azok a közös `BPlusTree::count_exact` és `scan_ranges` segédfüggvényekhez delegáljanak, ezzel eltávolítva a duplikált numerikus és többtartományos kezelési logikát.
- Hozzáad egy `QueryPlan::index_name` accessor-t, és módosítja az index modul exportjait, hogy támogassák az egységesített tartomány-származtatást anélkül, hogy belső segédfüggvényeket szivárogtatnának ki.

Build:
- Növeli a core crate verzióját `0.3.334`-re és az mcp server verzióját `1.0.528`-ra, hogy tükrözze a refaktort és a hibajavításokat.

Documentation:
- Dokumentálja a `QueryPlan` végrehajtó egységesítését és a kapcsolódó hibajavításokat a changelogban, beleértve a #8-as audit megállapítást és a két feltárt eltérést.

Tests:
- Hozzáad egy háromirányú `count == find == cursor == scan` paritás-orákulumot, beleértve a fájl-alapú streaming kurzor ellenőrzéseket is, hogy védje a kurzor végrehajtási útvonalát.
- Bevezeti a `plan_ranges` egységteszteket, amelyek lefedik az összes `QueryPlan` variánst, valamint fogyasztói smoke teszteket a `count_exact` és `scan_ranges` számára.
- Hozzáad regressziós teszteket a `count`/`find` eltérésekre a kereszt-típusú egyoldalú tartományokban és a numerikus tartományok rendezési sorrendjére a query planner alatt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify QueryPlan execution across count, find, and cursor paths via a shared plan-to-index-range derivation, fixing pre-existing count/find divergences and adding regression coverage.

Bug Fixes:
- Ensure single-sided non-numeric IndexRangeScan counts respect type buckets by routing non-exact ranges through post-filtered index-narrowed paths to match find results.
- Correct numeric range find(...).sort({field}) behavior by only treating scans as index-ordered when they are a single contiguous range, so multi-bucket and multi-range scans are properly resorted in memory.
- Align unbounded non-numeric range ends on IndexKey::MaxKey across executors to avoid executor-specific discrepancies.

Enhancements:
- Introduce PlanRanges as a single source of truth for translating QueryPlan variants into index key ranges, consumed by count, find, and streaming cursor paths.
- Refactor count_with_plan and collect_doc_ids_from_plan to delegate to shared BPlusTree::count_exact and scan_ranges helpers, removing duplicated numeric and multi-range handling logic.
- Add a QueryPlan::index_name accessor and adjust index module exports to support the unified range derivation without leaking internal helpers.

Build:
- Bump core crate version to 0.3.334 and mcp server version to 1.0.528 to reflect the refactor and bug fixes.

Documentation:
- Document the QueryPlan executor unification and related bug fixes in the changelog, including audit finding #8 and the two uncovered divergences.

Tests:
- Add a three-way count == find == cursor == scan parity oracle, including file-backed streaming cursor checks, to guard the cursor execution path.
- Introduce plan_ranges unit tests covering each QueryPlan variant and consumer smoke tests for count_exact and scan_ranges.
- Add regression tests for count/find divergences in cross-type single-sided ranges and numeric range sort ordering under the query planner.

</details>