### PR TITLE
fix(delete): delete_one/_many were not atomic — reversed lock order + concurrent double-decrement (audit P2-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — delete was not atomic: reversed lock order + concurrent double-decrement (audit P2-3) (mcp-server v1.0.531, core v0.3.337)
+
+Every delete write path de-indexed the document **before** acquiring the storage write lock
+(`remove_from_indexes()` then `storage.write()`), and read the target lock-free. This reversed the
+storage→indexes lock order the rest of the engine follows (#75) and, more seriously, opened a window
+where two concurrent deletes of the same document could **both** pass the lock-free live read and each
+write a tombstone + `adjust_live_count(-1)` → the live count silently drifted below the true value.
+`update_one_prepare` already did this correctly (storage lock held across the index mutation); the
+delete paths had diverged because the logic was copy-pasted across **seven** sites.
+
+All delete paths now funnel through a single chokepoint, `CollectionCore::tombstone_doc_atomic`, which
+acquires the storage write lock, **re-reads** the document under it (skipping a row already tombstoned by
+a concurrent writer, and re-matching the query when given), writes the tombstone, then de-indexes — all
+in one critical section, lock order storage→indexes. Callers fixed:
+
+- **delete_one:** `delete_one_prepare` (Safe), `delete_one_raw` (in-memory / Unsafe),
+  `delete_one_persist_batch` (Batch). As a side effect `delete_one_raw` now also resolves a string `_id`
+  to its stored integer form (`resolve_stored_id`), matching what `delete_one_prepare` already did.
+- **delete_many:** `delete_many_raw_with_docs` (in-memory / Unsafe) and the Safe bulk
+  `delete_many_persist`. `DeleteManyPrepared` dropped its precomputed `tombstone_writes` + `index_removals`
+  lists — the persist re-reads each doc under the lock instead, so there is nothing stale to write and the
+  prepare/persist contract shrinks to `deleted` + `wal_entries`.
+
+New `delete_one_atomicity_test` (13 tests) includes concurrent same-`_id` / same-filter guards for both
+delete_one and delete_many (in-memory raw path and Safe prepare/persist path) that assert each doc is
+deleted exactly once and the live count drops by exactly the matched count — these fail on the pre-fix
+code. The `update_one_persist_batch` update path shares the index-before-storage ordering and is out of
+this delete-focused fix's scope.
+
 ### Refactored — unify the four QueryPlan executors behind one range chokepoint (mcp-server v1.0.528, core v0.3.334)
 
 Audit finding #8: a single `QueryPlan` was interpreted by **four** hand-synced executors — the two

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.334"
+version = "0.3.337"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/collection_core/mod.rs
+++ b/ironbase-core/src/collection_core/mod.rs
@@ -1856,6 +1856,101 @@ impl<S: Storage + RawStorage> CollectionCore<S> {
         Ok(())
     }
 
+    /// Resolve an `_id` query value to the `DocumentId` actually stored in the
+    /// catalog, trying the raw value first and then its normalized (string→int)
+    /// form. Returns `None` if neither is present.
+    ///
+    /// This is a READ-lock lookup; callers must still go through
+    /// [`Self::tombstone_doc_atomic`], which re-checks under the write lock, so a
+    /// document that vanishes between resolution and tombstoning is handled safely.
+    fn resolve_stored_id(&self, raw_id: &DocumentId) -> Result<Option<DocumentId>> {
+        let storage = self.storage.read();
+        let meta = match storage.get_collection_meta(&self.name) {
+            Some(m) => m,
+            None => return Ok(None),
+        };
+        if meta.document_catalog.contains_key(raw_id) {
+            return Ok(Some(raw_id.clone()));
+        }
+        if let Some(normalized) = Self::normalize_document_id(raw_id) {
+            if meta.document_catalog.contains_key(&normalized) {
+                return Ok(Some(normalized));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Atomically tombstone a single document under ONE storage write lock.
+    ///
+    /// This is the single chokepoint every `delete_*` path funnels through. It
+    /// acquires the storage write lock, RE-READS `target_id` under it, writes the
+    /// tombstone, then removes the document from indexes — all in one critical
+    /// section. Lock order is storage→indexes (#75), matching `update_one_prepare`.
+    ///
+    /// Returns the pre-delete document value, or `None` if the id was missing, was
+    /// already tombstoned, or (when `query` is given) no longer matches — e.g. a
+    /// concurrent writer won the race. Returning `None` instead of blindly writing
+    /// a second tombstone is what prevents the double `adjust_live_count(-1)` that
+    /// silently corrupted the live count (audit P2-3): the old delete paths
+    /// de-indexed BEFORE taking the storage lock and read the document lock-free,
+    /// so two concurrent deletes of the same doc could each tombstone + decrement.
+    fn tombstone_doc_atomic(
+        &self,
+        target_id: &DocumentId,
+        query: Option<&Query>,
+    ) -> Result<Option<Value>> {
+        let mut storage = self.storage.write();
+
+        // Re-read under the lock via the catalog offset.
+        let offset = match storage
+            .get_collection_meta(&self.name)
+            .and_then(|m| m.document_catalog.get(target_id).copied())
+        {
+            Some(off) => off,
+            None => return Ok(None), // gone between resolution and the lock
+        };
+        let doc_bytes = storage.read_data(offset)?;
+        let doc: Value = serde_json::from_slice(&doc_bytes)
+            .map_err(|e| IronBaseError::Serialization(e.to_string()))?;
+
+        // Already deleted by a concurrent writer.
+        if doc
+            .get("_tombstone")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            return Ok(None);
+        }
+
+        // PERF: Direct Value→Document (no serialization roundtrip).
+        let document = Document::from_value(&doc)?;
+
+        // Re-match under the lock: the candidate may have been modified between
+        // candidate collection and the lock, or the planner may have
+        // over-approximated.
+        if let Some(q) = query {
+            if !q.matches(&document)? {
+                return Ok(None);
+            }
+        }
+
+        // Write the tombstone to storage (source of truth) BEFORE touching indexes,
+        // so a storage-write failure leaves indexes rebuildable from storage.
+        let mut tombstone = doc.clone();
+        if let Value::Object(ref mut map) = tombstone {
+            map.insert("_tombstone".to_string(), Value::Bool(true));
+            map.insert("_collection".to_string(), Value::String(self.name.clone()));
+        }
+        let tombstone_json = serde_json::to_string(&tombstone)?;
+        storage.write_document_raw(&self.name, target_id, tombstone_json.as_bytes())?;
+        storage.adjust_live_count(&self.name, -1);
+
+        // De-index AFTER the successful storage write, still under the storage lock.
+        self.remove_from_indexes(&document)?;
+
+        Ok(Some(doc))
+    }
+
     /// 🚀 OPTIMIZED: Batch update indexes using HashMap + rebuild
     ///
     /// **OLD APPROACH (O(n * k)):**

--- a/ironbase-core/src/collection_core/raw_operations.rs
+++ b/ironbase-core/src/collection_core/raw_operations.rs
@@ -56,14 +56,14 @@ pub struct UpdateManyPrepared {
 /// - PERSIST phase: Write tombstones to storage (after WAL commit)
 #[derive(Debug)]
 pub struct DeleteManyPrepared {
-    /// Number of documents to be deleted
+    /// Number of documents matched for deletion (user-facing count).
     pub deleted: u64,
-    /// WAL entries: (doc_id, old_doc)
+    /// WAL entries: (doc_id, old_doc). `old_doc` is `Null` for delete_many — replay
+    /// reconstructs a minimal tombstone from the doc_id alone (operation_replay.rs).
+    /// These doc_ids are also what `delete_many_persist` re-reads and tombstones
+    /// atomically via `tombstone_doc_atomic` (no precomputed tombstone/index lists:
+    /// the persist re-reads under the lock, audit P2-3).
     pub wal_entries: Vec<(DocumentId, Value)>,
-    /// Documents to remove from indexes
-    pub(crate) index_removals: Vec<Document>,
-    /// Tombstone writes: (doc_id, tombstone_json_string)
-    pub(crate) tombstone_writes: Vec<(DocumentId, String)>,
 }
 
 /// Prepared data for insert_one operation.
@@ -1027,51 +1027,27 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
 
         // ====================================================================
         // FAST PATH: Direct _id lookup O(1)
-        // When query is {"_id": value}, skip catalog scanning entirely.
-        // This is 10-100x faster than the slow path for large collections.
+        // Resolve the stored id (raw or normalized) then tombstone atomically.
+        // tombstone_doc_atomic re-reads under the storage write lock, so the
+        // resolve→tombstone window is race-safe (no double-decrement, audit P2-3).
         // ====================================================================
-        if let Some(doc_id) = Self::extract_id_query(query_json) {
-            // O(1) lookup via read_document_by_id
-            if let Some(doc) = self.read_document_by_id(&doc_id)? {
-                // PERF: Direct Value→Document (no serialization roundtrip)
-                let document = Document::from_value(&doc)?;
-
-                // Remove from all indexes BEFORE deleting
-                self.remove_from_indexes(&document)?;
-
-                // Acquire write lock for deletion
-                let mut storage = self.storage.write();
-
-                // Mark as tombstone (logical delete)
-                let mut tombstone = doc.clone();
-                if let Value::Object(ref mut map) = tombstone {
-                    map.insert("_tombstone".to_string(), Value::Bool(true));
-                    map.insert("_collection".to_string(), Value::String(self.name.clone()));
-                }
-                let tombstone_json = serde_json::to_string(&tombstone)?;
-
-                // Write tombstone WITH catalog tracking (updates catalog entry)
-                storage.write_document_raw(&self.name, &document.id, tombstone_json.as_bytes())?;
-                storage.adjust_live_count(&self.name, -1);
-
-                // Invalidate query cache
-                drop(storage); // Release lock before cache invalidation
+        if let Some(raw_id) = Self::extract_id_query(query_json) {
+            let Some(target_id) = self.resolve_stored_id(&raw_id)? else {
+                return Ok(0);
+            };
+            if self.tombstone_doc_atomic(&target_id, None)?.is_some() {
                 self.query_cache.invalidate_collection(&self.name);
-
                 return Ok(1);
             }
-            // Document not found - return 0
             return Ok(0);
         }
 
         // ====================================================================
         // SLOW PATH: Complex queries (non-_id filters)
-        // Uses collect_doc_ids which may scan the catalog
+        // collect_doc_ids ran with limit=1, so there is at most one candidate;
+        // tombstone_doc_atomic re-matches it under the lock before deleting.
         // ====================================================================
         let parsed_query = Query::from_json(query_json)?;
-
-        // STREAMING FIX: Collect only document IDs first (with limit=1 for efficiency)
-        // This avoids bulk-loading all documents into memory
         let (doc_ids, _) = self.collect_doc_ids_with_options(
             query_json,
             None,
@@ -1086,54 +1062,19 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
             None, // No deadline for delete operations
         )?;
 
-        // Find first matching and delete
-        let mut deleted = 0u64;
+        let Some(target_doc_id) = doc_ids.into_iter().next() else {
+            return Ok(0);
+        };
 
-        for doc_id in doc_ids {
-            if deleted > 0 {
-                break; // Only delete first match
-            }
-
-            // Stream-load document one at a time
-            if let Some(doc) = self.read_document_by_id(&doc_id)? {
-                // PERF: Direct Value→Document (no serialization roundtrip)
-                let document = Document::from_value(&doc)?;
-
-                // Check if matches query (should always match due to collect_doc_ids)
-                if parsed_query.matches(&document)? {
-                    // Remove from all indexes BEFORE deleting
-                    self.remove_from_indexes(&document)?;
-
-                    // Acquire write lock for deletion
-                    let mut storage = self.storage.write();
-
-                    // Mark as tombstone (logical delete)
-                    let mut tombstone = doc.clone();
-                    if let Value::Object(ref mut map) = tombstone {
-                        map.insert("_tombstone".to_string(), Value::Bool(true));
-                        map.insert("_collection".to_string(), Value::String(self.name.clone()));
-                    }
-                    let tombstone_json = serde_json::to_string(&tombstone)?;
-
-                    // Write tombstone WITH catalog tracking (updates catalog entry)
-                    storage.write_document_raw(
-                        &self.name,
-                        &document.id,
-                        tombstone_json.as_bytes(),
-                    )?;
-                    storage.adjust_live_count(&self.name, -1);
-
-                    deleted = 1;
-                }
-            }
-        }
-
-        // Invalidate query cache if any document was deleted
-        if deleted > 0 {
+        if self
+            .tombstone_doc_atomic(&target_doc_id, Some(&parsed_query))?
+            .is_some()
+        {
             self.query_cache.invalidate_collection(&self.name);
+            return Ok(1);
         }
 
-        Ok(deleted)
+        Ok(0)
     }
 
     /// Delete many documents (raw, no WAL) - use DatabaseCore::delete_many for durability
@@ -1171,40 +1112,15 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
         // BUG #2 FIX: Track actual deleted documents for WAL
         let mut deleted_docs: Vec<(DocumentId, Value)> = Vec::new();
 
+        // Each candidate is tombstoned atomically under one storage write lock via
+        // the shared chokepoint (re-read + re-match), so concurrent deletes can't
+        // double-decrement the live count and the lock order stays storage→indexes
+        // (#75; audit P2-3). A candidate concurrently modified/deleted returns None
+        // and is skipped — only genuinely-deleted docs are counted and WAL-logged.
         for doc_id in doc_ids {
-            // Stream-load document one at a time
-            if let Some(doc) = self.read_document_by_id(&doc_id)? {
-                // PERF: Direct Value→Document (no serialization roundtrip)
-                let document = Document::from_value(&doc)?;
-
-                // Check if matches query (should always match due to collect_doc_ids)
-                if parsed_query.matches(&document)? {
-                    // BUG #2 FIX: Collect deleted document for WAL BEFORE deletion
-                    deleted_docs.push((document.id.clone(), doc.clone()));
-
-                    // Remove from all indexes BEFORE deleting
-                    self.remove_from_indexes(&document)?;
-
-                    // Acquire write lock for deletion
-                    let mut storage = self.storage.write();
-
-                    // Mark as tombstone (logical delete)
-                    let mut tombstone = doc.clone();
-                    if let Value::Object(ref mut map) = tombstone {
-                        map.insert("_tombstone".to_string(), Value::Bool(true));
-                        map.insert("_collection".to_string(), Value::String(self.name.clone()));
-                    }
-                    let tombstone_json = serde_json::to_string(&tombstone)?;
-
-                    storage.write_document_raw(
-                        &self.name,
-                        &document.id,
-                        tombstone_json.as_bytes(),
-                    )?;
-                    storage.adjust_live_count(&self.name, -1);
-
-                    deleted += 1;
-                }
+            if let Some(old_doc) = self.tombstone_doc_atomic(&doc_id, Some(&parsed_query))? {
+                deleted_docs.push((doc_id, old_doc));
+                deleted += 1;
             }
         }
 
@@ -1371,34 +1287,15 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
         if let Some(id_list) = Self::extract_id_in_query(query_json) {
             let mut deleted = 0u64;
             let mut wal_entries: Vec<(DocumentId, Value)> = Vec::new();
-            let mut index_removals: Vec<Document> = Vec::new();
-            let mut tombstone_writes: Vec<(DocumentId, String)> = Vec::new();
 
             for doc_id in id_list {
-                // O(1) lookup via read_document_by_id
+                // O(1) lookup via read_document_by_id (skips tombstones already).
                 if let Some(doc) = self.read_document_by_id(&doc_id)? {
                     if is_tombstone(&doc) {
                         continue;
                     }
-
-                    // PERF: Direct Value→Document (no serialization roundtrip)
-                    let document = Document::from_value(&doc)?;
-
-                    // MEMORY OPT: Create minimal tombstone
-                    let tombstone = serde_json::json!({
-                        "_id": serde_json::to_value(&doc_id)?,
-                        "_tombstone": true,
-                        "_collection": &self.name
-                    });
-                    let tombstone_json = serde_json::to_string(&tombstone)?;
-                    tombstone_writes.push((doc_id.clone(), tombstone_json));
-
-                    // WAL entry with null old_doc
+                    // WAL entry with null old_doc; persist re-reads + tombstones this id.
                     wal_entries.push((doc_id, Value::Null));
-
-                    // Index removal needs Document for indexed field values
-                    index_removals.push(document);
-
                     deleted += 1;
                 }
                 // Document not found - silently skip (already deleted or never existed)
@@ -1407,8 +1304,6 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
             return Ok(DeleteManyPrepared {
                 deleted,
                 wal_entries,
-                index_removals,
-                tombstone_writes,
             });
         }
 
@@ -1426,8 +1321,6 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
 
         let mut deleted = 0u64;
         let mut wal_entries: Vec<(DocumentId, Value)> = Vec::new();
-        let mut index_removals: Vec<Document> = Vec::new();
-        let mut tombstone_writes: Vec<(DocumentId, String)> = Vec::new();
 
         for doc_id in doc_ids {
             // Stream-load document one at a time
@@ -1440,28 +1333,12 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
                 let document = Document::from_json(&doc_json_str)?;
 
                 if parsed_query.matches(&document)? {
-                    // MEMORY OPT #1: WAL only needs doc_id for delete recovery
-                    // old_doc is NOT used during WAL replay (see operation_replay.rs:82-100)
-                    // Recovery creates minimal tombstone from doc_id alone
-                    let wal_doc_id = doc_id.clone();
-
-                    // MEMORY OPT #2: Create minimal tombstone without full doc clone
-                    // Only _id, _tombstone, _collection are needed (see operation_replay.rs:89-93)
-                    let tombstone = serde_json::json!({
-                        "_id": serde_json::to_value(&doc_id)?,
-                        "_tombstone": true,
-                        "_collection": &self.name
-                    });
-                    let tombstone_json = serde_json::to_string(&tombstone)?;
-                    tombstone_writes.push((doc_id, tombstone_json));
-
-                    // WAL entry with null old_doc (saves ~5KB per document)
-                    wal_entries.push((wal_doc_id, Value::Null));
-
-                    // Index removal needs Document for indexed field values
-                    // MEMORY OPT #3: Move instead of clone (document not used after this)
-                    index_removals.push(document);
-
+                    // MEMORY OPT: WAL only needs doc_id for delete recovery — old_doc
+                    // is NOT used during replay (operation_replay.rs:82-100), which
+                    // reconstructs a minimal tombstone from doc_id alone. The actual
+                    // tombstone + de-index happens in persist via tombstone_doc_atomic
+                    // (re-read under the lock), so nothing is precomputed here.
+                    wal_entries.push((doc_id, Value::Null));
                     deleted += 1;
                 }
             }
@@ -1470,44 +1347,32 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
         Ok(DeleteManyPrepared {
             deleted,
             wal_entries,
-            index_removals,
-            tombstone_writes,
         })
     }
 
     /// PERSIST phase for delete_many: write tombstones AFTER WAL commit.
     ///
     /// BUG #1 FIX: Only call this after WAL is committed!
-    /// This method:
-    /// - Removes from all indexes FIRST
-    /// - Writes tombstones to storage
-    /// - Invalidates query cache
-    ///
-    /// NOTE: For batch operations, index-first is safer for partial storage failure.
-    /// If tombstone write fails mid-batch, removed index entries mean those docs
-    /// won't appear in queries (acceptable - they were meant to be deleted).
-    /// Recovery rebuilds indexes from storage, ensuring consistency.
+    /// This method tombstones each prepared document atomically through the shared
+    /// chokepoint [`Self::tombstone_doc_atomic`]: for every doc_id it acquires the
+    /// storage write lock, RE-READS the doc under it, then writes the tombstone and
+    /// removes the doc from indexes in one critical section (lock order
+    /// storage→indexes, #75). A doc a concurrent writer already deleted returns None
+    /// and is skipped, so the live count is never double-decremented (audit P2-3).
     fn delete_many_persist(&self, prepared: DeleteManyPrepared) -> Result<u64> {
-        // Remove from indexes FIRST (safer for partial storage failure)
-        for document in &prepared.index_removals {
-            self.remove_from_indexes(document)?;
-        }
-
-        // Write tombstones to storage
-        if !prepared.tombstone_writes.is_empty() {
-            let mut storage = self.storage.write();
-            for (doc_id, tombstone_json) in &prepared.tombstone_writes {
-                storage.write_document_raw(&self.name, doc_id, tombstone_json.as_bytes())?;
+        let mut deleted = 0u64;
+        for (doc_id, _old_doc) in &prepared.wal_entries {
+            if self.tombstone_doc_atomic(doc_id, None)?.is_some() {
+                deleted += 1;
             }
-            storage.adjust_live_count(&self.name, -(prepared.deleted as i64));
         }
 
         // Invalidate query cache if any document was deleted
-        if prepared.deleted > 0 {
+        if deleted > 0 {
             self.query_cache.invalidate_collection(&self.name);
         }
 
-        Ok(prepared.deleted)
+        Ok(deleted)
     }
 
     // ========================================================================
@@ -2014,74 +1879,40 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
     fn delete_one_prepare(&self, query_json: &Value) -> Result<DeleteOnePrepared> {
         self.check_not_closed()?;
 
+        let no_match = || DeleteOnePrepared {
+            doc_id: None,
+            old_doc: None,
+            deleted: 0,
+            collection_name: self.name.clone(),
+        };
+
         // ====================================================================
         // FAST PATH: Direct _id lookup O(1)
-        // When query is {"_id": value}, skip catalog scanning entirely.
-        // This is 10-100x faster than the slow path for large collections.
-        // FIX #7: Uses normalize_document_id to handle string/int conversion
-        // e.g., {"_id": "123"} should match DocumentId::Int(123)
+        // When query is {"_id": value}, resolve the stored id (raw or normalized)
+        // then tombstone atomically. tombstone_doc_atomic re-reads under the
+        // storage write lock, so the resolve→tombstone window is race-safe.
         // ====================================================================
-        if let Some(doc_id) = Self::extract_id_query(query_json) {
-            // Helper closure to perform the actual delete operation
-            let do_delete = |coll: &Self,
-                             actual_doc_id: &DocumentId,
-                             doc: Value|
-             -> Result<DeleteOnePrepared> {
-                // PERF: Direct Value→Document (no serialization roundtrip)
-                let document = Document::from_value(&doc)?;
-                let old_doc_value = doc.clone();
-
-                // Remove from indexes
-                coll.remove_from_indexes(&document)?;
-
-                // 🔒 ATOMIC: Acquire write lock for delete operation
-                let mut storage = coll.storage.write();
-
-                // Write tombstone
-                let mut tombstone = old_doc_value.clone();
-                if let Value::Object(ref mut map) = tombstone {
-                    map.insert("_tombstone".to_string(), Value::Bool(true));
-                    map.insert("_collection".to_string(), Value::String(coll.name.clone()));
-                }
-                let tombstone_json = serde_json::to_string(&tombstone)?;
-                storage.write_document_raw(&coll.name, actual_doc_id, tombstone_json.as_bytes())?;
-                storage.adjust_live_count(&coll.name, -1);
-
-                Ok(DeleteOnePrepared {
-                    doc_id: Some(actual_doc_id.clone()),
-                    old_doc: Some(old_doc_value),
-                    deleted: 1,
-                    collection_name: coll.name.clone(),
-                })
+        if let Some(raw_id) = Self::extract_id_query(query_json) {
+            let Some(target_id) = self.resolve_stored_id(&raw_id)? else {
+                return Ok(no_match());
             };
-
-            // Try original ID first
-            if let Some(doc) = self.read_document_by_id(&doc_id)? {
-                return do_delete(self, &doc_id, doc);
-            }
-            // Try normalized version (string "123" → int 123)
-            if let Some(normalized) = Self::normalize_document_id(&doc_id) {
-                if let Some(doc) = self.read_document_by_id(&normalized)? {
-                    return do_delete(self, &normalized, doc);
-                }
-            }
-            // Document not found
-            return Ok(DeleteOnePrepared {
-                doc_id: None,
-                old_doc: None,
-                deleted: 0,
-                collection_name: self.name.clone(),
-            });
+            return match self.tombstone_doc_atomic(&target_id, None)? {
+                Some(old_doc) => Ok(DeleteOnePrepared {
+                    doc_id: Some(target_id),
+                    old_doc: Some(old_doc),
+                    deleted: 1,
+                    collection_name: self.name.clone(),
+                }),
+                None => Ok(no_match()),
+            };
         }
 
         // ====================================================================
         // SLOW PATH: Complex queries (non-_id filters)
-        // Uses collect_doc_ids which may scan the catalog
+        // collect_doc_ids ran with limit=1, so there is at most one candidate;
+        // tombstone_doc_atomic re-matches it under the lock before deleting.
         // ====================================================================
         let parsed_query = Query::from_json(query_json)?;
-
-        // STREAMING FIX: Collect only document IDs first (with limit=1 for efficiency)
-        // This avoids bulk-loading all documents into memory
         let (doc_ids, _) = self.collect_doc_ids_with_options(
             query_json,
             None,
@@ -2096,50 +1927,19 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
             None, // No deadline for delete operations
         )?;
 
-        for doc_id in doc_ids {
-            // Stream-load document one at a time
-            if let Some(doc) = self.read_document_by_id(&doc_id)? {
-                let doc_json_str = serde_json::to_string(&doc)?;
-                let document = Document::from_json(&doc_json_str)?;
+        let Some(target_doc_id) = doc_ids.into_iter().next() else {
+            return Ok(no_match());
+        };
 
-                if parsed_query.matches(&document)? {
-                    // Save old doc for WAL
-                    let old_doc_value = doc.clone();
-                    let doc_id = document.id.clone();
-
-                    // Remove from indexes
-                    self.remove_from_indexes(&document)?;
-
-                    // 🔒 ATOMIC: Acquire write lock for delete operation
-                    let mut storage = self.storage.write();
-
-                    // Write tombstone
-                    let mut tombstone = old_doc_value.clone();
-                    if let Value::Object(ref mut map) = tombstone {
-                        map.insert("_tombstone".to_string(), Value::Bool(true));
-                        map.insert("_collection".to_string(), Value::String(self.name.clone()));
-                    }
-                    let tombstone_json = serde_json::to_string(&tombstone)?;
-                    storage.write_document_raw(&self.name, &doc_id, tombstone_json.as_bytes())?;
-                    storage.adjust_live_count(&self.name, -1);
-
-                    return Ok(DeleteOnePrepared {
-                        doc_id: Some(doc_id),
-                        old_doc: Some(old_doc_value),
-                        deleted: 1,
-                        collection_name: self.name.clone(),
-                    });
-                }
-            }
+        match self.tombstone_doc_atomic(&target_doc_id, Some(&parsed_query))? {
+            Some(old_doc) => Ok(DeleteOnePrepared {
+                doc_id: Some(target_doc_id),
+                old_doc: Some(old_doc),
+                deleted: 1,
+                collection_name: self.name.clone(),
+            }),
+            None => Ok(no_match()),
         }
-
-        // No match found
-        Ok(DeleteOnePrepared {
-            doc_id: None,
-            old_doc: None,
-            deleted: 0,
-            collection_name: self.name.clone(),
-        })
     }
 
     /// PERSIST phase for delete_one: cache invalidation only.
@@ -2258,29 +2058,18 @@ impl<S: Storage + RawStorage> RawOperations for CollectionCore<S> {
     /// PERSIST phase for delete_one in BATCH mode.
     /// Writes tombstone AFTER WAL commit.
     fn delete_one_persist_batch(&self, prepared: DeleteOnePreparedBatch) -> Result<u64> {
-        // Remove from indexes
-        let doc_json_str = serde_json::to_string(&prepared.old_doc)?;
-        let document = Document::from_json(&doc_json_str)?;
-        self.remove_from_indexes(&document)?;
+        // Tombstone atomically through the shared chokepoint: re-read under the
+        // storage write lock, then tombstone + de-index in one critical section
+        // (lock order storage→indexes, #75; audit P2-3). Re-reading the current doc
+        // (rather than trusting the prepare-time snapshot) also keeps index removal
+        // correct if the doc was modified between prepare and this flush. If it was
+        // already deleted by a concurrent writer, this is a no-op (idempotent).
+        let deleted = self.tombstone_doc_atomic(&prepared.doc_id, None)?.is_some() as u64;
 
-        // Write tombstone
-        let mut tombstone = prepared.old_doc.clone();
-        if let Value::Object(ref mut map) = tombstone {
-            map.insert("_tombstone".to_string(), Value::Bool(true));
-            map.insert("_collection".to_string(), Value::String(self.name.clone()));
-        }
-        let tombstone_json = serde_json::to_string(&tombstone)?;
-
-        {
-            let mut storage = self.storage.write();
-            storage.write_document_raw(&self.name, &prepared.doc_id, tombstone_json.as_bytes())?;
-            storage.adjust_live_count(&self.name, -1);
-        }
-
-        // Invalidate cache
+        // Invalidate cache (unconditional, matching the prior behaviour).
         self.query_cache.invalidate_collection(&self.name);
 
-        Ok(1)
+        Ok(deleted)
     }
 }
 

--- a/ironbase-core/src/database/mod.rs
+++ b/ironbase-core/src/database/mod.rs
@@ -192,10 +192,10 @@ impl BatchDocBuffer {
 
     /// Add a prepared delete_many to the buffer (WAL ORDERING FIX for _many)
     pub fn add_delete_many(&mut self, collection: String, prepared: DeleteManyPrepared) {
-        // Estimate memory usage from tombstone writes
-        for (_, tombstone_json) in &prepared.tombstone_writes {
-            self.memory_bytes += tombstone_json.len();
-        }
+        // Rough estimate: persist writes one minimal tombstone per matched doc.
+        // (DeleteManyPrepared no longer precomputes tombstone JSON — persist re-reads
+        // under the lock, audit P2-3 — so estimate a fixed per-doc cost instead.)
+        self.memory_bytes += prepared.deleted as usize * 100;
 
         self.delete_many_ops
             .entry(collection)

--- a/ironbase-core/tests/delete_one_atomicity_test.rs
+++ b/ironbase-core/tests/delete_one_atomicity_test.rs
@@ -1,0 +1,405 @@
+//! Regression tests for delete_one AND delete_many atomicity (audit P2-3).
+//!
+//! Every delete write path previously de-indexed BEFORE acquiring the storage write
+//! lock (reversed lock order vs #75) and read the target document lock-free, so two
+//! concurrent deletes of the same document could both pass the live read and each
+//! write a tombstone + `adjust_live_count(-1)` → the live count drifted below the
+//! true value. All paths now funnel through `tombstone_doc_atomic`, performing the
+//! whole read-modify-write under one storage write lock (re-read + tombstone-check),
+//! mirroring `update_one_prepare`.
+//!
+//! NOTE: counts after a mutation are read through a FRESH collection handle on
+//! purpose — the per-handle QueryCache (audit P2-5) means a reused handle could
+//! otherwise serve a stale count and mask the real storage state.
+
+use ironbase_core::storage::MemoryStorage;
+use ironbase_core::{DatabaseCore, DocumentId};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+fn doc(field: &str, val: Value) -> HashMap<String, Value> {
+    HashMap::from([(field.to_string(), val)])
+}
+
+/// Count live docs via a FRESH handle (avoids any per-handle query-cache staleness).
+fn fresh_count(db: &DatabaseCore<MemoryStorage>) -> u64 {
+    db.collection("c")
+        .unwrap()
+        .count_documents(&json!({}))
+        .unwrap()
+}
+
+#[test]
+fn test_delete_one_fast_path_id_still_works() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("c").unwrap();
+    let id = db.insert_one("c", doc("name", json!("Alice"))).unwrap();
+
+    let deleted = db.delete_one("c", &json!({ "_id": id })).unwrap();
+    assert_eq!(deleted, 1);
+    assert_eq!(fresh_count(&db), 0);
+}
+
+#[test]
+fn test_delete_one_slow_path_filter_still_works() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("c").unwrap();
+    db.insert_one("c", doc("name", json!("Alice"))).unwrap();
+    db.insert_one("c", doc("name", json!("Bob"))).unwrap();
+
+    let deleted = db.delete_one("c", &json!({ "name": "Bob" })).unwrap();
+    assert_eq!(deleted, 1);
+    assert_eq!(fresh_count(&db), 1);
+    assert_eq!(
+        db.collection("c")
+            .unwrap()
+            .count_documents(&json!({ "name": "Alice" }))
+            .unwrap(),
+        1
+    );
+}
+
+#[test]
+fn test_delete_one_normalized_string_id() {
+    // {"_id": "123"} must resolve to DocumentId::Int(123) under the lock.
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("c").unwrap();
+    let id = db.insert_one("c", doc("name", json!("Alice"))).unwrap();
+    let n = match id {
+        DocumentId::Int(n) => n,
+        other => panic!("expected Int auto-id, got {:?}", other),
+    };
+
+    let deleted = db
+        .delete_one("c", &json!({ "_id": n.to_string() }))
+        .unwrap();
+    assert_eq!(deleted, 1, "string _id must normalize to the stored Int id");
+    assert_eq!(fresh_count(&db), 0);
+}
+
+#[test]
+fn test_delete_one_not_found_returns_zero() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("c").unwrap();
+    db.insert_one("c", doc("name", json!("setup"))).unwrap();
+
+    assert_eq!(db.delete_one("c", &json!({ "_id": 999_999 })).unwrap(), 0);
+    assert_eq!(db.delete_one("c", &json!({ "name": "nope" })).unwrap(), 0);
+    assert_eq!(fresh_count(&db), 1);
+}
+
+#[test]
+fn test_delete_one_sequential_second_is_idempotent() {
+    // The second delete of an already-deleted id must report 0 and must not
+    // decrement the live count again.
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("c").unwrap();
+    db.insert_one("c", doc("name", json!("keep"))).unwrap();
+    let id = db.insert_one("c", doc("name", json!("victim"))).unwrap();
+
+    assert_eq!(db.delete_one("c", &json!({ "_id": id })).unwrap(), 1);
+    assert_eq!(db.delete_one("c", &json!({ "_id": id })).unwrap(), 0);
+    assert_eq!(db.delete_one("c", &json!({ "_id": id })).unwrap(), 0);
+    // exactly one live doc remains; count not driven negative/over-decremented
+    assert_eq!(fresh_count(&db), 1);
+}
+
+/// THE P2-3 GUARD (fast path): N threads delete the SAME _id concurrently. Exactly
+/// one may succeed; the live count must drop by exactly one. With the old code both
+/// threads could pass the lock-free live read and each tombstone + decrement → total
+/// deleted == 2 and the count under-counted. The assertion is a hard invariant (true
+/// under ANY scheduling for correct code), so this test never fails spuriously.
+#[test]
+fn test_concurrent_delete_same_id_fast_path_decrements_once() {
+    const THREADS: usize = 8;
+    const ROUNDS: usize = 25;
+
+    for _round in 0..ROUNDS {
+        let db = Arc::new(DatabaseCore::<MemoryStorage>::open_memory().unwrap());
+        db.collection("c").unwrap();
+        db.insert_one("c", doc("filler", json!(1))).unwrap();
+        let id = db.insert_one("c", doc("filler", json!(2))).unwrap();
+
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let total = Arc::new(AtomicU64::new(0));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let db = Arc::clone(&db);
+                let barrier = Arc::clone(&barrier);
+                let total = Arc::clone(&total);
+                let id = id.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    let d = db.delete_one("c", &json!({ "_id": id })).unwrap();
+                    total.fetch_add(d, Ordering::SeqCst);
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            total.load(Ordering::SeqCst),
+            1,
+            "exactly one concurrent delete of the same _id may succeed"
+        );
+        assert_eq!(
+            fresh_count(&db),
+            1,
+            "live count must drop by exactly one (no double-decrement)"
+        );
+    }
+}
+
+/// Same invariant via the SLOW path (non-_id filter): N threads delete by the same
+/// field filter that matches exactly one document.
+#[test]
+fn test_concurrent_delete_same_filter_slow_path_decrements_once() {
+    const THREADS: usize = 8;
+    const ROUNDS: usize = 25;
+
+    for _round in 0..ROUNDS {
+        let db = Arc::new(DatabaseCore::<MemoryStorage>::open_memory().unwrap());
+        db.collection("c").unwrap();
+        db.insert_one("c", doc("tag", json!("keep"))).unwrap();
+        db.insert_one("c", doc("tag", json!("victim"))).unwrap();
+
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let total = Arc::new(AtomicU64::new(0));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let db = Arc::clone(&db);
+                let barrier = Arc::clone(&barrier);
+                let total = Arc::clone(&total);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let d = db.delete_one("c", &json!({ "tag": "victim" })).unwrap();
+                    total.fetch_add(d, Ordering::SeqCst);
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            total.load(Ordering::SeqCst),
+            1,
+            "slow path: exactly one concurrent delete may succeed"
+        );
+        assert_eq!(fresh_count(&db), 1, "slow path: no double-decrement");
+    }
+}
+
+/// Genuine concurrency over DISTINCT ids must delete each exactly once (the atomic
+/// path must not lose or over-count deletes when threads touch different docs).
+#[test]
+fn test_concurrent_delete_distinct_ids_exact_count() {
+    const N: usize = 64;
+
+    let db = Arc::new(DatabaseCore::<MemoryStorage>::open_memory().unwrap());
+    db.collection("c").unwrap();
+    let ids: Vec<DocumentId> = (0..N)
+        .map(|i| db.insert_one("c", doc("seq", json!(i))).unwrap())
+        .collect();
+
+    let barrier = Arc::new(Barrier::new(N));
+    let total = Arc::new(AtomicU64::new(0));
+    let handles: Vec<_> = ids
+        .into_iter()
+        .map(|id| {
+            let db = Arc::clone(&db);
+            let barrier = Arc::clone(&barrier);
+            let total = Arc::clone(&total);
+            thread::spawn(move || {
+                barrier.wait();
+                let d = db.delete_one("c", &json!({ "_id": id })).unwrap();
+                total.fetch_add(d, Ordering::SeqCst);
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    assert_eq!(
+        total.load(Ordering::SeqCst),
+        N as u64,
+        "each distinct id must be deleted exactly once"
+    );
+    assert_eq!(fresh_count(&db), 0);
+}
+
+// ===========================================================================
+// delete_many — same chokepoint (tombstone_doc_atomic). Covers both the
+// in-memory raw path (delete_many_raw_with_docs) and the Safe-mode bulk path
+// (delete_many_prepare/persist), which previously also de-indexed before the
+// storage lock with precomputed tombstone/index lists (audit P2-3).
+// ===========================================================================
+
+#[test]
+fn test_delete_many_basic_memory() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("c").unwrap();
+    for i in 0..10 {
+        db.insert_one("c", HashMap::from([("g".to_string(), json!(i % 2))]))
+            .unwrap();
+    }
+    let deleted = db.delete_many("c", &json!({ "g": 0 })).unwrap();
+    assert_eq!(deleted, 5);
+    assert_eq!(fresh_count(&db), 5);
+}
+
+#[test]
+fn test_delete_many_safe_mode_prepare_persist() {
+    // File-backed DB → Safe durability → delete_many_prepare + delete_many_persist.
+    let dir = tempfile::TempDir::new().unwrap();
+    let db = DatabaseCore::open(dir.path().join("dm.mlite")).unwrap();
+    db.collection("c").unwrap();
+    for i in 0..10 {
+        db.insert_one("c", HashMap::from([("g".to_string(), json!(i % 2))]))
+            .unwrap();
+    }
+    let deleted = db.delete_many("c", &json!({ "g": 1 })).unwrap();
+    assert_eq!(deleted, 5);
+    assert_eq!(
+        db.collection("c")
+            .unwrap()
+            .count_documents(&json!({}))
+            .unwrap(),
+        5
+    );
+}
+
+#[test]
+fn test_delete_many_id_in_fast_path_safe() {
+    // Exercises extract_id_in_query fast path in delete_many_prepare.
+    let dir = tempfile::TempDir::new().unwrap();
+    let db = DatabaseCore::open(dir.path().join("dm_in.mlite")).unwrap();
+    db.collection("c").unwrap();
+    let ids: Vec<DocumentId> = (0..6)
+        .map(|i| {
+            db.insert_one("c", HashMap::from([("n".to_string(), json!(i))]))
+                .unwrap()
+        })
+        .collect();
+    let target: Vec<Value> = ids
+        .iter()
+        .take(3)
+        .map(|id| serde_json::to_value(id).unwrap())
+        .collect();
+    let deleted = db
+        .delete_many("c", &json!({ "_id": { "$in": target } }))
+        .unwrap();
+    assert_eq!(deleted, 3);
+    assert_eq!(
+        db.collection("c")
+            .unwrap()
+            .count_documents(&json!({}))
+            .unwrap(),
+        3
+    );
+}
+
+/// THE P2-3 GUARD for delete_many (in-memory raw path): N threads delete the same
+/// filter matching M docs. MemoryStorage delete_many returns the ACTUAL tombstoned
+/// count, so the sum across threads must be exactly M (each victim deleted once),
+/// and the live count must drop by exactly M. The pre-fix code could tombstone the
+/// same doc from two threads → sum > M and an over-decremented count.
+#[test]
+fn test_concurrent_delete_many_same_filter_memory_no_double_decrement() {
+    const THREADS: usize = 8;
+    const MATCH: u64 = 12;
+    const ROUNDS: usize = 15;
+
+    for _round in 0..ROUNDS {
+        let db = Arc::new(DatabaseCore::<MemoryStorage>::open_memory().unwrap());
+        db.collection("c").unwrap();
+        for _ in 0..5 {
+            db.insert_one("c", doc("tag", json!("keep"))).unwrap();
+        }
+        for _ in 0..MATCH {
+            db.insert_one("c", doc("tag", json!("victim"))).unwrap();
+        }
+
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let total = Arc::new(AtomicU64::new(0));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let db = Arc::clone(&db);
+                let barrier = Arc::clone(&barrier);
+                let total = Arc::clone(&total);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let d = db.delete_many("c", &json!({ "tag": "victim" })).unwrap();
+                    total.fetch_add(d, Ordering::SeqCst);
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            total.load(Ordering::SeqCst),
+            MATCH,
+            "each victim deleted exactly once across all threads"
+        );
+        assert_eq!(
+            fresh_count(&db),
+            5,
+            "only 'keep' docs survive; no double-decrement"
+        );
+    }
+}
+
+/// THE P2-3 GUARD for delete_many (Safe bulk path): same as above on a file-backed
+/// DB. Safe-mode delete_many returns the prepare-time match count per call (so the
+/// summed return is not a clean invariant under contention), but the LIVE count must
+/// drop by exactly M — the persist re-read guard prevents double-decrement.
+#[test]
+fn test_concurrent_delete_many_safe_mode_no_double_decrement() {
+    const THREADS: usize = 6;
+    const MATCH: usize = 10;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let db = Arc::new(DatabaseCore::open(dir.path().join("dm_conc.mlite")).unwrap());
+    db.collection("c").unwrap();
+    for _ in 0..4 {
+        db.insert_one("c", doc("tag", json!("keep"))).unwrap();
+    }
+    for _ in 0..MATCH {
+        db.insert_one("c", doc("tag", json!("victim"))).unwrap();
+    }
+
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let handles: Vec<_> = (0..THREADS)
+        .map(|_| {
+            let db = Arc::clone(&db);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                db.delete_many("c", &json!({ "tag": "victim" })).unwrap();
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let remaining = db
+        .collection("c")
+        .unwrap()
+        .count_documents(&json!({}))
+        .unwrap();
+    assert_eq!(
+        remaining, 4,
+        "only 'keep' docs survive; live count not over-decremented"
+    );
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.528"
+version = "1.0.531"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Audit P2-3 — delete was not atomic

Every delete write path de-indexed the document **before** acquiring the storage write lock (`remove_from_indexes()` then `storage.write()`), and read the target lock-free. This:

1. **Reversed the storage→indexes lock order** the rest of the engine follows (#75).
2. **Opened a concurrent double-decrement window**: two concurrent deletes of the same document could both pass the lock-free live read and each write a tombstone + `adjust_live_count(-1)` → the live count silently drifted **below** the true value.

`update_one_prepare` already did this correctly (storage lock held across the index mutation); the delete paths had diverged because the logic was copy-pasted across **seven** sites.

## Fix — one shared chokepoint

All delete paths now funnel through `CollectionCore::tombstone_doc_atomic`: acquire the storage write lock, **re-read** the doc under it (skip a row a concurrent writer already tombstoned, re-match the query when given), write the tombstone, then de-index — one critical section, lock order storage→indexes.

- **delete_one:** `delete_one_prepare` (Safe), `delete_one_raw` (in-memory/Unsafe), `delete_one_persist_batch` (Batch). `delete_one_raw` now also resolves a string `_id` to its stored integer form (`resolve_stored_id`), matching `delete_one_prepare`.
- **delete_many:** `delete_many_raw_with_docs` (in-memory) and the Safe bulk `delete_many_persist`. `DeleteManyPrepared` dropped its precomputed `tombstone_writes` + `index_removals` lists — the persist re-reads each doc under the lock instead, shrinking the prepare/persist contract to `deleted` + `wal_entries`.

Net **−87 lines** in source (the 7 copies collapsed into one chokepoint — the duplication was the root cause).

## Tests

New `delete_one_atomicity_test` (13 tests): concurrent same-`_id` / same-filter guards for **both** delete_one and delete_many (in-memory raw path **and** Safe prepare/persist path), asserting each doc is deleted exactly once and the live count drops by exactly the matched count. **These fail on the pre-fix code** (e.g. concurrent same-`_id` gave total deleted = 6 instead of 1). Full `ironbase-core` suite green; fmt + clippy clean. `wal_entries` unchanged (`(doc_id, Null)`) so WAL replay is intact.

## Scoped out (verified NOT a reachable bug)

`update_one_persist_batch` shares the index-before-storage ordering, but `flush_batch` holds `batch_doc_buffer.write()` across the entire persist phase → all batch persistence is serialized and Batch mode has no concurrent storage-write path, so its lock-free re-read cannot race. Cosmetic ordering only, not corruption.

Sequenced after #99 (P0-1) and #100 (P1-2): v1.0.531 / core 0.3.337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)