### PR TITLE
fix(hnsw): deterministic rebuild insertion order (flaky self-retrieval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — deterministic HNSW rebuild order (flaky self-retrieval) (core v0.3.346, mcp v1.0.542)
+
+`HnswIndex::rebuild()` re-inserted the active vectors in `id_to_index` (a `HashMap`)
+iteration order, which Rust randomizes per process. HNSW graph construction is
+insertion-order dependent, so every rebuild produced a *different* graph → recall
+became non-deterministic. This surfaced as a flaky test,
+`forced_compact_rebuilds_and_clears_orphans`: its post-rebuild `assert_top1`
+self-retrieval missed ~10% of the time on Linux (and intermittently on macOS CI). The
+miss is a reachability artifact (the self vector has cosine 1.0, strictly maximal — it
+fails to be *reached*, not mis-ranked), so it could not be fixed by widening
+`ef_search` (verified: still ~2% at ef=16×N).
+
+Root cause fix: re-insert in a deterministic order (sorted by current node index, which
+reconstructs the original insertion order). The per-index level RNG is already
+deterministically seeded, so a stable insert order makes the whole rebuild reproducible
+— and every rebuild caller (forced `db_compact`, checkpoint orphan rebuild) now produces
+a stable graph. No quality regression: the brute-force recall@10 gates
+(`recall_at10_vs_bruteforce_*`, `hnsw_recall_meets_target`) stay green; the previously
+flaky test now passes 100/100 locally. Behavior-only change, no API/format change.
+
 ### Fixed — compaction source page-cache drop: final-chunk source tail (K-1) (core v0.3.345, mcp v1.0.541)
 
 Follow-up to the page-cache-bounded compaction I/O (v1.0.539–540), from a multi-agent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.345"
+version = "0.3.346"
 edition = "2021"
 authors = ["Petitan"]
 repository = "https://github.com/petitan/IronBase"

--- a/ironbase-core/src/vector/hnsw.rs
+++ b/ironbase-core/src/vector/hnsw.rs
@@ -679,7 +679,7 @@ impl HnswIndex {
         // (orphan node + new active node with same ID).
         // try_reserve so a huge index fails with a typed OOM error instead of
         // aborting during the rebuild clone (mirrors the insert-path guard).
-        let mut items: Vec<(String, Vec<f32>)> = Vec::new();
+        let mut items: Vec<(usize, String, Vec<f32>)> = Vec::new();
         items.try_reserve(self.id_to_index.len()).map_err(|e| {
             IronBaseError::OutOfMemory(format!(
                 "Failed to reserve {} entries for HNSW rebuild: {}",
@@ -690,8 +690,19 @@ impl HnswIndex {
         items.extend(
             self.id_to_index
                 .iter()
-                .map(|(id, &idx)| (id.clone(), self.nodes[idx].vector.clone())),
+                .map(|(id, &idx)| (idx, id.clone(), self.nodes[idx].vector.clone())),
         );
+        // Re-insert in a DETERMINISTIC order. `id_to_index` is a HashMap, whose
+        // iteration order is randomized per process (RandomState), and HNSW graph
+        // construction is insertion-order dependent — so iterating it directly made
+        // every rebuild produce a different graph, i.e. non-deterministic recall.
+        // That surfaced as a flaky `forced_compact_rebuilds_and_clears_orphans`
+        // self-retrieval (~10% miss; not fixable by widening ef_search, since the
+        // miss is reachability, not ranking). The per-index level RNG is already
+        // deterministic (fixed seed), so a stable insert order makes the whole
+        // rebuild reproducible. Sort by the current node index, which reconstructs
+        // the original insertion order (fresh builds have node index i == vector i).
+        items.sort_by_key(|(idx, _, _)| *idx);
 
         // Floor the effective ceiling at the rebuild population BEFORE clearing:
         // rebuild re-inserts EXISTING active vectors, which must never be
@@ -707,7 +718,7 @@ impl HnswIndex {
         self.max_level = 0;
         self.id_to_index.clear();
 
-        for (id, vector) in items {
+        for (_idx, id, vector) in items {
             self.insert(&id, &vector)?;
         }
 

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.541"
+version = "1.0.542"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Root cause

`HnswIndex::rebuild()` collected the active vectors via `id_to_index.iter()` (a `HashMap`, randomized per process by `RandomState`) and re-inserted in that order. HNSW graph construction is **insertion-order dependent**, so every rebuild produced a *different* graph → non-deterministic recall.

This surfaced as a flaky test, `forced_compact_rebuilds_and_clears_orphans`: its post-rebuild `assert_top1` self-retrieval missed ~10% of the time on Linux (and intermittently on macOS CI — see PR #115's macOS run). The miss is a **reachability** artifact (the self vector has cosine 1.0, strictly maximal — it fails to be *reached*, not mis-ranked), so it could **not** be fixed by widening `ef_search` (verified empirically: still ~2% at ef=16×N).

## Fix (product code, test untouched)

Re-insert in a deterministic order — sorted by current node index, which reconstructs the original insertion order. The per-index level RNG is already deterministically seeded (fixed constant), so a stable insert order makes the whole rebuild reproducible. Every rebuild caller benefits: forced `db_compact`, checkpoint orphan rebuild.

## Validation

| ef_search | flaky test pass rate |
|-----------|----------------------|
| default (50) | 90/100 |
| DOCS (60) | 96/100 |
| 16×N (960) | 98/100 |
| **deterministic order (this PR)** | **100/100** |

- Brute-force recall gates (`recall_at10_vs_bruteforce_*`, `hnsw_recall_meets_target`) stay green → no quality regression.
- Full hnsw (29) + maintenance lib suites green; fmt + clippy clean.
- Behavior-only change; no API/format change.

## Note on versions
Bumps to core v0.3.346 / mcp v1.0.542, assuming #115 (v0.3.345 / v1.0.541) merges first. If merge order differs, the version line needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Biztosítja, hogy a HNSW index újraépítése determinisztikus legyen, ezzel kiküszöbölve a nem determinisztikus recall-t és az ingadozó ön-visszakeresést, valamint ennek megfelelően frissíti a core és server csomagverziókat.

Bug Fixes:
- Javítja a nem determinisztikus HNSW-újraépítéseket azáltal, hogy a vektorokat determinisztikus sorrendben, a node index alapján illeszti vissza, stabilizálva a recall és ön-visszakeresési viselkedést.

Enhancements:
- Dokumentálja a HNSW-újraépítés determinisztikusságának javítását és annak hatását a changelogban, egyértelművé téve a viselkedést és a teszteredményeket.

Build:
- A core workspace verzióját 0.3.346-ra, az MCP server verzióját pedig 1.0.542-re emeli.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure HNSW index rebuilds are deterministic to eliminate non-deterministic recall and flaky self-retrieval, and bump core and server package versions accordingly.

Bug Fixes:
- Fix non-deterministic HNSW rebuilds by re-inserting vectors in a deterministic order based on node index, stabilizing recall and self-retrieval behavior.

Enhancements:
- Document the HNSW rebuild determinism fix and its impact in the changelog, clarifying behavior and test outcomes.

Build:
- Bump core workspace version to 0.3.346 and MCP server version to 1.0.542.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Biztosítja, hogy a HNSW index újraépítése determinisztikus legyen, ezzel kiküszöbölve a nem determinisztikus recall-t és az ingadozó ön-visszakeresést, valamint ennek megfelelően frissíti a core és server csomagverziókat.

Bug Fixes:
- Javítja a nem determinisztikus HNSW-újraépítéseket azáltal, hogy a vektorokat determinisztikus sorrendben, a node index alapján illeszti vissza, stabilizálva a recall és ön-visszakeresési viselkedést.

Enhancements:
- Dokumentálja a HNSW-újraépítés determinisztikusságának javítását és annak hatását a changelogban, egyértelművé téve a viselkedést és a teszteredményeket.

Build:
- A core workspace verzióját 0.3.346-ra, az MCP server verzióját pedig 1.0.542-re emeli.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure HNSW index rebuilds are deterministic to eliminate non-deterministic recall and flaky self-retrieval, and bump core and server package versions accordingly.

Bug Fixes:
- Fix non-deterministic HNSW rebuilds by re-inserting vectors in a deterministic order based on node index, stabilizing recall and self-retrieval behavior.

Enhancements:
- Document the HNSW rebuild determinism fix and its impact in the changelog, clarifying behavior and test outcomes.

Build:
- Bump core workspace version to 0.3.346 and MCP server version to 1.0.542.

</details>

</details>