### PR TITLE
refactor(scripting): db_fulltext_search delegates to fusion::resolve_and_mode (DRY)

### DIFF
--- a/mcp-server/src/scripting/db_functions.rs
+++ b/mcp-server/src/scripting/db_functions.rs
@@ -786,15 +786,13 @@ fn register_search_functions(
                 }
             }
 
-            // Mode: "or" (default, disjunctive — industry standard) or "and" (opt-in precision).
-            // Mirrors fusion::resolve_and_mode (None/non-"and" → OR) so every lexical
-            // entry point shares one default. BREAKING vs the prior AND default (v1.0.537).
-            let mut and_mode = false; // OR default — consistent with fusion::resolve_and_mode
-            if let Some(mode_val) = options.get("mode") {
-                if let Ok(mode_str) = mode_val.clone().into_string() {
-                    and_mode = mode_str == "and";
-                }
-            }
+            // Mode default = "or" (disjunctive, industry standard); "and" = opt-in precision.
+            // Single source of truth: delegate to fusion::resolve_and_mode (None/non-"and"
+            // → OR) so every lexical entry point shares one default and cannot drift.
+            let mode_str = options
+                .get("mode")
+                .and_then(|v| v.clone().into_string().ok());
+            let and_mode = crate::tools::fusion::resolve_and_mode(mode_str.as_deref());
 
             // match_scope: "document" (default) or "chunk"
             let mut match_scope = "document";


### PR DESCRIPTION
Follow-up to a code-stasi review of the recent work. `db_fulltext_search` (Rhai) hand-rolled the OR-default conjunction parse (`and_mode = mode_str == "and"`) instead of calling `fusion::resolve_and_mode`, the single source of truth introduced in #109. Bit-identical behavior, but a drift hazard — a future change to the default would silently miss this lexical entry point. Now all four lexical entry points share one decision. No behavior change; build + clippy + fmt + resolve_and_mode test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fejlesztések:
- A `db_fulltext_search` scripting függvény refaktorálása úgy, hogy az `AND`/`OR` mód meghatározásához a `fusion::resolve_and_mode` kerüljön használatra, ezzel az alapértelmezett logikát egyetlen, központi forrásban konszolidálva.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refactor db_fulltext_search scripting function to use fusion::resolve_and_mode for determining AND/OR mode, consolidating the default logic in a single source of truth.

</details>