### PR TITLE
fix(wal): torn WAL tail (crash mid-append) bricked DB startup (audit P1-2) (v1.0.530)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — a torn WAL tail (crash mid-append) bricked database startup (mcp-server v1.0.530, core v0.3.336)
+
+`WALEntryIterator::read_next` treated a short read on the entry **header** as a
+clean end-of-log (`Ok(None)`) but used a bare `?` on the **data** and **checksum**
+reads. A crash while appending a WAL record leaves a torn trailing entry (header
+written, data/checksum partial) — the bare `?` surfaced that as
+`Err(UnexpectedEof)`, which `recover()` propagated, so **`recover_from_wal`
+aborted and the database failed to reopen** after an ordinary crash, even though
+the torn entry was never committed.
+
+A short read on the data/checksum is now handled like a short header: the partial
+trailing entry (and anything after it) is discarded as a clean end-of-log, which
+is the standard WAL recovery semantics — the records before it were fully written
+and fsync'd, the torn one never committed. A genuine checksum **mismatch** on a
+complete-length entry still returns `WALCorruption` (loud failure, unchanged), so
+real corruption is not silently swallowed. New `test_iterator_discards_torn_trailing_entry`
+covers truncation mid-data and mid-checksum across the prior complete entries.
+
 ### Refactored — unify the four QueryPlan executors behind one range chokepoint (mcp-server v1.0.528, core v0.3.334)
 
 Audit finding #8: a single `QueryPlan` was interpreted by **four** hand-synced executors — the two

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.334"
+version = "0.3.336"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/wal/reader.rs
+++ b/ironbase-core/src/wal/reader.rs
@@ -83,13 +83,26 @@ impl<R: Read + Seek> WALEntryIterator<R> {
             return Err(IronBaseError::WALCorruption);
         }
 
-        // Read data
+        // Read data. A SHORT read here is a torn trailing entry: the process
+        // crashed while appending this record, so its data/checksum never fully
+        // reached disk. That entry was never committed — discard it (and anything
+        // after) as a clean end-of-log, exactly like a short header above.
+        // Without this, a torn tail surfaced as an Err that aborted recovery and
+        // bricked DB startup after an ordinary crash (audit 2026-06-08 P1-2).
         let mut data = vec![0u8; data_len];
-        self.reader.read_exact(&mut data)?;
+        match self.reader.read_exact(&mut data) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(IronBaseError::Io(e)),
+        }
 
-        // Read checksum
+        // Read checksum (same torn-tail handling — a crash can land here too).
         let mut checksum_bytes = [0u8; 4];
-        self.reader.read_exact(&mut checksum_bytes)?;
+        match self.reader.read_exact(&mut checksum_bytes) {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(IronBaseError::Io(e)),
+        }
         let checksum = u32::from_le_bytes(checksum_bytes);
 
         let entry = WALEntry {
@@ -188,6 +201,45 @@ mod tests {
         let result = iter.next();
 
         assert!(matches!(result, Some(Err(IronBaseError::WALCorruption))));
+    }
+
+    #[test]
+    fn test_iterator_discards_torn_trailing_entry() {
+        // A crash mid-WAL-append leaves a partial final record (audit P1-2). Two
+        // truncation points are possible: mid-data and mid-checksum. In BOTH cases
+        // recovery must replay the prior COMPLETE entries and stop cleanly — never
+        // yield an Err (which previously aborted recovery → DB failed to reopen).
+        let committed1 = WALEntry::new(1, WALEntryType::Begin, vec![]);
+        let committed2 = WALEntry::new(1, WALEntryType::Operation, b"committed".to_vec());
+        let torn = WALEntry::new(1, WALEntryType::Operation, b"never-fully-written".to_vec());
+        let torn_bytes = torn.serialize();
+
+        // Truncate at every point INSIDE the final record (just past the header,
+        // mid-data, and mid-checksum) — each must be discarded without error.
+        for cut in [
+            WAL_HEADER_SIZE + 1,  // mid-data
+            torn_bytes.len() - 6, // late-data
+            torn_bytes.len() - 2, // mid-checksum (header + full data + 2/4 checksum bytes)
+        ] {
+            let mut data = Vec::new();
+            data.extend_from_slice(&committed1.serialize());
+            data.extend_from_slice(&committed2.serialize());
+            data.extend_from_slice(&torn_bytes[..cut]);
+
+            let iter = WALEntryIterator::new(Cursor::new(data)).unwrap();
+            let entries: Vec<_> = iter.collect();
+
+            assert_eq!(
+                entries.len(),
+                2,
+                "torn tail (cut={cut}) must be discarded, not errored"
+            );
+            assert!(
+                entries.iter().all(|e| e.is_ok()),
+                "a torn tail (cut={cut}) must not surface an error"
+            );
+            assert_eq!(entries[1].as_ref().unwrap().data, b"committed".to_vec());
+        }
     }
 
     #[test]

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.528"
+version = "1.0.530"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Audit P1-2 — a crash mid-WAL-append made the database fail to reopen

`WALEntryIterator::read_next` treated a short read on the entry **header** as a clean end-of-log (`Ok(None)`), but used a bare `?` on the **data** and **checksum** reads. A crash while appending a WAL record leaves a torn trailing entry (header written, data/checksum partial) → the bare `?` surfaced `Err(UnexpectedEof)`, which `recover()` propagated → **`recover_from_wal` aborted and the DB failed to reopen** after an ordinary crash, even though the torn entry was never committed.

## Fix (canonical WAL recovery semantics)

A short read on the data/checksum is now handled like a short header — the partial trailing entry (and anything after it) is discarded as a clean end-of-log. The records before it were fully written + fsync'd; the torn one was never committed, so discarding it is correct. A genuine checksum **mismatch** on a complete-length entry still returns `WALCorruption` (loud failure, **unchanged**), so real corruption is not silently swallowed.

```diff
-        self.reader.read_exact(&mut data)?;
+        match self.reader.read_exact(&mut data) {
+            Ok(_) => {}
+            Err(e) if e.kind() == ErrorKind::UnexpectedEof => return Ok(None), // torn tail
+            Err(e) => return Err(IronBaseError::Io(e)),
+        }
```
(same for the checksum read)

## Tests
- `test_iterator_discards_torn_trailing_entry` — truncation mid-data, late-data, and mid-checksum; the prior complete entries must still replay with **no `Err`**.
- `test_iterator_detects_corruption` (checksum mismatch → `WALCorruption`) unchanged and still passing.

## Verification
- WAL unit tests (5) + chaos crash (18) + chaos corruption (21) green.
- `cargo clippy -p ironbase-core --tests` + `cargo fmt --check` clean.
- Full `cargo test -p ironbase-core --no-fail-fast` → **1924 passed, 0 failed**.

Second fix from the 2026-06-08 concurrency/durability audit (P0-1 = PR #99). Versioned 0.3.336/1.0.530, sequential after #99 (rebase if #99 merges second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)