### PR TITLE
chore(ci): cargo-audit allowlist for non-actionable advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,34 @@
+# cargo-audit configuration (read by `cargo audit` in CI: .github/workflows/rust.yml).
+#
+# Each ignored advisory below is documented with WHY it is not actionable for this
+# codebase. These are deliberate, justified exceptions — NOT a blanket silence.
+# Re-evaluate when the listed real remediation lands.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2025-0141 — bincode is unmaintained (WARNING, not a vulnerability).
+    #   We pin bincode 1.x and use it for the persistent on-disk wire format
+    #   (.mlite header + .hnsw vector index). bincode 2.x/3.x is a full API rewrite
+    #   AND a wire-format change → bumping it (dependabot #28) breaks the build and
+    #   risks making existing databases unreadable. The 1.x line is stable and has
+    #   no known vulnerability. Real remediation (if ever needed): a deliberate,
+    #   tested migration to bincode 2.x serde-compat with config::legacy() + a
+    #   round-trip test against pre-existing files — tracked separately, not a dep bump.
+    "RUSTSEC-2025-0141",
+
+    # RUSTSEC-2026-0176 — pyo3 out-of-bounds read in PyList/PyTuple iterator
+    #   nth()/nth_back() (affects 0.24–0.28; fixed in 0.29.0).
+    #   NOT EXPLOITABLE here: bindings/python/src/lib.rs only iterates Py sequences
+    #   with plain `for x in seq.iter()` (forward iteration) and never calls
+    #   `.nth()` / `.nth_back()` on a PyList/PyTuple iterator, which is the sole
+    #   vulnerable path. Real remediation: upgrade pyo3 to >=0.29 (a separate
+    #   migration — note that dependabot #29's bump to 0.28 would NOT fix this).
+    "RUSTSEC-2026-0176",
+
+    # RUSTSEC-2026-0177 — pyo3 missing Sync bound on PyCFunction::new_closure
+    #   (affects <0.29; fixed in 0.29.0).
+    #   NOT APPLICABLE here: the codebase does not use PyCFunction::new_closure
+    #   (or new_closure_bound) anywhere. Real remediation: upgrade pyo3 to >=0.29
+    #   (same separate migration as RUSTSEC-2026-0176; 0.28 would not fix it).
+    "RUSTSEC-2026-0177",
+]


### PR DESCRIPTION
Makes the Security Audit CI job (`cargo audit`) green by allowlisting **only** advisories with no in-range remediation, each with a verified justification. Cargo.lock is gitignored → CI resolves fresh and already picks up patched transitive deps (quinn-proto, rustls-webpki, thin-vec, rand) automatically; those are NOT ignored.

- **RUSTSEC-2025-0141** (bincode "unmaintained" — warning, not a vuln): 1.x drives the persistent on-disk wire format (.mlite header + .hnsw); 2.x is a breaking API + wire-format change (dependabot #28 fails to build & risks unreadable DBs).
- **RUSTSEC-2026-0176** (pyo3 OOB read in nth()/nth_back()): not exploitable — bindings only use `for x in seq.iter()`, never nth/nth_back. Fixed upstream in pyo3 0.29.
- **RUSTSEC-2026-0177** (pyo3 new_closure Sync): not applicable — new_closure unused. Same 0.29 fix.

Verified: `cargo audit` exits 0 with this config on a freshly-resolved tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Adjunk hozzá egy `.cargo/audit.toml` konfigurációt, hogy a cargo-audit CI feladat sikeresen fusson, bizonyos tanácsok (advisories) engedélyező listára vételével és a hozzájuk tartozó, dokumentált indoklásokkal.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a .cargo/audit.toml configuration to make the cargo-audit CI job pass by allowlisting select advisories with documented justifications.

</details>