### PR TITLE
fix(compaction): source page-cache drop uses monotonic delta (v1.0.540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — compaction source page-cache drop: delta instead of cumulative prefix (core v0.3.344, mcp v1.0.540)
+
+Follow-up to the PR-2 page-cache-bounded compaction I/O (v1.0.539), from a multi-agent
+review. The source-side `posix_fadvise(DONTNEED)` in `compact_scan_standalone` dropped
+`[0, offset)` on every chunk flush — re-walking the whole already-evicted prefix each time
+(cumulative O(chunks · file_size) kernel work) and, because the snapshot collection map is a
+`HashMap` (non-deterministic order), `offset` is not globally monotonic across collections,
+so the "consumed prefix" framing was wrong for multi-collection databases. Now a monotonic
+high-water mark (`src_dropped_upto`) drops only the new delta `[src_dropped_upto, offset)`
+once: O(file_size) total, robust to collection order, never re-dropping or evicting the
+in-progress document's pages. Advisory only — data round-trip unchanged; the full core
+compaction suite (14 integration tests, incl. the multi-chunk guard) stays green.
+
+Also: documented the `[compaction]` section in `mcp-server/config.example.toml` (the
+tracked operator template; the live `config.toml` is gitignored) — including the
+host-memory-safety `max_file_to_ram_ratio` gate, previously only discoverable from source.
+
 ### Fixed — PR-2: page-cache-bounded compaction I/O (Fix B) (mcp-server v1.0.539, core v0.3.343)
 
 Completes the host-memory-safe compaction work (PR-1 was the legacy baseline seed + RAM-aware

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.343"
+version = "0.3.344"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/storage/compaction.rs
+++ b/ironbase-core/src/storage/compaction.rs
@@ -653,6 +653,11 @@ pub fn compact_scan_standalone(
     let mut chunk_count = 0;
     let mut total_memory_bytes: u64 = 0;
     let mut docs_processed: u64 = 0;
+    // PR-2 / Fix B: high-water mark of the source prefix already dropped from the
+    // page cache. Advances monotonically so each region is dropped at most once
+    // (O(file_size) total, not O(chunks·file_size)) and is robust to the
+    // non-monotonic offset order across collections (snapshot is a HashMap).
+    let mut src_dropped_upto: u64 = 0;
 
     for (coll_name, coll_meta) in snapshot.snapshot_collections.iter() {
         // Check for cancellation at collection boundary
@@ -737,9 +742,11 @@ pub fn compact_scan_standalone(
                                 }
                                 // PR-2 / Fix B: keep the page-cache footprint ~chunk_size,
                                 // not ~file_size. Write back + drop the just-written target
-                                // range, and drop the consumed source region up to the
-                                // current read position (`offset`) — readahead ahead of it
-                                // is preserved. Advisory; data is unaffected.
+                                // range, then drop ONLY the newly-consumed source delta
+                                // [src_dropped_upto, offset) — never re-dropping an already-
+                                // evicted prefix, and never the in-progress doc's pages.
+                                // Readahead ahead of `offset` is preserved. Advisory; data
+                                // is unaffected.
                                 super::io::flush_range_to_disk(
                                     &temp_file,
                                     flush_start,
@@ -750,7 +757,14 @@ pub fn compact_scan_standalone(
                                     flush_start,
                                     write_offset - flush_start,
                                 );
-                                super::io::advise_dontneed(&source_file, 0, offset);
+                                if offset > src_dropped_upto {
+                                    super::io::advise_dontneed(
+                                        &source_file,
+                                        src_dropped_upto,
+                                        offset - src_dropped_upto,
+                                    );
+                                    src_dropped_upto = offset;
+                                }
                                 chunk_count = 0;
                                 total_memory_bytes = 0;
                             }

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.539"
+version = "1.0.540"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mcp-server/config.example.toml
+++ b/mcp-server/config.example.toml
@@ -58,3 +58,21 @@ allowed_documents = ["doc_1", "doc_2"]  # Only specific documents
 [api_keys.rate_limit]
 requests_per_minute = 50
 writes_per_minute = 0  # No writes allowed
+
+# Automatic storage compaction (reclaims dead bytes from updates/deletes).
+# The whole section is optional — omitting it uses these same defaults.
+[compaction]
+enabled = true
+# Trigger compaction when file_size / live_bytes reaches this ratio.
+bloat_ratio_threshold = 2.0
+# Never auto-compact files smaller than this (MB).
+min_file_size_mb = 100
+# How often the background timer checks the bloat ratio (seconds).
+check_interval_secs = 300
+# Minimum gap between two auto-compactions (seconds).
+cooldown_secs = 1800
+# HOST-MEMORY SAFETY GATE: skip AUTO-compaction when the data file exceeds this
+# fraction of available RAM (a full compaction's transient page-cache footprint
+# is ~file_size; on a small host this can freeze the machine). Manual db_compact
+# is always allowed. 0.0 disables the gate. Default 0.5.
+max_file_to_ram_ratio = 0.5


### PR DESCRIPTION
Follow-up to PR-2 (#111, v1.0.539), surfaced by a multi-agent review of the merged code.

## Problem
The source-side `posix_fadvise(DONTNEED)` in `compact_scan_standalone` dropped `[0, offset)` on **every** chunk flush:
1. **Redundant work** — re-walks the whole already-evicted prefix each flush → cumulative O(chunks · file_size) kernel page-table work (vs O(file_size)).
2. **Incorrect across collections** — the snapshot collection map is a `HashMap` (non-deterministic order), so `offset` is **not globally monotonic**; the "consumed prefix" framing breaks for multi-collection databases (could re-drop / re-fault).

## Fix
A monotonic high-water mark `src_dropped_upto` drops only the new delta `[src_dropped_upto, offset)`, exactly once:
- O(file_size) total, no redundant re-walk;
- robust to collection iteration order;
- never re-drops an evicted prefix, never evicts the in-progress document's pages;
- readahead ahead of `offset` preserved.

Advisory hints only — **data round-trip is unchanged**. Full core compaction suite (14 integration tests, incl. the multi-chunk `compaction_many_chunks_preserves_all_data` guard) stays green; clippy + fmt clean.

## Also (CON-001)
Documents the `[compaction]` section in `mcp-server/config.example.toml` (the tracked operator template; the live `config.toml` is gitignored) — including the host-memory-safety `max_file_to_ram_ratio` gate, previously only discoverable from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Biztosítja, hogy a tömörítés csak az újonnan felhasznált forrásoldal-page-cache tartományokat dobja el, valamint dokumentálja a tömörítés konfigurációs beállításait és biztonsági korlátait.

Hibajavítások:
- Monotonikusan növekvő high-water mark követése a forrásfájl page-cache kiürítéséhez tömörítés közben, így flush-önként csak az új deltát dobjuk el, elkerülve a felesleges kernelmunkát és a gyűjtemények közötti sorrendfüggő viselkedést.

Build:
- A core workspace verzió frissítése 0.3.344-re és az mcp-ironbase-server frissítése 1.0.540-re.

Dokumentáció:
- Az opcionális [compaction] konfigurációs szekció és alapértelmezéseinek leírása az mcp-server/config.example.toml fájlban, beleértve a max_file_to_ram_ratio host-memory-safety korlátot.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure compaction only drops newly consumed source page-cache ranges and document compaction configuration options and safety limits.

Bug Fixes:
- Track a monotonic high-water mark for source file page-cache eviction during compaction so only the new delta is dropped per flush, avoiding redundant kernel work and order-dependent behavior across collections.

Build:
- Bump core workspace version to 0.3.344 and mcp-ironbase-server to 1.0.540.

Documentation:
- Describe the optional [compaction] configuration section and its defaults in mcp-server/config.example.toml, including the max_file_to_ram_ratio host-memory-safety gate.

</details>