### PR TITLE
fix(storage): multi-instance file lock bypass → two writers / corruption (audit P0-1) (v1.0.529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — multi-instance file lock could be bypassed → two live writers / corruption (mcp-server v1.0.529, core v0.3.335)
+
+`StorageEngine::open` guards single-writer access with an `fs2` exclusive advisory
+lock on a sibling `<db>.lock` file. The previous PID-based "stale lock" recovery
+made that guarantee bypassable (audit 2026-06-08 P0-1, empirically reproduced):
+on a failed `try_lock_exclusive` it read the PID written in the lock file and, if
+that PID looked dead, **unlinked and re-created** the lock file before re-locking.
+But `try_lock_exclusive` fails only when a **live** process holds the flock, while
+the PID could lag (a holder mid-acquire had not rewritten it) or read as dead
+across users (`kill(pid, 0)` → `EPERM` for another uid). Because the flock is
+per-inode, concurrent recoverers each unlinked the live holder's inode and locked
+a **fresh** one — so two openers could both succeed on the same `.mlite` → two
+live writers → corruption.
+
+The stale-detection (and `is_process_alive`, with its `kill`/`tasklist` probes) is
+removed entirely: the OS already releases the advisory lock when the holding
+process dies (crash / SIGKILL) or closes the fd, so a leftover `.lock` file is
+harmless and the next `try_lock_exclusive` simply succeeds. A genuine OS/FS lock
+fault (`ENOLCK`/`EIO`) is now surfaced instead of masked as `DatabaseLocked`. The
+lock path is derived by **appending** `.lock` (`format!("{path}.lock")`) rather
+than `with_extension`, so distinct databases like `foo` and `foo.mlite` no longer
+collide on one `foo.mlite.lock`. Regression tests cover the bypass, crash-recovery
+reopen, and the path collision. (Local-filesystem guarantee; advisory locks are
+host-local on NFS, as documented.)
+
 ### Refactored — unify the four QueryPlan executors behind one range chokepoint (mcp-server v1.0.528, core v0.3.334)
 
 Audit finding #8: a single `QueryPlan` was interpreted by **four** hand-synced executors — the two

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.334"
+version = "0.3.335"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/Cargo.toml
+++ b/ironbase-core/Cargo.toml
@@ -37,7 +37,7 @@ tracing = "0.1"    # For progress logging during long operations
 ahash = "0.8"      # Fast hashing for group/distinct operations
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"       # For process existence check (kill(pid, 0))
+libc = "0.2"       # System info via sysconf (aggregation/memory_info.rs)
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/ironbase-core/src/storage/mod.rs
+++ b/ironbase-core/src/storage/mod.rs
@@ -615,9 +615,14 @@ impl StorageEngine {
                 lock_file.sync_all()?;
                 Ok(lock_file)
             }
-            // WouldBlock = a LIVE process holds the flock (a dead holder's flock is
-            // auto-released by the OS) → the database is genuinely in use.
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+            // Lock contention = a LIVE process holds the flock (a dead holder's
+            // flock is auto-released by the OS) → the database is genuinely in use.
+            // fs2::lock_contended_error() is the portable contention error: its kind
+            // is WouldBlock on Unix but a Windows-specific kind under LockFileEx, so
+            // match against it rather than hardcoding WouldBlock (which missed the
+            // Windows case → contention was misreported as a raw Io error, breaking
+            // test_file_lock_prevents_double_open on Windows).
+            Err(e) if e.kind() == fs2::lock_contended_error().kind() => {
                 Err(IronBaseError::DatabaseLocked(db_path.to_string()))
             }
             // A genuine OS/filesystem fault (ENOLCK / EINTR / EIO, e.g. a mount

--- a/ironbase-core/src/storage/mod.rs
+++ b/ironbase-core/src/storage/mod.rs
@@ -576,12 +576,29 @@ pub struct StorageEngine {
 }
 
 impl StorageEngine {
-    /// Acquire lock with stale lock detection
+    /// Acquire the exclusive single-writer lock for a database file.
     ///
-    /// If the lock file exists and contains a PID of a dead process,
-    /// we consider it stale and remove it before retrying.
-    fn acquire_lock_with_stale_detection(lock_path: &Path, db_path: &str) -> Result<File> {
-        use std::io::{Read, Seek, Write};
+    /// The lock IS the `fs2` advisory lock on the `.lock` file — NOT the file's
+    /// existence. The OS releases the advisory lock when the holding process dies
+    /// (crash / SIGKILL) or closes the fd, so a leftover `.lock` file from a
+    /// crashed process is harmless: the next `try_lock_exclusive` simply succeeds
+    /// and overwrites the stale PID below.
+    ///
+    /// We deliberately do NOT do PID-based "stale lock" detection + unlink. That
+    /// was unsound (audit 2026-06-08 P0-1, empirically reproduced): `try_lock`
+    /// fails only when a LIVE process holds the flock, yet the PID written in the
+    /// file can lag (a holder mid-acquire has not rewritten it) or read as dead
+    /// cross-uid (`kill(pid,0)` → EPERM). The old code then unlinked + re-created
+    /// the lock file; because the flock is per-inode, concurrent recoverers each
+    /// locked a DIFFERENT inode and ALL succeeded → two live writers on one
+    /// `.mlite` → corruption. Trusting the OS flock removes that race entirely.
+    ///
+    /// LIMITATION: this assumes a LOCAL filesystem. `flock`-style advisory locks
+    /// are unreliable or host-local on network filesystems (NFS/SMB), so
+    /// multi-host exclusivity is NOT guaranteed there — an embedded DB is meant to
+    /// be opened from one host anyway.
+    fn acquire_exclusive_lock(lock_path: &Path, db_path: &str) -> Result<File> {
+        use std::io::{Seek, Write};
 
         let mut lock_file = OpenOptions::new()
             .read(true)
@@ -589,83 +606,25 @@ impl StorageEngine {
             .create(true)
             .open(lock_path)?;
 
-        // Try to acquire the lock
         match lock_file.try_lock_exclusive() {
             Ok(()) => {
-                // Lock acquired - write our PID
+                // We hold the lock — record our PID for diagnostics only.
                 lock_file.set_len(0)?;
                 lock_file.seek(std::io::SeekFrom::Start(0))?;
                 writeln!(lock_file, "{}", std::process::id())?;
                 lock_file.sync_all()?;
                 Ok(lock_file)
             }
-            Err(_) => {
-                // Lock failed - check if it's stale
-                let mut pid_str = String::new();
-                lock_file.seek(std::io::SeekFrom::Start(0))?;
-                let _ = lock_file.read_to_string(&mut pid_str);
-
-                if let Ok(pid) = pid_str.trim().parse::<u32>() {
-                    if !Self::is_process_alive(pid) {
-                        // Process is dead - lock is stale
-                        log_warn!(
-                            "[WARN] Stale lock detected (PID {} is dead), cleaning up...",
-                            pid
-                        );
-
-                        // Release any existing lock and reopen
-                        drop(lock_file);
-
-                        // Remove and recreate lock file
-                        let _ = std::fs::remove_file(lock_path);
-
-                        let mut lock_file = OpenOptions::new()
-                            .read(true)
-                            .write(true)
-                            .create(true)
-                            .open(lock_path)?;
-
-                        // Try again
-                        lock_file
-                            .try_lock_exclusive()
-                            .map_err(|_| IronBaseError::DatabaseLocked(db_path.to_string()))?;
-
-                        // Write our PID
-                        writeln!(lock_file, "{}", std::process::id())?;
-                        lock_file.sync_all()?;
-
-                        return Ok(lock_file);
-                    }
-                }
-
-                // Lock is held by a live process
+            // WouldBlock = a LIVE process holds the flock (a dead holder's flock is
+            // auto-released by the OS) → the database is genuinely in use.
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 Err(IronBaseError::DatabaseLocked(db_path.to_string()))
             }
+            // A genuine OS/filesystem fault (ENOLCK / EINTR / EIO, e.g. a mount
+            // without working advisory locks) — surface it, don't mask it as a
+            // benign "locked" that callers would retry forever.
+            Err(e) => Err(IronBaseError::Io(e)),
         }
-    }
-
-    /// Check if a process with the given PID is still alive
-    #[cfg(unix)]
-    fn is_process_alive(pid: u32) -> bool {
-        // On Unix, kill(pid, 0) checks if process exists without sending signal
-        // Returns 0 if process exists (even if we can't signal it)
-        // Returns -1 with ESRCH if process doesn't exist
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-    }
-
-    #[cfg(windows)]
-    fn is_process_alive(pid: u32) -> bool {
-        // On Windows, try to check via tasklist command
-        // This is slower but doesn't require additional dependencies
-        std::process::Command::new("tasklist")
-            .args(["/FI", &format!("PID eq {}", pid), "/NH"])
-            .output()
-            .map(|output| {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                // tasklist returns "INFO: No tasks..." if PID not found
-                !stdout.contains("INFO:") && stdout.contains(&pid.to_string())
-            })
-            .unwrap_or(true) // If check fails, assume process is alive (safer)
     }
 
     /// Open or create database
@@ -673,11 +632,14 @@ impl StorageEngine {
         let path_str = path.as_ref().to_string_lossy().to_string();
         let exists = path.as_ref().exists();
 
-        // Create separate lock file to allow other processes to READ the DB (hot backup)
-        // On Windows, file locks are mandatory and block ALL access including reads
-        // By locking a separate .lock file, we allow backup tools to read the DB file
-        let lock_path = PathBuf::from(&path_str).with_extension("mlite.lock");
-        let lock_file = Self::acquire_lock_with_stale_detection(&lock_path, &path_str)?;
+        // Lock a SEPARATE "<db path>.lock" file so read-only backup tools can
+        // still open the .mlite itself (on Windows file locks block all access).
+        // APPEND ".lock" — do NOT use `with_extension`, which REPLACES the final
+        // component (`foo` and `foo.mlite` would both map to `foo.mlite.lock` and
+        // falsely block each other; audit 2026-06-08 P0-1). `.mlite` paths are
+        // unchanged (`foo.mlite` → `foo.mlite.lock`).
+        let lock_path = PathBuf::from(format!("{path_str}.lock"));
+        let lock_file = Self::acquire_exclusive_lock(&lock_path, &path_str)?;
 
         let mut file = OpenOptions::new()
             .read(true)

--- a/ironbase-core/src/transaction_integration_tests.rs
+++ b/ironbase-core/src/transaction_integration_tests.rs
@@ -457,6 +457,11 @@ mod integration_tests {
         assert!(collections.contains(&"test".to_string()));
     }
 
+    // Unix-only: the setup overwrites the `.lock` file WHILE db1 holds it, which is
+    // possible only with Unix advisory flock. On Windows the lock is mandatory (the
+    // open/write would hit a sharing violation), and the dead-PID-bypass scenario it
+    // guards against was itself a Unix `kill(pid,0)` stale-detection concern.
+    #[cfg(unix)]
     #[test]
     fn test_dead_pid_in_lockfile_does_not_bypass_live_holder() {
         // Audit 2026-06-08 P0-1 (empirically reproduced): a `.lock` file recording

--- a/ironbase-core/src/transaction_integration_tests.rs
+++ b/ironbase-core/src/transaction_integration_tests.rs
@@ -456,4 +456,69 @@ mod integration_tests {
         let collections = db2.list_collections();
         assert!(collections.contains(&"test".to_string()));
     }
+
+    #[test]
+    fn test_dead_pid_in_lockfile_does_not_bypass_live_holder() {
+        // Audit 2026-06-08 P0-1 (empirically reproduced): a `.lock` file recording
+        // a PID that looks DEAD must NOT let a second opener bypass a LIVE holder.
+        // The old PID-based stale-detection unlinked the live holder's lock inode
+        // and re-locked a fresh one → two live writers on one .mlite → corruption.
+        // The fix trusts the OS flock (auto-released only on holder death), so the
+        // PID written in the file is irrelevant to exclusivity.
+        use crate::error::IronBaseError;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.mlite");
+        let lock_path = temp_dir.path().join("test.mlite.lock");
+
+        // db1 holds the exclusive fs2 lock.
+        let _db1 = DatabaseCore::open(&db_path).unwrap();
+
+        // Overwrite the .lock content with a PID guaranteed not to be alive
+        // (> any pid_max → kill(pid,0) → ESRCH). The flock held by db1 is unaffected.
+        std::fs::write(&lock_path, "2147483646\n").unwrap();
+
+        // A second open MUST still fail with DatabaseLocked — db1 holds the flock,
+        // regardless of the (dead-looking) PID written in the file.
+        match DatabaseCore::open(&db_path) {
+            Err(IronBaseError::DatabaseLocked(_)) => {}
+            Ok(_) => panic!("dead PID in .lock bypassed the live flock: second open succeeded"),
+            Err(e) => panic!("expected DatabaseLocked, got: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_stale_lockfile_from_crashed_holder_allows_reopen() {
+        // The other direction of P0-1: a crashed process leaves the `.lock` FILE
+        // (with its now-dead PID) but the OS released its flock on death. A fresh
+        // open MUST succeed — the file's existence is not a lock, only the flock
+        // is. This pins the foundational assumption (flock auto-release) the fix
+        // rests on, so a future lock-scheme change that doesn't auto-release on
+        // crash would fail here instead of silently locking the DB out forever.
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.mlite");
+        let lock_path = temp_dir.path().join("test.mlite.lock");
+
+        // Leftover stale lock file, NO flock held (simulates post-crash state).
+        std::fs::write(&lock_path, "2147483646\n").unwrap();
+
+        // Nothing holds the flock → open must succeed and overwrite the stale PID.
+        let _db = DatabaseCore::open(&db_path)
+            .expect("reopen after crash (stale .lock file, no flock) must succeed");
+    }
+
+    #[test]
+    fn test_distinct_db_files_do_not_share_a_lock() {
+        // P0-1 path fix: `foo` and `foo.mlite` are DIFFERENT databases and must
+        // not block each other. The old `with_extension("mlite.lock")` mapped BOTH
+        // to `foo.mlite.lock`; the fix appends `.lock` → `foo.lock` vs
+        // `foo.mlite.lock`. Both must open concurrently.
+        let temp_dir = TempDir::new().unwrap();
+        let p1 = temp_dir.path().join("foo");
+        let p2 = temp_dir.path().join("foo.mlite");
+
+        let _db1 = DatabaseCore::open(&p1).unwrap();
+        let _db2 = DatabaseCore::open(&p2)
+            .expect("distinct db files (foo vs foo.mlite) must not collide on one lock");
+    }
 }

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.528"
+version = "1.0.529"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Audit P0-1 — the `.mlite.lock` exclusive lock could be bypassed

`StorageEngine::open` guards single-writer access with an `fs2` exclusive advisory lock on a sibling `<db>.lock` file. The previous PID-based "stale lock" recovery made that guarantee **bypassable** — **empirically reproduced**: a second `open()` returned `Ok` while a live holder held the lock.

**Root cause:** on a failed `try_lock_exclusive`, the old code read the PID in the lock file and, if it looked dead, **unlinked + re-created** the lock file before re-locking. But `try_lock_exclusive` fails only when a **live** process holds the flock, while the PID could lag (a holder mid-acquire had not rewritten it) or read as dead across users (`kill(pid,0)` → `EPERM` for another uid). Because the flock is **per-inode**, concurrent recoverers each unlinked the live holder's inode and locked a **fresh** one → two openers both succeed on one `.mlite` → **two live writers → corruption**.

## Fix (min-tech-debt: delete the fragile mechanism, trust the OS primitive)

- **Remove** the PID stale-detection + `is_process_alive` (`kill`/`tasklist`) + unlink/re-create branch entirely. The OS already releases the advisory lock when the holder dies (crash/SIGKILL) or closes the fd, so a leftover `.lock` file is harmless — the next `try_lock_exclusive` simply succeeds and overwrites the stale PID.
- **Distinguish** `WouldBlock` (genuinely locked → `DatabaseLocked`) from a real OS/FS fault (`ENOLCK`/`EIO` → surfaced, not masked as a benign "locked" that callers retry forever).
- **Lock path** = `format!("{path}.lock")` (append) instead of `with_extension`, so distinct DBs `foo` and `foo.mlite` no longer collide on one `foo.mlite.lock`. (`.mlite` paths unchanged.)
- **Document** the local-filesystem assumption (advisory locks are host-local on NFS).

## Tests (`transaction_integration_tests.rs`)
- `test_dead_pid_in_lockfile_does_not_bypass_live_holder` — the reproduced bug (was Ok on master, now `DatabaseLocked`).
- `test_stale_lockfile_from_crashed_holder_allows_reopen` — pins the flock-auto-release assumption (a stale `.lock` from a crash must allow reopen).
- `test_distinct_db_files_do_not_share_a_lock` — the path-collision fix.
- The 3 existing lock tests (double-open blocked, release on drop/close) still pass.

## Verification
- 6 lock tests + `cargo clippy -p ironbase-core --tests` + `cargo fmt --check` clean.
- `is_process_alive` removed; `libc` dep kept (used by `aggregation/memory_info.rs`).
- Full `cargo test -p ironbase-core --no-fail-fast` green (only the documented load-flaky `test_auto_commit_waits_for_transaction`).

First fix from the 2026-06-08 concurrency/durability audit (memory: `concurrency-durability-audit-2026-06-08.md`); P1-P3 follow-ups tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)