### PR TITLE
fix(upsert): concurrent upsert on the same filter created duplicate documents (audit P2-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — concurrent upsert on the same filter created duplicate documents (audit P2-4) (mcp-server v1.0.532, core v0.3.338)
+
+`update_one_with_options` implements upsert as `update_one()` (the match — which releases all
+locks) **then** `insert_one()`, with no lock spanning the two. Two concurrent upserts on the same
+filter (no matching doc, no application-level unique index) could therefore **both** observe
+`matched == 0` and each insert → duplicate documents. Empirically reproduced: 8 threads upserting one
+filter produced 2–8 documents instead of 1.
+
+The audit's "just hold the collection write lock" turned out to be unsafe: every collection has a
+unique `_id` index, so `collection_has_unique_index` is always true and `insert_one` **always** takes
+the per-collection write lock — reusing it to wrap the upsert would reentrant-deadlock. The fix adds a
+**dedicated per-collection upsert lock** (`collection_upsert_locks`, mirroring `collection_write_locks`)
+held across the whole match→insert window. It is distinct from the write lock `insert_one` takes, so
+there is no reentrancy; lock order is always upsert_lock → collection_write_lock (no ABBA). Applied to
+both `update_one_with_options` variants (generic Safe path and the MemoryStorage path). With an
+application unique index the constraint already prevented the duplicate; the lock now also covers the
+no-unique-index case.
+
+New `upsert_toctou_test`: concurrent same-filter guards on both the in-memory and Safe (file-backed)
+paths assert exactly one document results (these **fail on the pre-fix code**, which is how the bug's
+reachability was confirmed before fixing), plus a sequential insert-then-update sanity check.
+
+
 ### Refactored — unify the four QueryPlan executors behind one range chokepoint (mcp-server v1.0.528, core v0.3.334)
 
 Audit finding #8: a single `QueryPlan` was interpreted by **four** hand-synced executors — the two

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.334"
+version = "0.3.338"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/database/collections.rs
+++ b/ironbase-core/src/database/collections.rs
@@ -172,6 +172,32 @@ impl<S: Storage + RawStorage> DatabaseCore<S> {
         lock
     }
 
+    /// Per-collection upsert serialization lock (audit P2-4).
+    ///
+    /// Returned lock is held across `update_one_with_options`'s match→insert window
+    /// so two concurrent upserts on the same filter cannot both observe `matched==0`
+    /// and each insert a duplicate. Separate from `get_collection_write_lock` (which
+    /// `insert_one` takes) to avoid a reentrant deadlock.
+    pub(crate) fn get_collection_upsert_lock(&self, name: &str) -> Arc<Mutex<()>> {
+        // Fast path: read lock to check if already exists
+        {
+            let locks = self.collection_upsert_locks.read();
+            if let Some(lock) = locks.get(name) {
+                return Arc::clone(lock);
+            }
+        }
+
+        // Slow path: create with write lock (double-checked)
+        let mut locks = self.collection_upsert_locks.write();
+        if let Some(lock) = locks.get(name) {
+            return Arc::clone(lock);
+        }
+
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(name.to_string(), Arc::clone(&lock));
+        lock
+    }
+
     /// Check if a collection has any unique indexes (excluding _id which is always unique)
     ///
     /// Used for hybrid locking optimization:
@@ -1468,10 +1494,11 @@ impl<S: Storage + RawStorage> DatabaseCore<S> {
         // Collect and delete index files BEFORE removing the IndexManager
         self.cleanup_index_files_for_collection(name);
 
-        // Remove shared IndexManager, SchemaManager, and collection write lock
+        // Remove shared IndexManager, SchemaManager, and collection write/upsert locks
         self.index_managers.write().remove(name);
         self.schema_managers.write().remove(name);
         self.collection_write_locks.write().remove(name);
+        self.collection_upsert_locks.write().remove(name);
 
         let mut storage = self.storage.write();
         storage.drop_collection(name)
@@ -1673,10 +1700,11 @@ impl<S: Storage + RawStorage> DatabaseCore<S> {
         // Collect and delete index files BEFORE removing the IndexManager
         self.cleanup_index_files_for_collection(name);
 
-        // Remove shared IndexManager, SchemaManager, and collection write lock
+        // Remove shared IndexManager, SchemaManager, and collection write/upsert locks
         self.index_managers.write().remove(name);
         self.schema_managers.write().remove(name);
         self.collection_write_locks.write().remove(name);
+        self.collection_upsert_locks.write().remove(name);
 
         let mut storage = self.storage.write();
         storage.drop_collection(name)

--- a/ironbase-core/src/database/durability.rs
+++ b/ironbase-core/src/database/durability.rs
@@ -752,6 +752,20 @@ impl DatabaseCore<StorageEngine> {
 
         self.check_not_closed()?;
 
+        // P2-4 FIX: hold a per-collection upsert lock across the whole match→insert
+        // window so two concurrent upserts on the same filter can't both observe
+        // matched==0 and each insert (reproduced under load: 8 threads → duplicate
+        // docs). This is a DEDICATED lock, distinct from the collection write lock
+        // insert_one takes — every collection has a unique _id index so insert_one
+        // always takes that one, and reusing it here would reentrant-deadlock. Lock
+        // order is always upsert_lock → collection_write_lock, so no ABBA.
+        let upsert_lock = if options.upsert {
+            Some(self.get_collection_upsert_lock(collection_name))
+        } else {
+            None
+        };
+        let _upsert_guard = upsert_lock.as_ref().map(|l| l.lock());
+
         // First, try the normal update
         // Handle CollectionNotFound specially for upsert
         let update_result = self.update_one(collection_name, query, update);
@@ -1454,6 +1468,20 @@ impl DatabaseCore<MemoryStorage> {
         use crate::upsert::create_upsert_document;
 
         self.check_not_closed()?;
+
+        // P2-4 FIX: hold a per-collection upsert lock across the whole match→insert
+        // window so two concurrent upserts on the same filter can't both observe
+        // matched==0 and each insert (reproduced under load: 8 threads → duplicate
+        // docs). This is a DEDICATED lock, distinct from the collection write lock
+        // insert_one takes — every collection has a unique _id index so insert_one
+        // always takes that one, and reusing it here would reentrant-deadlock. Lock
+        // order is always upsert_lock → collection_write_lock, so no ABBA.
+        let upsert_lock = if options.upsert {
+            Some(self.get_collection_upsert_lock(collection_name))
+        } else {
+            None
+        };
+        let _upsert_guard = upsert_lock.as_ref().map(|l| l.lock());
 
         // First, try the normal update
         // Handle CollectionNotFound specially for upsert

--- a/ironbase-core/src/database/mod.rs
+++ b/ironbase-core/src/database/mod.rs
@@ -321,6 +321,13 @@ pub struct DatabaseCore<S: Storage + RawStorage> {
     // Prevents race conditions in unique constraint checks
     pub(crate) collection_write_locks: Arc<RwLock<HashMap<String, Arc<Mutex<()>>>>>,
 
+    // Per-collection upsert serialization lock (audit P2-4).
+    // Held across update_one_with_options's match→insert window so two concurrent
+    // upserts on the same filter can't both see matched==0 and each insert. Distinct
+    // from collection_write_locks (which insert_one takes) → no reentrant deadlock;
+    // lock order is always upsert_lock → collection_write_lock.
+    pub(crate) collection_upsert_locks: Arc<RwLock<HashMap<String, Arc<Mutex<()>>>>>,
+
     // Guard: true while compact_nonblocking() is running
     // Prevents concurrent compaction from direct Rust consumers
     // (MCP server has its own adapter-level guard; this protects core-level callers)
@@ -475,6 +482,7 @@ impl DatabaseCore<StorageEngine> {
             write_lock_condvar: Arc::new(Condvar::new()),
             is_closed: Arc::new(AtomicBool::new(false)),
             collection_write_locks: Arc::new(RwLock::new(HashMap::new())),
+            collection_upsert_locks: Arc::new(RwLock::new(HashMap::new())),
             is_compacting: AtomicBool::new(false),
             last_compact_size: AtomicU64::new(stored_compact_size),
             recovered_operations: Arc::new(RwLock::new(recovered_ops_by_collection)),
@@ -596,6 +604,7 @@ impl DatabaseCore<MemoryStorage> {
             write_lock_condvar: Arc::new(Condvar::new()),
             is_closed: Arc::new(AtomicBool::new(false)),
             collection_write_locks: Arc::new(RwLock::new(HashMap::new())),
+            collection_upsert_locks: Arc::new(RwLock::new(HashMap::new())),
             is_compacting: AtomicBool::new(false),
             last_compact_size: AtomicU64::new(0),
             recovered_operations: Arc::new(RwLock::new(HashMap::new())),

--- a/ironbase-core/tests/upsert_toctou_test.rs
+++ b/ironbase-core/tests/upsert_toctou_test.rs
@@ -1,0 +1,142 @@
+//! Reproduction + regression test for the upsert TOCTOU (audit P2-4).
+//!
+//! `update_one_with_options` performs upsert as `update_one()` (match — releases all
+//! locks) THEN `insert_one()`, with NO lock spanning the two. Two concurrent upserts
+//! on the same filter (no matching doc, no unique index) can therefore both observe
+//! matched==0 and each insert → duplicate documents. MongoDB avoids this with a
+//! unique index on the query field; without one it is a real race.
+//!
+//! These tests assert the CORRECT behaviour (one doc); they FAIL on the pre-fix code,
+//! which is how the bug's reachability was empirically confirmed before fixing.
+
+use ironbase_core::{storage::MemoryStorage, DatabaseCore, UpdateOptions};
+use serde_json::json;
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+fn count_by_email(db: &DatabaseCore<MemoryStorage>, email: &str) -> u64 {
+    // Fresh handle — avoids any per-handle query-cache staleness (audit P2-5).
+    db.collection("users")
+        .unwrap()
+        .count_documents(&json!({ "email": email }))
+        .unwrap()
+}
+
+/// THE P2-4 GUARD: N threads upsert the SAME filter concurrently (no pre-existing
+/// doc, no unique index). At most ONE may insert; the rest must update the winner.
+/// On the pre-fix code both can pass matched==0 and insert → >1 doc.
+#[test]
+fn test_concurrent_upsert_same_filter_creates_one_doc() {
+    const THREADS: usize = 8;
+    const ROUNDS: usize = 25;
+
+    for _round in 0..ROUNDS {
+        let db = Arc::new(DatabaseCore::<MemoryStorage>::open_memory().unwrap());
+        db.collection("users").unwrap();
+
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|i| {
+                let db = Arc::clone(&db);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    db.update_one_with_options(
+                        "users",
+                        &json!({ "email": "race@example.com" }),
+                        &json!({ "$set": { "n": i } }),
+                        UpdateOptions::new().with_upsert(true),
+                    )
+                    .unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            count_by_email(&db, "race@example.com"),
+            1,
+            "concurrent upsert on the same filter must yield exactly one document"
+        );
+    }
+}
+
+/// Single-threaded upsert must still behave: first call inserts, second updates.
+#[test]
+fn test_upsert_sequential_insert_then_update() {
+    let db = DatabaseCore::<MemoryStorage>::open_memory().unwrap();
+    db.collection("users").unwrap();
+
+    let r1 = db
+        .update_one_with_options(
+            "users",
+            &json!({ "email": "a@example.com" }),
+            &json!({ "$set": { "name": "A" } }),
+            UpdateOptions::new().with_upsert(true),
+        )
+        .unwrap();
+    assert!(r1.upserted_id.is_some(), "first upsert inserts");
+
+    let r2 = db
+        .update_one_with_options(
+            "users",
+            &json!({ "email": "a@example.com" }),
+            &json!({ "$set": { "name": "B" } }),
+            UpdateOptions::new().with_upsert(true),
+        )
+        .unwrap();
+    assert!(
+        r2.upserted_id.is_none(),
+        "second upsert updates the existing doc"
+    );
+    assert_eq!(r2.matched_count, 1);
+
+    assert_eq!(count_by_email(&db, "a@example.com"), 1);
+}
+
+/// Same P2-4 guard on a FILE-backed DB → Safe durability → the generic
+/// `update_one_with_options` variant (the MemoryStorage one is covered above).
+#[test]
+fn test_concurrent_upsert_same_filter_safe_mode() {
+    const THREADS: usize = 8;
+    const ROUNDS: usize = 3;
+
+    for _round in 0..ROUNDS {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = Arc::new(DatabaseCore::open(dir.path().join("upsert.mlite")).unwrap());
+        db.collection("users").unwrap();
+
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|i| {
+                let db = Arc::clone(&db);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    db.update_one_with_options(
+                        "users",
+                        &json!({ "email": "race@example.com" }),
+                        &json!({ "$set": { "n": i } }),
+                        UpdateOptions::new().with_upsert(true),
+                    )
+                    .unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let count = db
+            .collection("users")
+            .unwrap()
+            .count_documents(&json!({ "email": "race@example.com" }))
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "Safe-mode concurrent upsert must yield exactly one document"
+        );
+    }
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.528"
+version = "1.0.532"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Audit P2-4 — concurrent upsert creates duplicates

`update_one_with_options` implements upsert as `update_one()` (the match — which **releases all locks**) **then** `insert_one()`, with no lock spanning the two. Two concurrent upserts on the same filter (no matching doc, no application unique index) can therefore **both** observe `matched == 0` and each insert → duplicate documents.

**Empirically reproduced before fixing:** 8 threads upserting one filter produced 2–8 documents instead of 1. The repro test (`test_concurrent_upsert_same_filter_creates_one_doc`) fails on the pre-fix code.

## Root cause found while fixing

The audit's "just hold the collection write lock" was **unsafe**: every collection has a unique `_id` index, so `collection_has_unique_index` is **always true** and `insert_one` **always** takes the per-collection write lock. Reusing that lock to wrap the upsert would reentrant-deadlock. (My first naive guard `if upsert && !unique` silently did nothing because the `!unique` condition was always false — the repro test caught that it didn't fix anything.)

## Fix — dedicated per-collection upsert lock

A new `collection_upsert_locks` map (mirroring `collection_write_locks`) provides a per-collection lock held across the **whole match→insert window**. It is **distinct** from the write lock `insert_one` takes, so:

- no reentrancy / deadlock,
- lock order is always `upsert_lock → collection_write_lock` (no ABBA),
- applied to **both** `update_one_with_options` variants (generic Safe path + MemoryStorage path),
- the lock entry is dropped alongside the write lock in `drop_collection`.

With an application-level unique index the constraint already prevented the duplicate; the lock now also covers the common no-unique-index case.

## Tests

New `upsert_toctou_test`: concurrent same-filter guards on **both** the in-memory and Safe (file-backed) paths assert exactly one document results (these **fail on the pre-fix code**), plus a sequential insert-then-update sanity check. Full `ironbase-core` suite green; fmt + clippy clean.

Sequenced after #99/#100/#104: v1.0.532 / core 0.3.338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)