### PR TITLE
feat(rag): context_fields — document-identity contextual embedding (v1.0.543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — context_fields: document-identity contextual embedding (mcp-server v1.0.543)
+
+Per-collection document-identity breadcrumb prepended to each chunk's *embedding*
+text (the stored chunk text is unchanged — embed-text ≠ store-text, the existing
+contextual-embedding pattern). The breadcrumb is built from declared metadata
+fields, e.g. `"customer: Agrovario Kft. | title: …"`, so the identical boilerplate
+chunks of different documents get *distinct* vectors instead of colliding.
+
+- New `context_fields` parameter on `rag_collection_create` (persisted into the RAG
+  config) and `rag_document_import` (explicit value wins, else falls back to the
+  stored RAG config). Order: context → section breadcrumb → cleaned body.
+- Backward compatible: `RagConfig.context_fields` uses `#[serde(default)]`, so legacy
+  configs deserialize to an empty list → verbatim embedding (no behavior change).
+- Only the `rag_document_import` path honors `context_fields`; `embed_document` and
+  the Rhai `db_rag_import` stay verbatim by design (documented boundary, like the
+  generic auto-embed verbatim convention).
+- Eval-harness A/B (rdocs): nDCG@10 +25%, Recall@10 +13%.
+
 ### Fixed — deterministic HNSW rebuild order (flaky self-retrieval) (core v0.3.346, mcp v1.0.542)
 
 `HnswIndex::rebuild()` re-inserted the active vectors in `id_to_index` (a `HashMap`)

--- a/mcp-server/Cargo.toml
+++ b/mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-ironbase-server"
-version = "1.0.542"
+version = "1.0.543"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mcp-server/src/chunking/mod.rs
+++ b/mcp-server/src/chunking/mod.rs
@@ -328,6 +328,12 @@ pub fn build_embed_text(
     }
 }
 
+/// Upper bound (bytes) on the document-identity context prefix. The prefix is a
+/// short breadcrumb (a few identity fields); cap it so a pathological metadata
+/// value cannot inflate every chunk's embed-text sent to the embedding provider.
+/// Truncated UTF-8-safely; the breadcrumb stays a hint, not a payload.
+pub const MAX_CONTEXT_PREFIX_BYTES: usize = 512;
+
 /// Build the document-identity context prefix prepended to every chunk's
 /// embed-text (NOT stored) so identical boilerplate across documents gets
 /// distinct vectors.
@@ -335,7 +341,8 @@ pub fn build_embed_text(
 /// Formats `"name: value"` pairs in `context_fields` order, joined by ` | `.
 /// String values are used verbatim; numbers/bools are rendered plain (no JSON
 /// quotes); missing, empty, null, or non-scalar (object/array) fields are
-/// skipped. Returns `None` when nothing usable remains.
+/// skipped. The result is capped at `MAX_CONTEXT_PREFIX_BYTES` (UTF-8-safe).
+/// Returns `None` when nothing usable remains.
 pub fn build_context_prefix(
     context_fields: &[String],
     fields: &serde_json::Map<String, serde_json::Value>,
@@ -358,10 +365,18 @@ pub fn build_context_prefix(
         })
         .collect();
     if parts.is_empty() {
-        None
-    } else {
-        Some(parts.join(" | "))
+        return None;
     }
+    let mut prefix = parts.join(" | ");
+    if prefix.len() > MAX_CONTEXT_PREFIX_BYTES {
+        // Truncate at the largest char boundary <= the cap (UTF-8-safe).
+        let mut end = MAX_CONTEXT_PREFIX_BYTES;
+        while end > 0 && !prefix.is_char_boundary(end) {
+            end -= 1;
+        }
+        prefix.truncate(end);
+    }
+    Some(prefix)
 }
 
 /// Split content into chunks
@@ -762,5 +777,19 @@ mod tests {
         fields.insert("title".to_string(), serde_json::json!("X"));
         let context_fields: Vec<String> = vec![];
         assert_eq!(build_context_prefix(&context_fields, &fields), None);
+    }
+
+    #[test]
+    fn test_build_context_prefix_caps_length() {
+        // A pathological metadata value must not inflate the prefix unboundedly.
+        let mut fields = serde_json::Map::new();
+        fields.insert("customer".to_string(), serde_json::json!("x".repeat(2000)));
+        let p = build_context_prefix(&["customer".to_string()], &fields).unwrap();
+        assert!(
+            p.len() <= MAX_CONTEXT_PREFIX_BYTES,
+            "prefix must be capped at {MAX_CONTEXT_PREFIX_BYTES}, got {}",
+            p.len()
+        );
+        assert!(p.starts_with("customer: x"));
     }
 }

--- a/mcp-server/src/chunking/mod.rs
+++ b/mcp-server/src/chunking/mod.rs
@@ -300,19 +300,67 @@ pub(crate) fn find_table_header(text: &str) -> Option<String> {
 
 /// Build the text used to embed a chunk.
 ///
-/// Combines the chunk body with its section breadcrumb so the embedding vector
-/// carries hierarchical context (e.g. `"Brakes > PEF-35 > Specs\n\n<body>"`).
+/// Combines the chunk body with an optional document-identity `context`
+/// breadcrumb and its section breadcrumb so the embedding vector carries
+/// document- and hierarchy-level context. Order: context → section_path → body
+/// (e.g. `"customer: Agrovario | title: X\nBrakes > PEF-35 > Specs\n\n<body>"`).
 /// Markdown tables in the body are flattened to plain text for cleaner
 /// tokenization.
 ///
 /// This is used ONLY for embedding — the original chunk text is stored and
 /// returned unchanged. Generic auto-embedding (auto_embed.rs / crud.rs) embeds
 /// the source field verbatim and intentionally does not call this.
-pub fn build_embed_text(body: &str, section_path: Option<&[String]>) -> String {
+pub fn build_embed_text(
+    body: &str,
+    section_path: Option<&[String]>,
+    context: Option<&str>,
+) -> String {
     let clean = strip_markdown_tables(body);
-    match section_path {
-        Some(path) if !path.is_empty() => format!("{}\n\n{}", path.join(" > "), clean),
-        _ => clean,
+    let breadcrumb = match section_path {
+        Some(path) if !path.is_empty() => Some(path.join(" > ")),
+        _ => None,
+    };
+    match (context, breadcrumb) {
+        (Some(ctx), Some(bc)) => format!("{}\n{}\n\n{}", ctx, bc, clean),
+        (Some(ctx), None) => format!("{}\n\n{}", ctx, clean),
+        (None, Some(bc)) => format!("{}\n\n{}", bc, clean),
+        (None, None) => clean,
+    }
+}
+
+/// Build the document-identity context prefix prepended to every chunk's
+/// embed-text (NOT stored) so identical boilerplate across documents gets
+/// distinct vectors.
+///
+/// Formats `"name: value"` pairs in `context_fields` order, joined by ` | `.
+/// String values are used verbatim; numbers/bools are rendered plain (no JSON
+/// quotes); missing, empty, null, or non-scalar (object/array) fields are
+/// skipped. Returns `None` when nothing usable remains.
+pub fn build_context_prefix(
+    context_fields: &[String],
+    fields: &serde_json::Map<String, serde_json::Value>,
+) -> Option<String> {
+    let parts: Vec<String> = context_fields
+        .iter()
+        .filter_map(|name| {
+            let value = fields.get(name)?;
+            let rendered = match value {
+                serde_json::Value::String(s) => s.trim().to_string(),
+                serde_json::Value::Number(n) => n.to_string(),
+                serde_json::Value::Bool(b) => b.to_string(),
+                // Null / Object / Array are not document-identity scalars → skip.
+                _ => return None,
+            };
+            if rendered.is_empty() {
+                return None;
+            }
+            Some(format!("{}: {}", name, rendered))
+        })
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" | "))
     }
 }
 
@@ -596,22 +644,25 @@ mod tests {
     #[test]
     fn test_build_embed_text_with_section_path() {
         let path = vec!["Fékpadok".to_string(), "PEF-35".to_string()];
-        let result = build_embed_text("A műszaki adatok.", Some(&path));
+        let result = build_embed_text("A műszaki adatok.", Some(&path), None);
         assert_eq!(result, "Fékpadok > PEF-35\n\nA műszaki adatok.");
     }
 
     #[test]
     fn test_build_embed_text_without_section_path() {
-        assert_eq!(build_embed_text("Plain body.", None), "Plain body.");
+        assert_eq!(build_embed_text("Plain body.", None, None), "Plain body.");
         // Empty path behaves like None (no breadcrumb prefix)
         let empty: Vec<String> = vec![];
-        assert_eq!(build_embed_text("Plain body.", Some(&empty)), "Plain body.");
+        assert_eq!(
+            build_embed_text("Plain body.", Some(&empty), None),
+            "Plain body."
+        );
     }
 
     #[test]
     fn test_build_embed_text_flattens_table() {
         let body = "| A | B |\n|---|---|\n| 1 | 2 |";
-        assert_eq!(build_embed_text(body, None), "A, B\n1, 2");
+        assert_eq!(build_embed_text(body, None, None), "A, B\n1, 2");
     }
 
     #[test]
@@ -619,8 +670,97 @@ mod tests {
         let path = vec!["Árlista".to_string()];
         let body = "| Megnevezés | Ár |\n|---|---|\n| PEF-35 | 1750000 |";
         assert_eq!(
-            build_embed_text(body, Some(&path)),
+            build_embed_text(body, Some(&path), None),
             "Árlista\n\nMegnevezés, Ár\nPEF-35, 1750000"
         );
+    }
+
+    #[test]
+    fn test_build_embed_text_with_context_only() {
+        let ctx = "customer: Agrovario | title: X";
+        assert_eq!(
+            build_embed_text("Plain body.", None, Some(ctx)),
+            "customer: Agrovario | title: X\n\nPlain body."
+        );
+    }
+
+    #[test]
+    fn test_build_embed_text_with_context_and_breadcrumb() {
+        let ctx = "customer: Agrovario";
+        let path = vec!["Szerződés".to_string(), "Adatkezelés".to_string()];
+        // Order: context → section_path breadcrumb → clean body
+        assert_eq!(
+            build_embed_text("A test.", Some(&path), Some(ctx)),
+            "customer: Agrovario\nSzerződés > Adatkezelés\n\nA test."
+        );
+    }
+
+    #[test]
+    fn test_build_context_prefix_multiple_fields() {
+        let mut fields = serde_json::Map::new();
+        fields.insert("title".to_string(), serde_json::json!("Szerződés"));
+        fields.insert("customer".to_string(), serde_json::json!("Agrovario Kft."));
+        // Output follows context_fields order, not map order.
+        let context_fields = vec!["customer".to_string(), "title".to_string()];
+        assert_eq!(
+            build_context_prefix(&context_fields, &fields),
+            Some("customer: Agrovario Kft. | title: Szerződés".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_context_prefix_skips_missing_and_empty() {
+        let mut fields = serde_json::Map::new();
+        fields.insert("title".to_string(), serde_json::json!("X"));
+        fields.insert("blank".to_string(), serde_json::json!("   "));
+        fields.insert("nullf".to_string(), serde_json::Value::Null);
+        let context_fields = vec![
+            "customer".to_string(), // missing
+            "blank".to_string(),    // whitespace-only → skipped
+            "nullf".to_string(),    // null → skipped
+            "title".to_string(),    // present
+        ];
+        assert_eq!(
+            build_context_prefix(&context_fields, &fields),
+            Some("title: X".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_context_prefix_renders_scalars_plain() {
+        let mut fields = serde_json::Map::new();
+        fields.insert("year".to_string(), serde_json::json!(2026));
+        fields.insert("active".to_string(), serde_json::json!(true));
+        let context_fields = vec!["year".to_string(), "active".to_string()];
+        // Numbers/bools rendered plain, no JSON quotes.
+        assert_eq!(
+            build_context_prefix(&context_fields, &fields),
+            Some("year: 2026 | active: true".to_string())
+        );
+    }
+
+    #[test]
+    fn test_build_context_prefix_skips_non_scalar() {
+        let mut fields = serde_json::Map::new();
+        fields.insert("obj".to_string(), serde_json::json!({"a": 1}));
+        fields.insert("arr".to_string(), serde_json::json!([1, 2]));
+        let context_fields = vec!["obj".to_string(), "arr".to_string()];
+        // Object/array are not document-identity scalars → None.
+        assert_eq!(build_context_prefix(&context_fields, &fields), None);
+    }
+
+    #[test]
+    fn test_build_context_prefix_all_missing_is_none() {
+        let fields = serde_json::Map::new();
+        let context_fields = vec!["customer".to_string(), "title".to_string()];
+        assert_eq!(build_context_prefix(&context_fields, &fields), None);
+    }
+
+    #[test]
+    fn test_build_context_prefix_empty_fields_list_is_none() {
+        let mut fields = serde_json::Map::new();
+        fields.insert("title".to_string(), serde_json::json!("X"));
+        let context_fields: Vec<String> = vec![];
+        assert_eq!(build_context_prefix(&context_fields, &fields), None);
     }
 }

--- a/mcp-server/src/scripting/db_functions.rs
+++ b/mcp-server/src/scripting/db_functions.rs
@@ -1588,9 +1588,11 @@ fn rag_import_impl(
     }
 
     // Generate embeddings: breadcrumb + cleaned body; stored chunk.text is unchanged.
+    // No document-identity context here (db_rag_import stays verbatim by design — only
+    // rag_document_import wires context_fields); see chunking::build_embed_text.
     let texts: Vec<String> = chunks
         .iter()
-        .map(|c| build_embed_text(&c.text, c.section_path.as_deref()))
+        .map(|c| build_embed_text(&c.text, c.section_path.as_deref(), None))
         .collect();
     let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
     let embeddings = match provider.embed_batch(&text_refs) {

--- a/mcp-server/src/tools/definitions/rag.rs
+++ b/mcp-server/src/tools/definitions/rag.rs
@@ -31,6 +31,11 @@ pub fn tools() -> Vec<Value> {
                         "items": {"type": "string"},
                         "description": "Extra text fields to fulltext-index besides text_field, e.g. [\"title\", \"customer\"]. Each gets its own fulltext index, and the `search` tool then defaults to searching all of them — no manual index_create (type='fulltext') needed."
                     },
+                    "context_fields": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Document-identity metadata fields prepended to the embedding text (not stored) so identical boilerplate across documents gets distinct vectors, e.g. [\"customer\",\"title\"]. Empty = verbatim embedding."
+                    },
                     "provider": {
                         "type": "string",
                         "description": "Embedding provider (ollama, vllm, openai). Defaults to the provider configured in [embedding] section of config.toml."
@@ -110,6 +115,11 @@ pub fn tools() -> Vec<Value> {
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "Extra metadata text fields to fulltext-index (besides content), e.g. [\"title\", \"customer\"]. Only applies when auto-creating the collection (no RAG config yet)."
+                    },
+                    "context_fields": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Document-identity metadata fields prepended to the embedding text (not stored) so identical boilerplate across documents gets distinct vectors, e.g. [\"customer\",\"title\"]. Explicit value wins; otherwise the collection's stored RAG config is used. Empty = verbatim embedding."
                     }
                 },
                 "required": ["collection", "content"]

--- a/mcp-server/src/tools/embedding.rs
+++ b/mcp-server/src/tools/embedding.rs
@@ -272,9 +272,11 @@ fn handle_embed_document(
 
     for batch in chunks.chunks(batch_size) {
         // Embed breadcrumb + cleaned body; the original chunk.text is stored unchanged.
+        // No document-identity context here (embed_document stays verbatim by design —
+        // only rag_document_import wires context_fields); see chunking::build_embed_text.
         let texts: Vec<String> = batch
             .iter()
-            .map(|c| build_embed_text(&c.text, c.section_path.as_deref()))
+            .map(|c| build_embed_text(&c.text, c.section_path.as_deref(), None))
             .collect();
         let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
         let embeddings = provider

--- a/mcp-server/src/tools/params.rs
+++ b/mcp-server/src/tools/params.rs
@@ -811,6 +811,11 @@ pub struct RagCollectionCreateParams {
     /// ["title", "customer"]. When set, hybrid_search defaults to searching all
     /// of them. Omitted → single `text_field` (backward compatible).
     pub text_fields: Option<Vec<String>>,
+    /// Document-identity metadata fields prepended to each chunk's embedding text
+    /// (not stored), e.g. ["customer", "title"]. Stored in the RAG config and used
+    /// by rag_document_import so identical boilerplate gets distinct vectors.
+    /// Omitted → verbatim embedding (backward compatible).
+    pub context_fields: Option<Vec<String>>,
     pub provider: Option<String>,
     #[serde(default = "default_rag_language")]
     pub language: String,
@@ -841,6 +846,11 @@ pub struct RagDocumentImportParams {
     /// (besides `content`), e.g. ["title", "customer"]. Only applies when the
     /// collection has no RAG config yet. Omitted → single content index.
     pub text_fields: Option<Vec<String>>,
+    /// Document-identity metadata fields prepended to each chunk's embedding text
+    /// (not stored), e.g. ["customer", "title"]. Explicit value wins; otherwise the
+    /// collection's stored RAG config context_fields is used. Omitted on both →
+    /// verbatim embedding (backward compatible).
+    pub context_fields: Option<Vec<String>>,
 }
 
 /// Parameters for `rag_collection_stats` tool

--- a/mcp-server/src/tools/params.rs
+++ b/mcp-server/src/tools/params.rs
@@ -847,9 +847,13 @@ pub struct RagDocumentImportParams {
     /// collection has no RAG config yet. Omitted → single content index.
     pub text_fields: Option<Vec<String>>,
     /// Document-identity metadata fields prepended to each chunk's embedding text
-    /// (not stored), e.g. ["customer", "title"]. Explicit value wins; otherwise the
-    /// collection's stored RAG config context_fields is used. Omitted on both →
-    /// verbatim embedding (backward compatible).
+    /// (not stored), e.g. ["customer", "title"]. Explicit value wins for THIS import;
+    /// otherwise the collection's stored RAG config context_fields is used. Reserved
+    /// (`doc_id`, `chunk_index`, …) and the embedding/text fields are never sourced
+    /// into the prefix. NOTE: an explicit value on a collection that already has a RAG
+    /// config is applied to this import only, NOT persisted (set it via
+    /// rag_collection_create to persist; a warning is logged when it differs).
+    /// Omitted on both → verbatim embedding (backward compatible).
     pub context_fields: Option<Vec<String>>,
 }
 

--- a/mcp-server/src/tools/rag.rs
+++ b/mcp-server/src/tools/rag.rs
@@ -567,8 +567,8 @@ fn handle_rag_document_import(
 
     // Resolve the document-identity context fields: explicit param wins, else the
     // collection's stored RagConfig. Build the prefix ONCE (same for every chunk in
-    // this import) from the doc-level fields (title + custom metadata keys); the
-    // prefix is prepended to embed-text only, the stored chunk.text is unchanged.
+    // this import) from the doc-level fields; the prefix is prepended to embed-text
+    // only, the stored chunk.text is unchanged.
     let resolved_context_fields: Vec<String> = p
         .context_fields
         .clone()
@@ -577,13 +577,28 @@ fn handle_rag_document_import(
     let context_prefix = if resolved_context_fields.is_empty() {
         None
     } else {
+        // Build the lookup map with ONLY the declared context fields, applying the
+        // SAME security filter as the stored document (RESERVED_METADATA_KEYS +
+        // embedding_field/text_field): a reserved/protected key must NEVER be sourced
+        // into the embed-text, which can leave the host for an external embedding
+        // provider. Cloning only the few declared values also avoids deep-copying the
+        // whole metadata object. Precedence matches the stored doc: a metadata value
+        // wins, with the `title` param as the fallback for the "title" field.
+        let meta_obj = p.metadata.as_ref().and_then(|m| m.as_object());
         let mut ctx_map = serde_json::Map::new();
-        if let Some(ref title) = p.title {
-            ctx_map.insert("title".to_string(), json!(title));
-        }
-        if let Some(meta_obj) = p.metadata.as_ref().and_then(|m| m.as_object()) {
-            for (k, v) in meta_obj {
-                ctx_map.insert(k.clone(), v.clone());
+        for name in &resolved_context_fields {
+            if RESERVED_METADATA_KEYS.contains(&name.as_str())
+                || name == &embedding_field
+                || name == &text_field
+            {
+                continue;
+            }
+            if let Some(v) = meta_obj.and_then(|o| o.get(name)) {
+                ctx_map.insert(name.clone(), v.clone());
+            } else if name == "title" {
+                if let Some(ref title) = p.title {
+                    ctx_map.insert("title".to_string(), json!(title));
+                }
             }
         }
         crate::chunking::build_context_prefix(&resolved_context_fields, &ctx_map)
@@ -682,6 +697,23 @@ fn handle_rag_document_import(
                      has a RAG config. Set text_fields via rag_collection_create.",
                     missing,
                     p.collection
+                );
+            }
+        }
+        // Parity with text_fields: an explicit context_fields applied to a collection
+        // that already has a RAG config is honored for THIS import (via
+        // resolved_context_fields above) but is NOT persisted — the stored config wins
+        // for later param-less imports. Warn when it differs so the divergence is not
+        // silent (set context_fields via rag_collection_create to persist).
+        if let Some(ref requested) = p.context_fields {
+            if *requested != cfg.context_fields {
+                tracing::warn!(
+                    "rag_document_import: explicit 'context_fields' {:?} applied to THIS import \
+                     only — collection '{}' already has a RAG config (stored: {:?}). Set \
+                     context_fields via rag_collection_create to persist.",
+                    requested,
+                    p.collection,
+                    cfg.context_fields
                 );
             }
         }

--- a/mcp-server/src/tools/rag.rs
+++ b/mcp-server/src/tools/rag.rs
@@ -479,6 +479,43 @@ pub(crate) fn resolve_fulltext_fields(
 // rag_document_import Handler
 // ============================================================================
 
+/// Build the document-identity context prefix for an import (prepended to every
+/// chunk's embed-text, NOT stored). Sources ONLY the declared `context_fields`,
+/// applying the SAME security filter as the stored document: `RESERVED_METADATA_KEYS`
+/// and the embedding/text fields are never sourced into the embed-text (which can
+/// leave the host for an external embedding provider). Cloning only the few declared
+/// values avoids deep-copying the whole metadata. Precedence matches the stored doc:
+/// a metadata value wins, with `title` as the fallback for the "title" field.
+/// Returns `None` for an empty `context_fields` or when nothing usable remains.
+fn build_import_context_prefix(
+    context_fields: &[String],
+    title: Option<&str>,
+    metadata: Option<&serde_json::Map<String, Value>>,
+    embedding_field: &str,
+    text_field: &str,
+) -> Option<String> {
+    if context_fields.is_empty() {
+        return None;
+    }
+    let mut ctx_map = serde_json::Map::new();
+    for name in context_fields {
+        if RESERVED_METADATA_KEYS.contains(&name.as_str())
+            || name == embedding_field
+            || name == text_field
+        {
+            continue;
+        }
+        if let Some(v) = metadata.and_then(|o| o.get(name)) {
+            ctx_map.insert(name.clone(), v.clone());
+        } else if name == "title" {
+            if let Some(t) = title {
+                ctx_map.insert("title".to_string(), json!(t));
+            }
+        }
+    }
+    crate::chunking::build_context_prefix(context_fields, &ctx_map)
+}
+
 fn handle_rag_document_import(
     params: Value,
     adapter: &Arc<IronBaseAdapter>,
@@ -574,35 +611,13 @@ fn handle_rag_document_import(
         .clone()
         .or_else(|| rag_config.as_ref().map(|c| c.context_fields.clone()))
         .unwrap_or_default();
-    let context_prefix = if resolved_context_fields.is_empty() {
-        None
-    } else {
-        // Build the lookup map with ONLY the declared context fields, applying the
-        // SAME security filter as the stored document (RESERVED_METADATA_KEYS +
-        // embedding_field/text_field): a reserved/protected key must NEVER be sourced
-        // into the embed-text, which can leave the host for an external embedding
-        // provider. Cloning only the few declared values also avoids deep-copying the
-        // whole metadata object. Precedence matches the stored doc: a metadata value
-        // wins, with the `title` param as the fallback for the "title" field.
-        let meta_obj = p.metadata.as_ref().and_then(|m| m.as_object());
-        let mut ctx_map = serde_json::Map::new();
-        for name in &resolved_context_fields {
-            if RESERVED_METADATA_KEYS.contains(&name.as_str())
-                || name == &embedding_field
-                || name == &text_field
-            {
-                continue;
-            }
-            if let Some(v) = meta_obj.and_then(|o| o.get(name)) {
-                ctx_map.insert(name.clone(), v.clone());
-            } else if name == "title" {
-                if let Some(ref title) = p.title {
-                    ctx_map.insert("title".to_string(), json!(title));
-                }
-            }
-        }
-        crate::chunking::build_context_prefix(&resolved_context_fields, &ctx_map)
-    };
+    let context_prefix = build_import_context_prefix(
+        &resolved_context_fields,
+        p.title.as_deref(),
+        p.metadata.as_ref().and_then(|m| m.as_object()),
+        &embedding_field,
+        &text_field,
+    );
 
     // Generate embeddings in batches (OOM protection)
     let mut all_embeddings: Vec<Vec<f32>> = Vec::new();
@@ -901,6 +916,54 @@ fn handle_rag_collection_stats(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_build_import_context_prefix_filters_reserved_and_protected() {
+        // A declared context field naming a reserved or protected key must NOT be
+        // sourced into the prefix (it would leak to the embedding provider).
+        let meta = json!({"customer": "Acme", "doc_id": "secret-123", "embedding": [0.1]});
+        let meta = meta.as_object().unwrap();
+        let fields = vec![
+            "customer".to_string(),
+            "doc_id".to_string(),    // reserved → skipped
+            "embedding".to_string(), // protected (embedding_field) → skipped
+        ];
+        let p = build_import_context_prefix(&fields, None, Some(meta), "embedding", "content");
+        assert_eq!(p, Some("customer: Acme".to_string()));
+    }
+
+    #[test]
+    fn test_build_import_context_prefix_title_fallback_and_metadata_wins() {
+        // "title" absent from metadata → falls back to the title param.
+        let meta = json!({"customer": "Acme"});
+        let p = build_import_context_prefix(
+            &["title".to_string(), "customer".to_string()],
+            Some("Q3 Quote"),
+            meta.as_object(),
+            "embedding",
+            "content",
+        );
+        assert_eq!(p, Some("title: Q3 Quote | customer: Acme".to_string()));
+
+        // metadata "title" wins over the title param (matches the stored doc).
+        let meta2 = json!({"title": "Meta Title"});
+        let p2 = build_import_context_prefix(
+            &["title".to_string()],
+            Some("Param Title"),
+            meta2.as_object(),
+            "embedding",
+            "content",
+        );
+        assert_eq!(p2, Some("title: Meta Title".to_string()));
+    }
+
+    #[test]
+    fn test_build_import_context_prefix_empty_fields_is_none() {
+        assert_eq!(
+            build_import_context_prefix(&[], Some("X"), None, "embedding", "content"),
+            None
+        );
+    }
 
     #[test]
     fn test_rag_config_serialization() {

--- a/mcp-server/src/tools/rag.rs
+++ b/mcp-server/src/tools/rag.rs
@@ -45,6 +45,13 @@ pub struct RagConfig {
     /// to multi-field search consistently with how the collection was set up (#66).
     #[serde(default)]
     pub text_fields: Vec<String>,
+    /// Document-identity metadata fields prepended to each chunk's embed-text
+    /// (NOT stored) so identical boilerplate across documents gets distinct
+    /// vectors, e.g. ["customer", "title"]. Empty on legacy configs → verbatim
+    /// embedding (backward compatible). Only the rag_document_import path honors
+    /// this; embed_document/db_rag_import stay verbatim by design.
+    #[serde(default)]
+    pub context_fields: Vec<String>,
     pub provider: String,
     pub language: String,
     pub dimension: usize,
@@ -385,11 +392,13 @@ fn handle_rag_collection_create(
     }
 
     // 4. Save RAG config
+    let context_fields = p.context_fields.clone().unwrap_or_default();
     let config = RagConfig {
         collection: p.collection.clone(),
         embedding_field: p.embedding_field.clone(),
         text_field: p.text_field.clone(),
         text_fields: fulltext_fields.clone(),
+        context_fields: context_fields.clone(),
         provider: provider_name.clone(),
         language: p.language.clone(),
         dimension,
@@ -404,6 +413,7 @@ fn handle_rag_collection_create(
             "embedding_field": p.embedding_field,
             "text_field": p.text_field,
             "text_fields": fulltext_fields,
+            "context_fields": context_fields,
             "provider": provider_name,
             "language": p.language,
             "dimension": dimension
@@ -555,6 +565,30 @@ fn handle_rag_document_import(
         }
     }
 
+    // Resolve the document-identity context fields: explicit param wins, else the
+    // collection's stored RagConfig. Build the prefix ONCE (same for every chunk in
+    // this import) from the doc-level fields (title + custom metadata keys); the
+    // prefix is prepended to embed-text only, the stored chunk.text is unchanged.
+    let resolved_context_fields: Vec<String> = p
+        .context_fields
+        .clone()
+        .or_else(|| rag_config.as_ref().map(|c| c.context_fields.clone()))
+        .unwrap_or_default();
+    let context_prefix = if resolved_context_fields.is_empty() {
+        None
+    } else {
+        let mut ctx_map = serde_json::Map::new();
+        if let Some(ref title) = p.title {
+            ctx_map.insert("title".to_string(), json!(title));
+        }
+        if let Some(meta_obj) = p.metadata.as_ref().and_then(|m| m.as_object()) {
+            for (k, v) in meta_obj {
+                ctx_map.insert(k.clone(), v.clone());
+            }
+        }
+        crate::chunking::build_context_prefix(&resolved_context_fields, &ctx_map)
+    };
+
     // Generate embeddings in batches (OOM protection)
     let mut all_embeddings: Vec<Vec<f32>> = Vec::new();
     all_embeddings.try_reserve(chunks.len()).map_err(|e| {
@@ -566,10 +600,17 @@ fn handle_rag_document_import(
     })?;
 
     for batch in chunks.chunks(100) {
-        // Embed breadcrumb + cleaned body; the original chunk.text is stored unchanged.
+        // Embed context + breadcrumb + cleaned body; the original chunk.text is stored
+        // unchanged. context_prefix is the same for every chunk in this import.
         let texts: Vec<String> = batch
             .iter()
-            .map(|c| build_embed_text(&c.text, c.section_path.as_deref()))
+            .map(|c| {
+                build_embed_text(
+                    &c.text,
+                    c.section_path.as_deref(),
+                    context_prefix.as_deref(),
+                )
+            })
             .collect();
         let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
         let embeddings = provider
@@ -609,6 +650,7 @@ fn handle_rag_document_import(
             embedding_field: embedding_field.clone(),
             text_field: text_field.clone(),
             text_fields: fulltext_fields,
+            context_fields: resolved_context_fields.clone(),
             provider: provider_name.clone(),
             language: p.language.clone(),
             dimension: provider.dimension(),
@@ -835,6 +877,7 @@ mod tests {
             embedding_field: "embedding".to_string(),
             text_field: "content".to_string(),
             text_fields: vec!["content".to_string(), "title".to_string()],
+            context_fields: vec!["customer".to_string(), "title".to_string()],
             provider: "ollama".to_string(),
             language: "hungarian".to_string(),
             dimension: 300,
@@ -845,6 +888,7 @@ mod tests {
         assert_eq!(parsed.collection, "test");
         assert_eq!(parsed.dimension, 300);
         assert_eq!(parsed.text_fields, vec!["content", "title"]);
+        assert_eq!(parsed.context_fields, vec!["customer", "title"]);
     }
 
     #[test]
@@ -858,6 +902,8 @@ mod tests {
         let cfg: RagConfig = serde_json::from_value(json).unwrap();
         assert!(cfg.text_fields.is_empty());
         assert_eq!(cfg.effective_text_fields(), vec!["content"]);
+        // Pre-context_fields config → empty (verbatim embedding, backward compatible).
+        assert!(cfg.context_fields.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

RAG chunk imports can now prepend declared **document-identity metadata fields** (e.g. `["customer","title"]`) to each chunk's **embed text** — the stored chunk text is unchanged (embed-text ≠ store-text, the existing pattern). This gives identical boilerplate chunks across different documents **distinct vectors**, so per-document / per-customer retrieval over shared boilerplate works.

## Why (measured)

On the rdocs corpus, ~40% of chunks share a `cosine ≥ 0.999` twin — legitimate boilerplate (GDPR clauses, terms, equipment specs) repeated across 1103 distinct contracts (verified: **0** `(doc_id, chunk_index)` collisions, so not re-import duplicates → dedup would lose real data). The live hybrid `search` could not disambiguate which customer's copy of a boilerplate clause to return (**0/9** on customer-disambiguation queries).

Measured on the PR #110 eval harness (87 curated rdocs queries, live hybrid `search`, full contextual re-embed into a test collection vs verbatim baseline):

| metric | verbatim | contextual | Δ |
|--------|:---:|:---:|:---:|
| nDCG@5 | 0.163 | 0.211 | **+30%** |
| nDCG@10 | 0.169 | 0.211 | **+25%** |
| Recall@5 | 0.360 | 0.394 | **+9%** |
| Recall@10 | 0.415 | 0.468 | **+13%** |

Consistent net-positive across all metrics, through the full fusion pipeline (the contextual vector lane helps even over the unchanged BM25 lane). The DPR "can hurt on some corpora" risk did not materialize on rdocs. Literature: Anthropic Contextual Retrieval (2024) — this is a cheap deterministic metadata variant; DPR title-prepending; DAPR benchmark.

## Implementation

- `chunking::build_embed_text` gains a third `context: Option<&str>` arg (order: **context → section breadcrumb → body**); `None` preserves prior behavior.
- `chunking::build_context_prefix(fields, map)` formats `"name: value | …"` from the declared fields, skipping missing/empty/null/non-scalar values.
- `RagConfig.context_fields` (`#[serde(default)]` → legacy configs = empty = verbatim, **backward compatible**).
- `rag_collection_create` + `rag_document_import` gain a `context_fields` param; `rag_document_import` resolves explicit param ?? stored config, builds the prefix once per import from `title` + `metadata`, and persists the resolved fields.
- **Deliberate boundary:** `embed_document` and Rhai `db_rag_import` stay verbatim (`None` context), mirroring the existing "generic auto-embed verbatim" boundary.

## Tests

`build_embed_text` (context/breadcrumb combinations) + `build_context_prefix` (multi-field, missing/empty/scalar/non-scalar/all-missing/empty-list) + `RagConfig` round-trip & backward-compat. Full mcp-server suite green, clippy `-D warnings` clean, fmt clean.

## Note

This adds the **capability**; production `rdocs` is still verbatim. Realizing the measured gain requires a one-time re-import of rdocs with `context_fields=["customer","title"]` (a separate operational step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Konfigurálható dokumentum-azonosító kontextusmezők hozzáadása RAG importokhoz, hogy a különböző dokumentumokból származó, sablonszerű (boilerplate) szövegrészek eltérő beágyazásokat kapjanak, miközben az eltárolt szöveg változatlan marad.

Új funkciók:
- Gyűjteményenkénti `context_fields` bevezetése a RAG konfigurációban és az eszközparaméterekben, hogy a `rag_document_import` során a dokumentum-azonosító metaadatok a darabok (chunkok) beágyazási szövege elé fűzhetők legyenek.
- Újrafelhasználható, dokumentumszintű kontextus-prefix felépítése a cím és a metaadatok alapján, amely a meglévő szekció-„breadcrumbs”-szel kombinálódik a RAG dokumentumok importálásakor generált beágyazások létrehozásakor.

Fejlesztések:
- A darabok (chunkok) beágyazási szövegének felépítése mostantól opcionális dokumentum-azonosító kontextus-prefixet is fogad, miközben változatlanul megőrzi a korábbi viselkedést, ha ez nincs beállítva.
- Az `embed_document` és a `db_rag_import` változatlanul „verbatim” beágyazási útvonalon marad, egyértelműen dokumentálva a határt a kontextusos és a szó szerinti (verbatim) beágyazási folyamatok között.

Build:
- Az `mcp-server` crate verziójának emelése 1.0.543-ra.

Dokumentáció:
- Az új `context_fields` viselkedés, paraméterek és a mért visszakeresési (retrieval) javulások dokumentálása a changelogban és a RAG eszközsémákban.

Tesztek:
- Unit tesztek bővítése az embed-szöveg felépítésére, valamint lefedettség hozzáadása az új kontextus-prefix építőre és a RAG konfiguráció visszafele kompatibilitására.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable document-identity context fields for RAG imports so boilerplate chunks from different documents receive distinct embeddings while keeping stored text verbatim.

New Features:
- Introduce per-collection context_fields in RAG configuration and tool parameters to prepend document-identity metadata to chunk embedding text during rag_document_import.
- Add construction of a reusable document-level context prefix from title and metadata, combined with existing section breadcrumbs when generating embeddings for imported RAG documents.

Enhancements:
- Extend chunk embedding text construction to accept an optional document-identity context prefix while preserving the existing behavior when unset.
- Keep embed_document and db_rag_import on verbatim embedding paths, explicitly documenting the boundary between contextual and verbatim embedding flows.

Build:
- Bump mcp-server crate version to 1.0.543.

Documentation:
- Document the new context_fields behavior, parameters, and measured retrieval improvements in the changelog and RAG tool schemas.

Tests:
- Expand unit tests for embed-text construction and add coverage for the new context prefix builder and RAG config backward compatibility.

</details>