### PR TITLE
refactor(search): BREAKING — disjunctive (OR) lexical default, industry-standard hybrid (v1.0.537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — BREAKING: lexical retrieval default is now disjunctive (OR), industry-standard (mcp-server v1.0.537)
+
+The fulltext / hybrid-fusion lexical lane now defaults to **disjunctive (OR)** matching
+instead of conjunctive (AND). This aligns IronBase with the industry-standard hybrid /
+RRF design: the lexical lane retrieves disjunctively and relevance is decided by the
+graded BM25 score + RRF + reranking — not by a binary all-terms gate applied *before*
+fusion.
+
+**Why.** The prior AND default (v1.0.389–536) ran a document-level AND qualification that
+HARD-FILTERED the fulltext lane to documents containing every query token. This dropped
+strong partial matches — a BM25 rank-1 hit could vanish entirely from the fused result
+when the document lacked any single query token (e.g. a synonym: query "légkondi", doc
+"klíma"). Re-binarizing BM25's inherently graded scoring is non-standard for RRF, where
+each retriever is meant to run independently and cover the other's blind spot. Measured on
+the rdocs eval set, switching to OR lifts specific-query Recall@10 from 0.625 → 0.782
+(and Recall@5 0.537 → 0.671) at a small precision cost on high-redundancy browse queries.
+
+A separate fuzzy-coverage membership multiplier was prototyped and **rejected**: a real
+server-side A/B showed it is byte-for-byte identical to plain OR once reranking is on
+(the existing rerank density boost already supplies the graded coverage signal), and the
+literature confirms the classic Fuzzy IR model is a pre-BM25 Boolean-era technique that
+modern BM25+RRF hybrids do not layer on.
+
+**Migration.** `mode="and"` is still available as an explicit opt-in precision filter
+(all query tokens required), and `match_scope` ("document"/"chunk") continues to apply
+**only** under `mode="and"`. Clients that relied on the implicit AND default must now pass
+`mode="and"` to preserve the old behavior. Affects `fulltext_search`, the Rhai
+`db_hybrid_search`, and the `search` tool's internal fusion (single decision point:
+`fusion::resolve_and_mode`).
+
 ### Fixed — index-based $group count path: multiplier overflow + stale planner references (mcp-server v1.0.535, core v0.3.341)
 
 Post-review follow-up on this branch (fresh `/code-review` pass over the full diff).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -802,13 +802,13 @@ let results = db_hybrid_search("kb", "keresett szöveg", #{
     deduplicate: false,      // MMR diversity reranking (default: false)
     mmr_lambda: 0.7,         // MMR lambda (1.0=relevance, 0.0=diversity, default: 0.7)
     merge_chunks: true,      // Szomszédos chunk összevonás
-    match_scope: "document", // "chunk" (default) | "document" (mode=and + RAG)
+    match_scope: "document", // "document" (default) | "chunk" — csak mode="and" mellett él
     search_mode: "balanced", // "balanced" | "semantic" | "keyword"
     vector_weight: 0.5,      // Explicit vektor súly (felülírja search_mode-ot)
     fulltext_weight: 0.5,    // Explicit fulltext súly
     title_field: "title",    // Cím mező reranking boost-hoz
     text_fields: ["content", "title"], // Multi-field fulltext
-    mode: "and",             // Fulltext mode: "and" (default) | "or"
+    mode: "or",              // Fulltext mode: "or" (default, diszjunktív) | "and" (opt-in precízió)
     group_by_document: true, // Dokumentumok szerinti csoportosítás (default: false)
     filter: #{ year: 2026 }, // Dokumentum szűrő
 });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,25 +875,23 @@ let results = db_hybrid_search("kb", "keresett szöveg", #{
 }
 ```
 
-**Fulltext mode paraméter (45f74bf7, #47, cd70eae4 #61):**
-- `mode`: `"and"` (default) = MINDEN szó kell a dokumentumban, `"or"` = bármely szó elég (deprecated)
-- Elérhető: Rhai `db_hybrid_search` + `fulltext_search` MCP tool — **mindkettő AND default** (v1.0.389+, korábban fulltext_search OR volt). A `search` MCP tool intent-only (a mode-ot a motor dönti).
-- AND mód szűkíti a fulltext komponenst; vektor keresés változatlan → RRF fusion vektor-only eredményeket is ad
-- `mode` hiánya = `"and"` (v1.0.375+)
+**Fulltext mode paraméter (45f74bf7, #47, cd70eae4 #61, BREAKING: diszjunktív default):**
+- `mode`: **`"or"` (default, v1.0.537+)** = bármely szó elég, BM25 score rangsorol (iparági standard diszjunktív retrieval); `"and"` = MINDEN szó kell (opt-in precízió-szűrő)
+- Elérhető: Rhai `db_hybrid_search` + `fulltext_search` MCP tool — **mindkettő OR default** (v1.0.537+; **korábban AND volt v1.0.389–536**). A `search` MCP tool intent-only (a motor diszjunktívan keres).
+- **BREAKING CHANGE indok:** a bináris AND-overlay a BM25 fölött non-standard RRF-ben — eldobja a graded BM25 scoringot és a top-1 BM25 részleges-egyezést (keyword_buries). A standard: diszjunktív lane + BM25/RRF/rerank dönt. Mérés: specific Recall@10 0.625→0.782. Részletek: `memory/search-fuzzy-coverage-fusion-2026-06-16`.
+- `mode` hiánya = `"or"` (v1.0.537+)
 
 | Fájl | Változás |
 |------|----------|
 | `params.rs` | `pub mode: Option<String>` mindkét struct-ban |
-| `definitions/hybrid.rs` | `"mode"` schema entry (default: "and", "or" deprecated) |
-| `definitions/index.rs` | `"mode"` schema entry (default: "and", v1.0.389+) |
-| `hybrid.rs` | `and_mode: p.mode.as_deref() != Some("or")` |
-| `index.rs` | `and_mode: p.mode.as_deref() != Some("or")` (v1.0.389+) |
+| `definitions/index.rs` | `"mode"` schema entry (default: **"or"**, v1.0.537+) |
+| `fusion.rs` | `resolve_and_mode(mode) = mode == Some("and")` (None→OR, v1.0.537+; egyetlen döntéspont, mindhárom hívóra) |
 
 **Document-level AND mode (0f208d41, #56, cd70eae4 #61):**
-- `match_scope`: `"document"` (default, v1.0.389+) = szavak a dokumentum különböző chunkjaiban is lehetnek, `"chunk"` = minden szó egyetlen chunkban
-- **Keresési logika:** kvalifikáció (AND) → minden query token megjelenik a dokumentumban; chunk retrieval (OR) → bármely tokent tartalmazó chunk visszajön
+- `match_scope`: `"document"` (default) = szavak a dokumentum különböző chunkjaiban is lehetnek, `"chunk"` = minden szó egyetlen chunkban. **Csak `mode="and"` mellett él** (a default OR-ban inert, v1.0.537+).
+- **Keresési logika (mode=and):** kvalifikáció (AND) → minden query token megjelenik a dokumentumban; chunk retrieval (OR) → bármely tokent tartalmazó chunk visszajön
 - Korábban default "chunk" volt, de 3+ szavas query-knél túl szigorú (egyetlen chunk ritkán tartalmaz minden tokent)
-- Aktiválódik: `mode="and"` + `match_scope` != `"chunk"` (v1.0.389+, korábban csak explicit `match_scope="document"` vagy `group_by_document=true`)
+- Aktiválódik: **explicit `mode="and"`** + `match_scope` != `"chunk"` (v1.0.537+, korábban a default AND miatt automatikus volt)
 - Algoritmus: posting list interszekcióval kvalifikálja a dokumentumokat, majd OR módban keres a kvalifikált doc_id-kre szűrve
 - Vektor keresés NEM szűrt (RRF természetesen kezeli)
 - Response: `"match_scope": "document"/"chunk"`, `"qualified_doc_ids": N`

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.535"
+version = "1.0.537"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mcp-server/src/scripting/db_functions.rs
+++ b/mcp-server/src/scripting/db_functions.rs
@@ -786,13 +786,13 @@ fn register_search_functions(
                 }
             }
 
-            // Mode: "and" (default) or "or"
-            let mut and_mode = true; // AND default — consistent with MCP fulltext_search
+            // Mode: "or" (default, disjunctive — industry standard) or "and" (opt-in precision).
+            // Mirrors fusion::resolve_and_mode (None/non-"and" → OR) so every lexical
+            // entry point shares one default. BREAKING vs the prior AND default (v1.0.537).
+            let mut and_mode = false; // OR default — consistent with fusion::resolve_and_mode
             if let Some(mode_val) = options.get("mode") {
                 if let Ok(mode_str) = mode_val.clone().into_string() {
-                    if mode_str == "or" {
-                        and_mode = false;
-                    }
+                    and_mode = mode_str == "and";
                 }
             }
 

--- a/mcp-server/src/tools/definitions/index.rs
+++ b/mcp-server/src/tools/definitions/index.rs
@@ -119,13 +119,13 @@ pub fn tools() -> Vec<Value> {
                     "query": fields::search_query(),
                     "mode": {
                         "type": "string",
-                        "description": "Search mode: 'and' (default) = ALL words must match in document, 'or' = any word matches",
+                        "description": "Search mode: 'or' (default) = any word matches, relevance ranked by BM25 score (industry-standard disjunctive retrieval); 'and' = ALL words must match (opt-in precision filter)",
                         "enum": ["and", "or"],
-                        "default": "and"
+                        "default": "or"
                     },
                     "match_scope": {
                         "type": "string",
-                        "description": "Match scope for AND mode: 'document' (default) = all words must appear across the document's chunks (ideal for RAG), 'chunk' = all words in a single chunk. No effect in 'or' mode.",
+                        "description": "Match scope for 'and' mode only: 'document' (default) = all words must appear across the document's chunks (ideal for RAG), 'chunk' = all words in a single chunk. No effect in the default 'or' mode.",
                         "enum": ["document", "chunk"],
                         "default": "document"
                     },

--- a/mcp-server/src/tools/fusion.rs
+++ b/mcp-server/src/tools/fusion.rs
@@ -704,6 +704,16 @@ pub(crate) struct QualificationOutcome {
     pub qualified_doc_count: Option<usize>,
 }
 
+/// Resolve the lexical retrieval conjunction mode from the `mode` parameter.
+///
+/// Default (None) is DISJUNCTIVE (OR, returns `false`) — the industry-standard
+/// hybrid/RRF design where relevance is ranked by BM25 score, not gated by a
+/// binary all-terms requirement. Only an explicit `mode="and"` opts into the
+/// conjunctive all-terms filter. Any other value (incl. "or") → OR.
+pub(crate) fn resolve_and_mode(mode: Option<&str>) -> bool {
+    mode == Some("and")
+}
+
 /// Apply document-level AND qualification if needed.
 ///
 /// Shared orchestration logic used by both `hybrid_search` and `fulltext_search`.
@@ -723,7 +733,14 @@ pub(crate) fn apply_document_qualification(
 ) -> Result<QualificationOutcome> {
     validate_match_scope(match_scope)?;
 
-    let and_mode = mode != Some("or");
+    // Default = DISJUNCTIVE (OR), aligning with the industry-standard hybrid /
+    // RRF design: the lexical lane retrieves disjunctively and relevance is decided
+    // by the (graded) BM25 score + RRF + rerank — NOT by a binary all-terms gate.
+    // A hard AND qualification before fusion drops strong partial (BM25 rank-1)
+    // matches and is non-standard for RRF (it re-binarizes BM25's graded scoring).
+    // AND is now OPT-IN (`mode="and"`) for callers that explicitly want all-terms
+    // precision. BREAKING CHANGE vs the prior AND default (clients may need updating).
+    let and_mode = resolve_and_mode(mode);
     let is_doc_scope = and_mode && match_scope != Some("chunk");
 
     if !is_doc_scope || fields.is_empty() {
@@ -839,6 +856,15 @@ pub(crate) fn apply_document_qualification(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_resolve_and_mode_default_is_disjunctive() {
+        // Industry-standard default: None → OR (disjunctive). Only explicit "and" → AND.
+        assert!(!resolve_and_mode(None)); // default = OR
+        assert!(!resolve_and_mode(Some("or")));
+        assert!(resolve_and_mode(Some("and"))); // opt-in precision
+        assert!(!resolve_and_mode(Some("anything-else"))); // unknown → OR (safe default)
+    }
 
     #[test]
     fn test_strip_punctuation() {

--- a/mcp-server/src/tools/hybrid.rs
+++ b/mcp-server/src/tools/hybrid.rs
@@ -1057,7 +1057,7 @@ mod tests {
         assert!(p.max_chunks_per_doc.is_none()); // default: no cap
         assert!(p.provider.is_none()); // no provider → use collection config
         assert!(p.filter.is_none()); // default: no filter
-        assert!(p.mode.is_none()); // default: None (= "and")
+        assert!(p.mode.is_none()); // default: None (= "or", disjunctive)
         assert!(p.text_fields.is_none()); // default: None (= single text_field)
         assert!(p.vector.is_some()); // explicit vector provided
     }
@@ -1097,7 +1097,7 @@ mod tests {
         });
         let p: HybridSearchParams = HybridSearchParams::parse(params).unwrap();
         assert_eq!(p.mode.as_deref(), Some("and"));
-        assert!(p.match_scope.is_none()); // default: None (= "document" — doc-level AND)
+        assert!(p.match_scope.is_none()); // default: None (= "document"); applies only under explicit mode="and"
     }
 
     #[test]
@@ -1128,8 +1128,9 @@ mod tests {
     }
 
     #[test]
-    fn test_params_match_scope_without_mode_and() {
-        // match_scope="document" with mode=None (default AND) — doc qualification WILL activate
+    fn test_params_match_scope_without_mode_or_default() {
+        // match_scope="document" with mode=None: the default is now DISJUNCTIVE (OR),
+        // so document-level AND qualification does NOT activate without explicit mode="and".
         let params = json!({
             "collection": "test",
             "vector": [0.1, 0.2],
@@ -1138,7 +1139,7 @@ mod tests {
         });
         let p: HybridSearchParams = HybridSearchParams::parse(params).unwrap();
         assert_eq!(p.match_scope.as_deref(), Some("document"));
-        assert!(p.mode.is_none()); // None = AND default → doc qualification activates
+        assert!(p.mode.is_none()); // None = OR default → match_scope inert until mode="and"
     }
 
     #[test]
@@ -1692,14 +1693,16 @@ mod pipeline_integration_tests {
             json!({"collection":"kb","type":"fulltext","field":"title"}),
         );
 
-        // BM25-only (vector_weight=0 → skip embedding), multi-field, default
-        // match_scope="document". Doc 1 has ALL query tokens; doc 2 has only one
-        // and must be excluded by document-level AND qualification.
+        // BM25-only (vector_weight=0 → skip embedding), multi-field, explicit
+        // mode="and" + match_scope="document" (document-level AND qualification is
+        // now OPT-IN; the default is disjunctive OR). Doc 1 has ALL query tokens;
+        // doc 2 has only one and must be excluded by document-level AND qualification.
         let (_p, fo) = fuse(
             &a,
             json!({"collection":"kb","query":"fékpad PEF-35",
                 "text_fields":["content","title"], "vector_weight":0.0,
-                "fulltext_weight":1.0, "limit":10}),
+                "fulltext_weight":1.0, "limit":10,
+                "mode":"and", "match_scope":"document"}),
         );
 
         assert!(

--- a/mcp-server/src/tools/params.rs
+++ b/mcp-server/src/tools/params.rs
@@ -246,11 +246,13 @@ pub struct FulltextSearchParams {
     pub skip: Option<usize>,
     pub min_score: Option<f64>,
     pub projection: Option<Value>,
-    /// Search mode: "and" (default) = ALL words must match, "or" = any word matches
+    /// Search mode: "or" (default) = any word matches, ranked by BM25 score
+    /// (industry-standard disjunctive retrieval); "and" = ALL words must match
+    /// (opt-in precision filter).
     pub mode: Option<String>,
-    /// Match scope: "document" (default) = all words must appear across the document's chunks,
-    /// "chunk" = all words must appear in a single chunk. Only relevant for RAG collections
-    /// with chunked documents. Has no effect in "or" mode.
+    /// Match scope for "and" mode only: "document" (default) = all words must appear
+    /// across the document's chunks, "chunk" = all words in a single chunk. Only
+    /// relevant for RAG collections with chunked documents. No effect in default "or" mode.
     pub match_scope: Option<String>,
     /// MongoDB-style filter applied AFTER TF-IDF scoring (core-level filtering).
     /// Use this to combine fulltext search with other query operators (e.g., $regex, $eq)
@@ -658,11 +660,13 @@ pub struct HybridSearchParams {
     /// Optional title field for title match boost in reranking (up to 1.5x)
     pub title_field: Option<String>,
 
-    /// Fulltext search mode: "and" (default) = ALL words must match, "or" (deprecated) = any word matches
+    /// Fulltext/fusion mode: "or" (default) = any word matches, ranked by BM25 +
+    /// RRF (industry-standard disjunctive retrieval); "and" = ALL words must match
+    /// (opt-in precision filter).
     pub mode: Option<String>,
 
-    /// Match scope for AND mode: "chunk" (default) or "document"
-    /// "document" = all words must appear across the document's chunks (not necessarily in one chunk)
+    /// Match scope for "and" mode only: "document" (default) = all words must appear
+    /// across the document's chunks (not necessarily in one chunk), "chunk" = one chunk.
     pub match_scope: Option<String>,
 
     /// Multiple fulltext fields to search across (overrides text_field). Best-field strategy (max score).


### PR DESCRIPTION
## Summary

The fulltext / hybrid-fusion **lexical lane now defaults to disjunctive (OR)** matching instead of conjunctive (AND), aligning IronBase with the industry-standard hybrid / RRF design: the lexical lane retrieves disjunctively and relevance is decided by the graded **BM25 score + RRF + reranking** — not by a binary all-terms gate applied *before* fusion.

## Root cause this fixes

The prior AND default (v1.0.389–536) ran a document-level AND qualification that **hard-filtered** the fulltext lane to documents containing *every* query token. A BM25 **rank-1** hit could vanish entirely from the fused result when the doc lacked any single token (e.g. synonym: query `"légkondi"`, doc `"klíma"`) — ~18% of specific-bucket relevant docs ("keyword_buries"). Re-binarizing BM25's inherently graded scoring is non-standard for RRF, where each retriever should run independently and cover the other's blind spot.

## Change

- **Single decision point:** `fusion::resolve_and_mode(mode) = (mode == Some("and"))` → `None` ⇒ OR (was `mode != Some("or")` ⇒ AND). Propagates to all three callers (`search` tool, Rhai `db_hybrid_search`, `fulltext_search`).
- `mode="and"` remains an **explicit opt-in** precision filter; `match_scope` (`document`/`chunk`) applies **only** under `mode="and"`.
- Schema (`definitions/index.rs`), param docs (`params.rs`), CLAUDE.md + CHANGELOG updated (documented as BREAKING with migration).
- `mcp-server` v1.0.535 → **v1.0.537**.

## Evidence (rdocs eval, server-side A/B)

| metric (specific bucket) | AND (old) | OR (new) |
|---|---|---|
| Recall@5 | 0.537 | **0.671** |
| Recall@10 | 0.625 | **0.782** |
| nDCG@5 | 0.494 | **0.530** |

Small precision cost on high-redundancy "browse" queries (ALL nDCG 0.721→0.707). A fuzzy-coverage membership multiplier was prototyped and **rejected** — byte-identical to plain OR once reranking is on (the existing rerank density boost already supplies the graded coverage signal), and modern BM25+RRF hybrids do not layer a separate (pre-BM25, Boolean-era) Fuzzy IR set model on top.

## Validation

- `327/327` mcp-server lib tests green; clippy + fmt clean (pre-commit hook passed).
- Unit test `test_resolve_and_mode_default_is_disjunctive` pins the new default.
- End-to-end on live v1.0.537: keyword_buries docs resurface under the default `search` — `"légkondi töltő ajánlatok"` → rank 1 (previously dropped by AND), `"MAHA fékteszter"` → rank 8 (top-10).

## Migration

Clients that relied on the implicit AND default must now pass `mode="and"` to preserve the old all-terms behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Alapértelmezetten módosítja a lexikális visszakeresés módját hibrid és teljes szöveges keresésnél diszjunktívra (OR), hogy iparági szabványnak megfelelő BM25+RRF viselkedést biztosítson, a konjunktív (AND) egyezést pedig explicit bekapcsolandó opcióvá teszi, és ennek megfelelően frissíti a dokumentációt, sémákat, teszteket és verziózást.

Fejlesztések:
- A lexikális/teljes szöveges visszakeresés alapértelmezett keresési módja mostantól diszjunktív (OR), míg az AND minősítés csak explicit `mode="and"` megadásával érhető el, és a `match_scope` csak ebben a módban érvényesül.
- Bevezet egy egységes `resolve_and_mode` segédfüggvényt, hogy a konjunkciós mód feloldását a fusion, a hibrid keresés és a teljes szöveges keresés között központilag kezelje.
- Tisztázza az API paraméter-dokumentációt, az eszköz-definíciókat és a belső dokumentumokat a `mode` és `match_scope` szemantikájával kapcsolatban a keresési eszközöknél.

Build:
- Az `mcp-server` crate verziójának emelése v1.0.535-ről v1.0.537-re.

Dokumentáció:
- Dokumentálja a lexikális visszakeresés alapértelmezett módjára vonatkozó, kompatibilitást törő változást, annak indoklását és a migrációs útmutatót a changelogban és a `CLAUDE.md` fájlban.

Tesztek:
- Teszteket ad hozzá és módosít, hogy rögzítse az új OR alapértelmezést, érvényesítse a `mode`/`match_scope` viselkedést, és biztosítsa, hogy a dokumentumszintű AND minősítés csak kifejezett kérés esetén aktiválódjon.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Change the default lexical retrieval mode in hybrid and fulltext search to disjunctive (OR) for industry-standard BM25+RRF behavior, making conjunctive (AND) matching an explicit opt-in and updating documentation, schemas, tests, and versioning accordingly.

Enhancements:
- Default search mode for lexical/fulltext retrieval is now disjunctive (OR), with AND qualification available only via explicit mode="and" and match_scope applying only under this mode.
- Introduce a single resolve_and_mode helper to centralize conjunction mode resolution across fusion, hybrid search, and fulltext search.
- Clarify API parameter docs, tool definitions, and internal docs around mode and match_scope semantics for the search tools.

Build:
- Bump mcp-server crate version from v1.0.535 to v1.0.537.

Documentation:
- Document the breaking change to the default lexical retrieval mode, its rationale, and migration guidance in the changelog and CLAUDE.md.

Tests:
- Add and adjust tests to pin the new OR default, validate mode/match_scope behavior, and ensure document-level AND qualification only activates when explicitly requested.

</details>