### PR TITLE
fix(compaction): host-memory-safe auto-compaction — PR-1 (baseline seed + RAM gate) + PR-2 (page-cache-bounded I/O) (v1.0.539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — PR-2: page-cache-bounded compaction I/O (Fix B) (mcp-server v1.0.539, core v0.3.343)
+
+Completes the host-memory-safe compaction work (PR-1 was the legacy baseline seed + RAM-aware
+auto-compact gate below). A full-file compaction reads the entire source and writes the entire
+target through buffered I/O, so the OS page cache balloons to ~file size and can freeze a
+small-RAM host (the page cache is reclaimable → a cgroup `MemoryMax` does not protect against it).
+
+`compact_scan_standalone` now keeps the resident page-cache footprint bounded to ~`chunk_size`
+regardless of total file size, via Linux page-cache hints (`storage/io.rs`, `#[cfg(target_os =
+"linux")]`; macOS/Windows get no-op fallbacks — `posix_fadvise`/`sync_file_range` are unavailable
+there and the freeze was verified on Linux/WSL2):
+- `advise_sequential` on the source fd at start (keeps readahead effective);
+- after each chunk flush, `flush_range_to_disk` (`sync_file_range` WAIT_BEFORE|WRITE|WAIT_AFTER) +
+  `advise_dontneed(POSIX_FADV_DONTNEED)` on the just-written target range, so dirty pages are
+  written back and dropped instead of accumulating;
+- `advise_dontneed` on the consumed source region up to the current read offset (readahead ahead
+  of it is preserved).
+
+All hints are advisory and best-effort (errors ignored); they never change the bytes written —
+data round-trip is unaffected. With this, a manual `db_compact` (or auto-compaction on a host the
+RAM gate allows) of a 100GB file stays bounded instead of freezing the host. Guard:
+`compaction_many_chunks_preserves_all_data` (2500 docs > default chunk_size → multiple
+flush→sync→DONTNEED cycles, verifies every live doc survives and tombstones are dropped); full
+core compaction suite (14 integration tests) green.
+
 ### Changed — BREAKING: lexical retrieval default is now disjunctive (OR), industry-standard (mcp-server v1.0.537)
 
 The fulltext / hybrid-fusion lexical lane now defaults to **disjunctive (OR)** matching
@@ -64,9 +89,9 @@ config: `[compaction] max_file_to_ram_ratio` (serde default, legacy configs unaf
 unit tests in `compaction::tests` (incl. `should_compact_refuses_oversized_file_even_at_infinite_bloat`
 reproducing the verified WSL case).
 
-Remaining (PR-2, separate): Fix B — page-cache-bounded compaction I/O (`posix_fadvise(DONTNEED)` +
-`sync_file_range`, `#[cfg(unix)]`) so a manual compaction of a 100GB file stays bounded regardless of
-file size.
+PR-2 (Fix B — page-cache-bounded compaction I/O) is now also done: see the entry above
+(`posix_fadvise(DONTNEED)` + `sync_file_range`, `#[cfg(target_os = "linux")]`), so a manual
+compaction of a 100GB file stays bounded regardless of file size.
 
 ### Fixed — index-based $group count path: multiplier overflow + stale planner references (mcp-server v1.0.535, core v0.3.341)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,37 @@ modern BM25+RRF hybrids do not layer on.
 `mode="and"` to preserve the old behavior. Affects `fulltext_search`, the Rhai
 `db_hybrid_search`, and the `search` tool's internal fusion (single decision point:
 `fusion::resolve_and_mode`).
+### Fixed — host-memory-safe auto-compaction: legacy baseline seed + RAM-aware gate (mcp-server v1.0.538, core v0.3.342)
+
+Auto-compaction could freeze the host. Two independent root causes, two layered fixes (PR-1 of the
+plan in `~/.claude/plans/compaction-host-memory-safe.md`).
+
+**Fix C — legacy / never-compacted baseline seed (`database/mod.rs` open path).** A file written
+before P1-7 (Header < v6), or *any* DB that has never been compacted, persists
+`last_compact_size = 0`. With 0, `storage_wastage()` computes `bloat_ratio = +inf`, so
+`should_compact()` fires a full-file compaction ~5 min (`check_interval_secs = 300`) after **every**
+startup. On a large file the buffered whole-file read+write balloons the OS page cache and freezes
+the host — verified 2026-06-16: a 7.1GB legacy `docs.mlite` froze an 11GB WSL2 host three times (the
+page cache is reclaimable, so a cgroup `MemoryMax` does *not* protect against it). The open path now
+seeds the in-memory baseline from the current file size when live data is present, so bloat starts at
+~1.0 instead of `+inf`; it self-corrects at the first real compaction and is persisted on graceful
+close. An empty / all-tombstone file is **not** seeded (stays 0 → genuine garbage remains eligible
+for reclaim). The estimate is logged (`tracing::warn!`), never silent. Guards:
+`never_compacted_db_with_data_seeds_finite_bloat_on_open`, `empty_db_does_not_seed_baseline_on_open`.
+
+**Fix A — RAM-aware auto-compact gate (`compaction.rs`).** New 4th gate in `should_compact`: skip
+auto-compaction when the data file exceeds `max_file_to_ram_ratio` (default `0.5`) of available
+system RAM, since a full compaction's transient page-cache footprint is ~file_size. A 100GB file on
+a 16GB host now never auto-compacts blindly; the operator can still run a manual `db_compact` in a
+maintenance window or on a larger host. `0.0` disables the gate. The warn fires only when bloat +
+min-size gates would otherwise have passed (a compaction was genuinely wanted but refused). New
+config: `[compaction] max_file_to_ram_ratio` (serde default, legacy configs unaffected). Guards: 7
+unit tests in `compaction::tests` (incl. `should_compact_refuses_oversized_file_even_at_infinite_bloat`
+reproducing the verified WSL case).
+
+Remaining (PR-2, separate): Fix B — page-cache-bounded compaction I/O (`posix_fadvise(DONTNEED)` +
+`sync_file_range`, `#[cfg(unix)]`) so a manual compaction of a 100GB file stays bounded regardless of
+file size.
 
 ### Fixed — index-based $group count path: multiplier overflow + stale planner references (mcp-server v1.0.535, core v0.3.341)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.341"
+version = "0.3.342"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.342"
+version = "0.3.343"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/database/mod.rs
+++ b/ironbase-core/src/database/mod.rs
@@ -424,6 +424,42 @@ impl DatabaseCore<StorageEngine> {
         // reopened DB keeps an accurate bloat_ratio instead of 0 → +inf → a
         // spurious full-file auto-compaction on every restart.
         let stored_compact_size = storage.last_compact_size();
+        // Fix C (legacy pre-v6 baseline seed, 2026-06-16): a file written before
+        // P1-7 (Header < v6) — OR any DB that has simply never been compacted —
+        // has no persisted last_compact_size and loads as 0. With 0,
+        // storage_wastage() yields bloat_ratio = +inf, so should_compact() fires
+        // a full-file compaction ~5 min after every startup. On a large file that
+        // buffered whole-file I/O balloons the host page cache and can freeze the
+        // machine (verified 2026-06-16: a 7.1GB legacy docs.mlite froze an 11GB
+        // WSL2 host 3×). Seed the baseline from the current file size so bloat
+        // starts at ~1.0 instead of +inf; it self-corrects at the first real
+        // compaction. Only seed when live data is actually present: an empty or
+        // all-tombstone file keeps 0 so genuine garbage is still eligible for
+        // reclaim (the RAM-safety gate in compaction.rs then makes that safe).
+        // NOT a silent dummy — the estimate is logged.
+        let stored_compact_size = if stored_compact_size == 0 {
+            let total_live: u64 = storage
+                .collections_ref()
+                .values()
+                .map(|m| m.live_document_count)
+                .sum();
+            let file_size = std::fs::metadata(&path_str).map(|m| m.len()).unwrap_or(0);
+            if total_live > 0 && file_size > 0 {
+                tracing::warn!(
+                    file_size_mb = file_size / (1024 * 1024),
+                    live_documents = total_live,
+                    "Seeding compaction baseline from current file size (legacy pre-v6 \
+                     file or never-compacted DB had no persisted last_compact_size). \
+                     This avoids a spurious full-file auto-compaction on startup; the \
+                     baseline self-corrects at the first real compaction."
+                );
+                file_size
+            } else {
+                0
+            }
+        } else {
+            stored_compact_size
+        };
         let max_recovered = recovered_ops
             .iter()
             .map(|(tx_id, _)| *tx_id)

--- a/ironbase-core/src/storage/compaction.rs
+++ b/ironbase-core/src/storage/compaction.rs
@@ -632,6 +632,9 @@ pub fn compact_scan_standalone(
 
     // Open a separate read-only handle for pread()
     let source_file = std::fs::File::open(&snapshot.source_path)?;
+    // PR-2 / Fix B: we read the source strictly in catalog order — hint sequential
+    // so readahead stays effective even as we drop consumed pages below.
+    super::io::advise_sequential(&source_file);
 
     // Count total documents for progress reporting
     let total_docs: u64 = snapshot
@@ -718,6 +721,7 @@ pub fn compact_scan_standalone(
                                 || total_memory_bytes >= MAX_COMPACTION_MEMORY_BYTES;
 
                             if should_flush {
+                                let flush_start = write_offset;
                                 for (flush_coll_name, docs) in collection_docs.iter_mut() {
                                     if !docs.is_empty() {
                                         write_offset = flush_compaction_chunk_standalone(
@@ -731,6 +735,22 @@ pub fn compact_scan_standalone(
                                         docs.clear();
                                     }
                                 }
+                                // PR-2 / Fix B: keep the page-cache footprint ~chunk_size,
+                                // not ~file_size. Write back + drop the just-written target
+                                // range, and drop the consumed source region up to the
+                                // current read position (`offset`) — readahead ahead of it
+                                // is preserved. Advisory; data is unaffected.
+                                super::io::flush_range_to_disk(
+                                    &temp_file,
+                                    flush_start,
+                                    write_offset - flush_start,
+                                );
+                                super::io::advise_dontneed(
+                                    &temp_file,
+                                    flush_start,
+                                    write_offset - flush_start,
+                                );
+                                super::io::advise_dontneed(&source_file, 0, offset);
                                 chunk_count = 0;
                                 total_memory_bytes = 0;
                             }
@@ -757,6 +777,7 @@ pub fn compact_scan_standalone(
     }
 
     // Flush remaining documents
+    let final_flush_start = write_offset;
     for (coll_name, docs) in collection_docs.iter_mut() {
         if !docs.is_empty() {
             write_offset = flush_compaction_chunk_standalone(
@@ -769,6 +790,17 @@ pub fn compact_scan_standalone(
             )?;
         }
     }
+    // PR-2 / Fix B: write back + drop the final chunk's target pages too.
+    super::io::flush_range_to_disk(
+        &temp_file,
+        final_flush_start,
+        write_offset - final_flush_start,
+    );
+    super::io::advise_dontneed(
+        &temp_file,
+        final_flush_start,
+        write_offset - final_flush_start,
+    );
 
     temp_file.sync_all()?;
 

--- a/ironbase-core/src/storage/io.rs
+++ b/ironbase-core/src/storage/io.rs
@@ -97,6 +97,83 @@ pub(crate) fn read_document_from_file(
     Ok(data)
 }
 
+// =========================================================================
+// Page-cache-bounded I/O hints (PR-2 / Fix B — host-memory-safe compaction)
+//
+// A full-file compaction reads the entire source and writes the entire target
+// through buffered I/O. On a large file the OS page cache balloons to ~file size
+// and can freeze a small-RAM host (the page cache is reclaimable, so a cgroup
+// MemoryMax does NOT protect against it). These hints keep the resident footprint
+// bounded to ~chunk_size regardless of file size, by dropping consumed/flushed
+// ranges from the page cache as the sequential pass advances.
+//
+// Linux-only (`posix_fadvise`/`sync_file_range`): macOS lacks posix_fadvise and
+// sync_file_range, Windows has neither — both get the no-op fallback (the freeze
+// was verified on Linux/WSL2; other platforms manage the unified buffer cache
+// differently). All calls are ADVISORY and best-effort: errors are ignored and
+// never affect the data written (round-trip integrity is unchanged).
+// =========================================================================
+
+/// Hint that `file` will be read sequentially (enables aggressive readahead).
+#[cfg(target_os = "linux")]
+pub(crate) fn advise_sequential(file: &std::fs::File) {
+    use std::os::unix::io::AsRawFd;
+    // offset=0, len=0 → the whole file.
+    unsafe {
+        libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_SEQUENTIAL);
+    }
+}
+
+/// Drop the page-cache pages backing `[offset, offset+len)` of `file`.
+/// Used after a range has been consumed (read) or flushed (written) so a large
+/// sequential pass does not accumulate the whole file in the page cache.
+#[cfg(target_os = "linux")]
+pub(crate) fn advise_dontneed(file: &std::fs::File, offset: u64, len: u64) {
+    use std::os::unix::io::AsRawFd;
+    if len == 0 {
+        return;
+    }
+    unsafe {
+        libc::posix_fadvise(
+            file.as_raw_fd(),
+            offset as libc::off_t,
+            len as libc::off_t,
+            libc::POSIX_FADV_DONTNEED,
+        );
+    }
+}
+
+/// Write back `[offset, offset+len)` of `file` and BLOCK until those pages are
+/// clean (WAIT_BEFORE | WRITE | WAIT_AFTER), so a following [`advise_dontneed`]
+/// can actually evict them (DONTNEED only drops clean pages). Bounds the dirty
+/// page-cache footprint of the write side to ~one chunk.
+#[cfg(target_os = "linux")]
+pub(crate) fn flush_range_to_disk(file: &std::fs::File, offset: u64, len: u64) {
+    use std::os::unix::io::AsRawFd;
+    if len == 0 {
+        return;
+    }
+    unsafe {
+        libc::sync_file_range(
+            file.as_raw_fd(),
+            offset as libc::off64_t,
+            len as libc::off64_t,
+            libc::SYNC_FILE_RANGE_WAIT_BEFORE
+                | libc::SYNC_FILE_RANGE_WRITE
+                | libc::SYNC_FILE_RANGE_WAIT_AFTER,
+        );
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn advise_sequential(_file: &std::fs::File) {}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn advise_dontneed(_file: &std::fs::File, _offset: u64, _len: u64) {}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn flush_range_to_disk(_file: &std::fs::File, _offset: u64, _len: u64) {}
+
 impl StorageEngine {
     /// Write data to end of document region
     /// Returns the offset where data was written

--- a/ironbase-core/tests/compaction_tests.rs
+++ b/ironbase-core/tests/compaction_tests.rs
@@ -438,3 +438,67 @@ fn last_compact_size_persists_across_drop_without_close() {
         w.bloat_ratio
     );
 }
+
+/// Fix C (2026-06-16): a DB that has live data but was NEVER compacted (legacy
+/// pre-v6 file, or any never-compacted DB) persists `last_compact_size = 0`.
+/// Without the seed, `storage_wastage()` returns `bloat_ratio = +inf`, so the
+/// auto-compactor rewrites the whole file ~5 min after every startup — on a
+/// large file that buffered whole-file I/O can freeze the host (verified: a
+/// 7.1GB docs.mlite froze an 11GB WSL2 host 3×). The open path must seed the
+/// baseline from the current file size when live data is present, so bloat
+/// starts finite (~1.0). This guard fails on the unfixed code (bloat = +inf)
+/// and passes after the seed.
+#[test]
+fn never_compacted_db_with_data_seeds_finite_bloat_on_open() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("never_compacted.mlite");
+
+    {
+        let db = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+        for i in 0..50i64 {
+            let mut doc = HashMap::new();
+            doc.insert("v".to_string(), json!(i));
+            db.insert_one("c", doc).unwrap();
+        }
+        // NO compact() ever — graceful close persists last_compact_size = 0.
+        db.close().unwrap();
+    }
+
+    let db2 = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+    let w = db2.storage_wastage();
+    assert!(
+        w.estimated_live_bytes > 0,
+        "never-compacted DB with live data must seed a non-zero baseline (got 0 \
+         → bloat_ratio would be +inf → spurious startup compaction)"
+    );
+    assert!(
+        w.bloat_ratio.is_finite(),
+        "bloat_ratio must be finite after the legacy seed, got {}",
+        w.bloat_ratio
+    );
+}
+
+/// Fix C corollary: an empty (or all-tombstone) DB has no live data, so the seed
+/// must NOT fire — `last_compact_size` stays 0. This keeps genuine garbage
+/// eligible for reclaim (the RAM-safety gate then makes that compaction safe) and
+/// proves the seed does not blindly stamp every never-compacted file. Note: an
+/// empty file also trips the min-file-size gate, so leaving bloat = +inf here is
+/// harmless.
+#[test]
+fn empty_db_does_not_seed_baseline_on_open() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("empty_db.mlite");
+
+    {
+        let db = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+        db.close().unwrap();
+    }
+
+    let db2 = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+    let w = db2.storage_wastage();
+    assert_eq!(
+        w.estimated_live_bytes, 0,
+        "empty DB must NOT seed a baseline (no live data); got {}",
+        w.estimated_live_bytes
+    );
+}

--- a/ironbase-core/tests/compaction_tests.rs
+++ b/ironbase-core/tests/compaction_tests.rs
@@ -502,3 +502,57 @@ fn empty_db_does_not_seed_baseline_on_open() {
         w.estimated_live_bytes
     );
 }
+
+/// PR-2 / Fix B: exercise the IN-LOOP chunk flush+drop path (page-cache-bounded
+/// I/O hints) across MANY chunks by inserting more than the default chunk_size
+/// (1000) docs, so `compact_scan_standalone` runs multiple
+/// flush → sync_file_range → posix_fadvise(DONTNEED) cycles. Proves the advisory
+/// I/O hints never corrupt data: every live document survives with the correct
+/// value and tombstones are dropped. (On non-Linux the hints are no-ops, so this
+/// is a pure round-trip integrity test there.)
+#[test]
+fn compaction_many_chunks_preserves_all_data() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("compact_many_chunks.mlite");
+
+    let total = 2500i64; // > default chunk_size (1000) → multiple in-loop flushes
+    let deleted: Vec<i64> = (0..total).step_by(5).collect();
+    {
+        let db = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+        for i in 0..total {
+            let mut doc = HashMap::new();
+            doc.insert("k".to_string(), json!(i));
+            doc.insert(
+                "payload".to_string(),
+                json!(format!("doc-{i}-{}", "x".repeat(64))),
+            );
+            db.insert_one("c", doc).unwrap();
+        }
+        // Delete every 5th → tombstones to remove during compaction.
+        for &i in &deleted {
+            db.delete_one("c", &json!({ "k": i })).unwrap();
+        }
+        let stats = db.compact().unwrap();
+        assert_eq!(stats.tombstones_removed, deleted.len() as u64);
+        assert_eq!(stats.documents_kept, total as u64 - deleted.len() as u64);
+        db.close().unwrap();
+    }
+
+    // Reopen and verify the surviving docs are intact (not corrupted by the
+    // fadvise/sync_file_range hints across the many flush cycles).
+    let db2 = DatabaseCore::<StorageEngine>::open(&db_path).unwrap();
+    let coll = db2.collection("c").unwrap();
+    assert_eq!(
+        coll.find(&json!({})).unwrap().len(),
+        total as usize - deleted.len()
+    );
+    // A doc that must survive (1234 % 5 != 0) keeps its exact payload.
+    let found = coll.find(&json!({ "k": 1234 })).unwrap();
+    assert_eq!(found.len(), 1);
+    assert_eq!(
+        found[0].get("payload").unwrap(),
+        &json!(format!("doc-1234-{}", "x".repeat(64)))
+    );
+    // A deleted doc must be gone.
+    assert_eq!(coll.find(&json!({ "k": 1235 })).unwrap().len(), 0);
+}

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.538"
+version = "1.0.539"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.537"
+version = "1.0.538"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mcp-server/src/compaction.rs
+++ b/mcp-server/src/compaction.rs
@@ -38,6 +38,9 @@ fn default_check_interval() -> u64 {
 fn default_cooldown() -> u64 {
     1800
 }
+fn default_max_file_to_ram_ratio() -> f64 {
+    0.5
+}
 
 /// Auto-compaction configuration.
 ///
@@ -60,6 +63,15 @@ pub struct AutoCompactConfig {
     /// Minimum seconds between two compactions (default: 1800 = 30 min)
     #[serde(default = "default_cooldown")]
     pub cooldown_secs: u64,
+    /// Skip auto-compact when the data file is larger than this fraction of
+    /// available system RAM (default: 0.5). A full compaction does buffered
+    /// whole-file I/O whose transient page-cache footprint is ~file_size; on a
+    /// host where the file dwarfs free RAM this balloons the (page) cache and
+    /// freezes the machine (verified 2026-06-16: 7.1GB file froze an 11GB WSL2
+    /// 3×). The operator can still run a manual `db_compact` in a maintenance
+    /// window / on a larger host. 0.0 disables the gate.
+    #[serde(default = "default_max_file_to_ram_ratio")]
+    pub max_file_to_ram_ratio: f64,
 }
 
 impl Default for AutoCompactConfig {
@@ -70,6 +82,7 @@ impl Default for AutoCompactConfig {
             min_file_size_mb: default_min_file_mb(),
             check_interval_secs: default_check_interval(),
             cooldown_secs: default_cooldown(),
+            max_file_to_ram_ratio: default_max_file_to_ram_ratio(),
         }
     }
 }
@@ -108,13 +121,44 @@ impl AutoCompactState {
         }
     }
 
+    /// Gate 4 predicate: is the file too large to compact safely on this host?
+    ///
+    /// A full compaction does buffered whole-file I/O (read source + write live
+    /// set) whose transient page-cache footprint is ~file_size. When the file
+    /// dwarfs available RAM this balloons the cache and freezes the host (the
+    /// page cache is reclaimable, so a cgroup `MemoryMax` does NOT protect it —
+    /// verified 2026-06-16). `available_ram_bytes == None` (unknown) → do not
+    /// block (best-effort; the caller logs). `max_file_to_ram_ratio == 0.0`
+    /// disables the gate.
+    pub fn exceeds_memory_safety(
+        &self,
+        file_size_bytes: u64,
+        available_ram_bytes: Option<u64>,
+    ) -> bool {
+        if self.config.max_file_to_ram_ratio <= 0.0 {
+            return false;
+        }
+        match available_ram_bytes {
+            Some(avail) if avail > 0 => {
+                file_size_bytes as f64 > self.config.max_file_to_ram_ratio * avail as f64
+            }
+            _ => false,
+        }
+    }
+
     /// Should we trigger compaction given the current wastage?
     ///
-    /// Three gates:
+    /// Four gates:
     /// 1. bloat_ratio >= threshold
     /// 2. file_size >= min_file_size_mb
     /// 3. cooldown elapsed since last compact
-    pub fn should_compact(&self, bloat_ratio: f64, file_size_bytes: u64) -> bool {
+    /// 4. file_size not too large for available RAM (host-memory safety)
+    pub fn should_compact(
+        &self,
+        bloat_ratio: f64,
+        file_size_bytes: u64,
+        available_ram_bytes: Option<u64>,
+    ) -> bool {
         // Gate 1: bloat ratio
         if bloat_ratio < self.config.bloat_ratio_threshold {
             return false;
@@ -131,6 +175,11 @@ impl AutoCompactState {
             if last.elapsed().as_secs() < self.config.cooldown_secs {
                 return false;
             }
+        }
+
+        // Gate 4: host-memory safety (see exceeds_memory_safety)
+        if self.exceeds_memory_safety(file_size_bytes, available_ram_bytes) {
+            return false;
         }
 
         true
@@ -276,10 +325,20 @@ pub fn auto_compact_check(
     state: &Arc<parking_lot::Mutex<AutoCompactState>>,
 ) -> bool {
     let wastage = adapter.compute_wastage();
+    let available_ram = ironbase_core::aggregation::memory_info::get_available_memory_bytes();
 
-    let should_compact = {
+    let (should_compact, blocked_by_memory) = {
         let state_guard = state.lock();
-        state_guard.should_compact(wastage.bloat_ratio, wastage.file_size_bytes)
+        let sc =
+            state_guard.should_compact(wastage.bloat_ratio, wastage.file_size_bytes, available_ram);
+        // The memory gate is the deciding blocker iff the bloat + min-size gates
+        // would otherwise have passed (so we only warn when a compaction was
+        // genuinely wanted but refused for host-memory safety).
+        let blocked_by_memory = !sc
+            && wastage.bloat_ratio >= state_guard.config.bloat_ratio_threshold
+            && wastage.file_size_bytes >= state_guard.config.min_file_size_mb * 1024 * 1024
+            && state_guard.exceeds_memory_safety(wastage.file_size_bytes, available_ram);
+        (sc, blocked_by_memory)
     };
 
     tracing::debug!(
@@ -292,6 +351,17 @@ pub fn auto_compact_check(
         should_compact,
         "Storage wastage check"
     );
+
+    if blocked_by_memory {
+        tracing::warn!(
+            file_size_mb = wastage.file_size_bytes / (1024 * 1024),
+            available_mb = available_ram.map(|b| b / (1024 * 1024)).unwrap_or(0),
+            bloat_ratio = format!("{:.2}", wastage.bloat_ratio),
+            "Auto-compact skipped: data file too large for available RAM (host-memory \
+             safety gate). Run a manual db_compact in a maintenance window or on a host \
+             with more RAM."
+        );
+    }
 
     if !should_compact {
         return false;
@@ -408,4 +478,76 @@ pub fn spawn_auto_compact_timer(
     }
 
     handle
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GB: u64 = 1024 * 1024 * 1024;
+
+    fn state() -> AutoCompactState {
+        AutoCompactState::new(AutoCompactConfig::default())
+    }
+
+    // --- Gate 4 predicate (exceeds_memory_safety) ---------------------------
+
+    #[test]
+    fn memory_safety_blocks_file_larger_than_ratio() {
+        let s = state(); // ratio 0.5
+                         // 7.1GB file, 10GB available → 7.1 > 0.5*10=5 → blocked (the verified WSL case)
+        assert!(s.exceeds_memory_safety(7 * GB + GB / 10, Some(10 * GB)));
+    }
+
+    #[test]
+    fn memory_safety_allows_file_within_ratio() {
+        let s = state();
+        // 7GB file, 64GB available → 7 < 0.5*64=32 → allowed
+        assert!(!s.exceeds_memory_safety(7 * GB, Some(64 * GB)));
+        // small file, modest host
+        assert!(!s.exceeds_memory_safety(200 * 1024 * 1024, Some(16 * GB)));
+    }
+
+    #[test]
+    fn memory_safety_unknown_ram_does_not_block() {
+        let s = state();
+        assert!(!s.exceeds_memory_safety(100 * GB, None));
+    }
+
+    #[test]
+    fn memory_safety_disabled_with_zero_ratio() {
+        let cfg = AutoCompactConfig {
+            max_file_to_ram_ratio: 0.0,
+            ..Default::default()
+        };
+        let s = AutoCompactState::new(cfg);
+        assert!(!s.exceeds_memory_safety(100 * GB, Some(GB)));
+    }
+
+    // --- should_compact gate composition ------------------------------------
+
+    #[test]
+    fn should_compact_refuses_oversized_file_even_at_infinite_bloat() {
+        // Legacy v5 docs.mlite reproduction: never-compacted → bloat_ratio=+inf,
+        // file 7.1GB ≥ 100MB min, no cooldown — every prior gate passes, but the
+        // memory gate (7.1GB > 0.5*10GB) must refuse to auto-trigger.
+        let s = state();
+        assert!(!s.should_compact(f64::INFINITY, 7 * GB + GB / 10, Some(10 * GB)));
+    }
+
+    #[test]
+    fn should_compact_allows_bloated_file_that_fits_ram() {
+        let s = state();
+        // bloat 3.0 ≥ 2.0, file 7GB ≥ 100MB, fits 64GB host → compact
+        assert!(s.should_compact(3.0, 7 * GB, Some(64 * GB)));
+    }
+
+    #[test]
+    fn should_compact_still_honors_bloat_and_min_size_gates() {
+        let s = state();
+        // low bloat → no compact regardless of RAM
+        assert!(!s.should_compact(1.5, 7 * GB, Some(64 * GB)));
+        // tiny file (< 100MB) → no compact even at infinite bloat
+        assert!(!s.should_compact(f64::INFINITY, 10 * 1024 * 1024, Some(64 * GB)));
+    }
 }


### PR DESCRIPTION
## Summary

Makes auto-compaction **host-memory-safe**. A full-file compaction reads the whole source and writes the whole target through buffered I/O; on a large file the OS page cache balloons to ~file size and can **freeze a small-RAM host** (the page cache is reclaimable, so a cgroup `MemoryMax` does *not* protect against it). Verified 2026-06-16: a 7.1GB legacy `docs.mlite` froze an 11GB WSL2 host three times. Two independent root causes → two layered fixes, shipped together here.

## PR-1 — legacy baseline seed + RAM-aware gate (core v0.3.342 → mcp v1.0.538)

- **Fix C (`database/mod.rs` open path):** a pre-v6 / never-compacted DB persists `last_compact_size = 0` → `bloat_ratio = +inf` → `should_compact()` fires a full-file compaction ~5 min after **every** startup. Now seeds the in-memory baseline from current file size when live data is present (bloat starts ~1.0, not +inf; self-corrects at first real compaction). Empty/all-tombstone files not seeded. Logged, never silent.
- **Fix A (`compaction.rs`):** new 4th gate in `should_compact` — skip auto-compaction when `file_size > max_file_to_ram_ratio` (default `0.5`) of available RAM. A 100GB file on a 16GB host never auto-compacts blindly; manual `db_compact` still available. New config `[compaction] max_file_to_ram_ratio` (serde default, legacy-safe).
- Tests: 7 unit + 2 integration (`never_compacted_db_with_data_seeds_finite_bloat_on_open`, `empty_db_does_not_seed_baseline_on_open`).

## PR-2 — page-cache-bounded compaction I/O / Fix B (core v0.3.343 → mcp v1.0.539)

`compact_scan_standalone` now keeps the resident page-cache footprint bounded to ~`chunk_size` regardless of file size, via Linux page-cache hints (`storage/io.rs`, `#[cfg(target_os = "linux")]`; macOS/Windows get no-op fallbacks — `posix_fadvise`/`sync_file_range` are unavailable there, and the freeze is a Linux/WSL2 concern):
- `advise_sequential` on the source fd at start;
- per chunk flush: `flush_range_to_disk` (`sync_file_range` WAIT_BEFORE|WRITE|WAIT_AFTER) + `advise_dontneed(POSIX_FADV_DONTNEED)` on the just-written target range;
- `advise_dontneed` on the consumed source region up to the current read offset (readahead ahead preserved).

All hints are advisory/best-effort (errors ignored) — they never change the bytes written. A manual `db_compact` of a 100GB file now stays bounded instead of freezing the host. Guard: `compaction_many_chunks_preserves_all_data` (2500 docs > default chunk_size → multiple flush→sync→DONTNEED cycles; every live doc survives, tombstones dropped).

## Why both now

PR-1 alone makes a small host *safe* (no blind freeze) but gates auto-compaction off for a 100GB-on-small-host DB → it would grow unbounded with no safe reclaim path. PR-2 makes the (manual or gate-permitted) compaction itself bounded, so the DB can actually be compacted safely on any host.

## Validation

- Full `ironbase-core` compaction suite: **14 integration tests green** (incl. the new multi-chunk Fix B guard). clippy + fmt clean (pre-commit hook passed).
- Rebased onto current master (after #109 OR-default + #110 eval); CHANGELOG + version conflicts reconciled (mcp → v1.0.539, core → v0.3.343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

A(z) adatbázis-tömörítés host-memória-biztossá tétele az automatikus tömörítés rendelkezésre álló RAM-hoz kötésével és az oldal‑cache használatának korlátozásával a tömörítési I/O során.

Bug Fixes:
- Megakadályozza az ismétlődő, teljes fájlra kiterjedő automatikus tömörítést a régi vagy soha nem tömörített adatbázisokon azáltal, hogy a tömörítési bázisértéket a jelenlegi fájlméretből származtatja, ha léteznek élő adatok.
- RAM‑tudatos kaput ad az automatikus tömörítéshez, így a túlméretezett adatfájlok nem indítanak automatikus teljes tömörítést kis memóriájú hostokon.
- Korlátozza a tömörítés OS oldal‑cache lenyomatát hozzávetőleg egyetlen csomagra azáltal, hogy Linux‑specifikus I/O hint-eket ad ki a teljes fájlra kiterjedő tömörítés során.

Enhancements:
- Elérhetővé tesz egy konfigurálható `max_file_to_ram_ratio` tömörítési beállítást, alapértelmezésekkel és naplózással, amikor a tömörítés memória‑biztonsági okokból kihagyásra kerül.

Build:
- Frissíti a workspace, core és server crate verziókat az új tömörítési viselkedés tükrözésére.

Documentation:
- Dokumentálja a host-memória-biztos tömörítési viselkedést és konfigurációt a changelogban, beleértve a régi rendszerek bázisérték‑inicializálását és a RAM‑tudatos kapuzás szemantikáját.

Tests:
- Regressziós teszteket ad hozzá a régi rendszerek bázisérték‑inicializálási viselkedésére soha nem tömörített és üres adatbázisok esetén.
- Többcsomagos tömörítési tesztet ad hozzá az adatintegritás ellenőrzésére az új, oldal‑cache‑korlátos tömörítési I/O útvonal alatt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make database compaction host-memory-safe by gating auto-compaction on available RAM and bounding page-cache usage during compaction I/O.

Bug Fixes:
- Prevent repeated full-file auto-compaction on legacy or never-compacted databases by seeding the compaction baseline from current file size when live data exists.
- Add a RAM-aware gate to auto-compaction so oversized data files do not trigger automatic full compaction on small-memory hosts.
- Limit the OS page-cache footprint of compaction to approximately one chunk by issuing Linux-specific I/O hints during full-file compaction.

Enhancements:
- Expose a configurable max_file_to_ram_ratio compaction setting, with defaults and logging when compaction is skipped for memory safety.

Build:
- Bump workspace, core, and server crate versions to reflect the new compaction behavior.

Documentation:
- Document host-memory-safe compaction behavior and configuration in the changelog, including legacy baseline seeding and RAM-aware gating semantics.

Tests:
- Add regression tests for legacy baseline seeding behavior on never-compacted and empty databases.
- Add a multi-chunk compaction test to verify data integrity under the new page-cache-bounded compaction I/O path.

</details>